### PR TITLE
fix(render): resolve Blueprint deployment failures

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -57,7 +57,6 @@ services:
     runtime: static
     buildCommand: cd web && npm ci && npm run build
     staticPublishPath: ./web/dist
-    region: frankfurt
     branch: main
     envVars:
       - key: VITE_API_URL
@@ -85,7 +84,6 @@ services:
     runtime: static
     buildCommand: cd web && npm ci && npm run build
     staticPublishPath: ./web/dist
-    region: frankfurt
     branch: 001-gtd-todo-app
     envVars:
       - key: VITE_API_URL

--- a/render.yaml
+++ b/render.yaml
@@ -7,7 +7,7 @@ services:
     name: gtd-api-prod
     runtime: docker
     dockerfilePath: ./infra/docker/api/Dockerfile
-    dockerContext: ./api
+    dockerContext: .
     region: frankfurt
     plan: free
     branch: main
@@ -31,7 +31,7 @@ services:
     name: gtd-api-staging
     runtime: docker
     dockerfilePath: ./infra/docker/api/Dockerfile
-    dockerContext: ./api
+    dockerContext: .
     region: frankfurt
     plan: free
     branch: 001-gtd-todo-app
@@ -55,7 +55,7 @@ services:
   - type: web
     name: gtd-web-prod
     runtime: static
-    buildCommand: cd web && npm ci && npm run build
+    buildCommand: npm ci --prefix web && npm run build --prefix web
     staticPublishPath: ./web/dist
     branch: main
     envVars:
@@ -82,7 +82,7 @@ services:
   - type: web
     name: gtd-web-staging
     runtime: static
-    buildCommand: cd web && npm ci && npm run build
+    buildCommand: npm ci --prefix web && npm run build --prefix web
     staticPublishPath: ./web/dist
     branch: 001-gtd-todo-app
     envVars:


### PR DESCRIPTION
## Summary
Fixes Render Blueprint deployment failures for API and Web services.

## Issues Fixed
Render reported the following deployment failures:
- ✅ gtd-api-prod (deploy failed)
- ✅ gtd-api-staging (deploy failed)  
- ✅ gtd-web-staging (deploy failed)

## Root Causes

### 1. Incorrect Docker Context
**Problem**: `dockerContext: ./api` prevented COPY commands from working
**Evidence**: The Dockerfile copies from paths relative to repository root:
```dockerfile
COPY infra/docker/api/nginx.conf /etc/nginx/nginx.conf
COPY api/ /var/www/html/
```
**Fix**: Changed `dockerContext: ./api` → `dockerContext: .`

### 2. Static Sites Cannot Have Region
**Problem**: Render validation error for static sites with `region` property
**Fix**: Removed `region: frankfurt` from gtd-web-prod and gtd-web-staging

### 3. Build Command Issues
**Problem**: `cd web && npm ci && npm run build` may fail in Render's environment
**Fix**: Changed to `npm ci --prefix web && npm run build --prefix web`

## Changes

### render.yaml
- **API services**: Fixed dockerContext to repository root (`.`)
- **Static sites**: Removed region property  
- **Web services**: Updated buildCommand to use `--prefix` flag

## Testing

After merging, verify in Render Dashboard that all services deploy successfully:
- [ ] gtd-api-prod deploys and shows "Live" status
- [ ] gtd-api-staging deploys and shows "Live" status  
- [ ] gtd-web-prod deploys and shows "Live" status
- [ ] gtd-web-staging deploys and shows "Live" status

Test health endpoints:
```bash
curl https://gtd-api-prod.onrender.com/api/health
curl https://gtd-api-staging.onrender.com/api/health
```

## Related
- Completes Sprint 0 (S0-024 to S0-033) infrastructure tasks
- Follow-up to docs added in PR #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)