### PR TITLE
fix(render): Remove region from static sites

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -57,7 +57,6 @@ services:
     runtime: static
     buildCommand: cd web && npm ci && npm run build
     staticPublishPath: ./web/dist
-    region: frankfurt
     branch: main
     envVars:
       - key: VITE_API_URL
@@ -85,7 +84,6 @@ services:
     runtime: static
     buildCommand: cd web && npm ci && npm run build
     staticPublishPath: ./web/dist
-    region: frankfurt
     branch: 001-gtd-todo-app
     envVars:
       - key: VITE_API_URL


### PR DESCRIPTION
## Problem

Render Blueprint validation fails with:
```
services[2]: static sites cannot have a region
services[3]: static sites cannot have a region
```

## Solution

Remove `region: frankfurt` property from static site services in `render.yaml`:
- ✅ `gtd-web-prod` (service index 2)
- ✅ `gtd-web-staging` (service index 3)

Web Services (Docker-based) keep their `region: frankfurt` configuration as this is supported.

## Changes

```diff
  - type: web
    name: gtd-web-prod
    runtime: static
    buildCommand: cd web && npm ci && npm run build
    staticPublishPath: ./web/dist
-   region: frankfurt
    branch: main
```

```diff
  - type: web
    name: gtd-web-staging
    runtime: static
    buildCommand: cd web && npm ci && npm run build
    staticPublishPath: ./web/dist
-   region: frankfurt
    branch: 001-gtd-todo-app
```

## Test Plan

- [x] Validated YAML syntax
- [ ] **Manual**: Apply Blueprint in Render Dashboard
- [ ] **Manual**: Verify no region validation errors
- [ ] **Manual**: Confirm static sites deploy successfully

## Impact

This is a hotfix for the Render Blueprint configuration. No functional changes to the application.

**Services affected**:
- gtd-web-prod (static site)
- gtd-web-staging (static site)

**Services unchanged**:
- gtd-api-prod (Web Service - keeps region)
- gtd-api-staging (Web Service - keeps region)
- gtd-db-prod (Database)
- gtd-db-staging (Database)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)