### PR TITLE
feat(apple-signin): implement complete JWT verification with firebase/php-jwt

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -12,6 +12,7 @@
         "doctrine/doctrine-bundle": "^2.11",
         "doctrine/doctrine-migrations-bundle": "^3.3",
         "doctrine/orm": "^2.17",
+        "firebase/php-jwt": "^6.11",
         "lexik/jwt-authentication-bundle": "^2.20",
         "nelmio/cors-bundle": "^2.4",
         "phpdocumentor/reflection-docblock": "^5.3",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "43e236b5eec2ddd689555736eacf6f28",
+    "content-hash": "7421e0e66d40a87973dcc7936e1e345b",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -1394,6 +1394,69 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "firebase/php-jwt",
+            "version": "v6.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/firebase/php-jwt.git",
+                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.4",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psr/cache": "^2.0||^3.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
+            },
+            "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/firebase/php-jwt/issues",
+                "source": "https://github.com/firebase/php-jwt/tree/v6.11.1"
+            },
+            "time": "2025-04-09T20:32:01+00:00"
         },
         {
             "name": "lcobucci/clock",

--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -22,3 +22,4 @@ services:
             $appleClientId: '%env(APPLE_CLIENT_ID)%'
             $appleTeamId: '%env(APPLE_TEAM_ID)%'
             $appleKeyId: '%env(APPLE_KEY_ID)%'
+            $applePrivateKeyPath: '%env(APPLE_PRIVATE_KEY_PATH)%'

--- a/api/src/Service/AppleSignInService.php
+++ b/api/src/Service/AppleSignInService.php
@@ -2,6 +2,9 @@
 
 namespace App\Service;
 
+use Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -15,11 +18,15 @@ class AppleSignInService
     private const APPLE_PUBLIC_KEYS_URL = 'https://appleid.apple.com/auth/keys';
     private const APPLE_TOKEN_ISSUER = 'https://appleid.apple.com';
 
+    /** @var array<string, Key>|null Cached Apple public keys */
+    private ?array $cachedPublicKeys = null;
+
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly string $appleClientId,
         private readonly ?string $appleTeamId = null,
         private readonly ?string $appleKeyId = null,
+        private readonly ?string $applePrivateKeyPath = null,
     ) {
     }
 
@@ -27,46 +34,45 @@ class AppleSignInService
      * Verify Apple Sign-In identity token
      *
      * @param string $identityToken The JWT token from Apple Sign-In
-     * @return array{valid: bool, apple_id?: string, email?: string, email_verified?: bool, error?: string}
+     * @return array{valid: bool, apple_id?: string, email?: string, email_verified?: bool, is_private_email?: bool, error?: string}
      */
     public function verifyIdentityToken(string $identityToken): array
     {
         try {
-            // Decode the JWT token without verification first to get the header
+            // Validate token format
             $tokenParts = explode('.', $identityToken);
             if (count($tokenParts) !== 3) {
+                $this->logger->warning('Apple Sign-In: Invalid token format');
                 return [
                     'valid' => false,
                     'error' => 'Invalid token format',
                 ];
             }
 
-            // Decode header to get the key ID (kid)
-            $header = json_decode(base64_decode(strtr($tokenParts[0], '-_', '+/')), true);
-            if (!$header || !isset($header['kid'])) {
-                return [
-                    'valid' => false,
-                    'error' => 'Invalid token header',
-                ];
-            }
-
             // Get Apple's public keys
             $publicKeys = $this->getApplePublicKeys();
-            if (!isset($publicKeys[$header['kid']])) {
+
+            // Decode and verify the JWT using firebase/php-jwt
+            try {
+                $decoded = JWT::decode($identityToken, $publicKeys);
+                $payload = (array) $decoded;
+            } catch (\Firebase\JWT\ExpiredException $e) {
+                $this->logger->warning('Apple Sign-In: Token expired', ['error' => $e->getMessage()]);
                 return [
                     'valid' => false,
-                    'error' => 'Public key not found',
+                    'error' => 'Token expired',
                 ];
-            }
-
-            // Verify the token signature
-            $publicKey = $publicKeys[$header['kid']];
-            $payload = $this->verifyJWT($identityToken, $publicKey);
-
-            if (!$payload) {
+            } catch (\Firebase\JWT\SignatureInvalidException $e) {
+                $this->logger->warning('Apple Sign-In: Invalid signature', ['error' => $e->getMessage()]);
                 return [
                     'valid' => false,
                     'error' => 'Token signature verification failed',
+                ];
+            } catch (\Exception $e) {
+                $this->logger->warning('Apple Sign-In: JWT decode failed', ['error' => $e->getMessage()]);
+                return [
+                    'valid' => false,
+                    'error' => 'Token verification failed: ' . $e->getMessage(),
                 ];
             }
 
@@ -76,13 +82,18 @@ class AppleSignInService
                 return $validationResult;
             }
 
+            $this->logger->info('Apple Sign-In: Token verified successfully', [
+                'apple_id' => $payload['sub'] ?? 'unknown',
+                'email' => $payload['email'] ?? 'not provided',
+            ]);
+
             // Extract user information
             return [
                 'valid' => true,
                 'apple_id' => $payload['sub'] ?? null,
                 'email' => $payload['email'] ?? null,
-                'email_verified' => ($payload['email_verified'] ?? 'false') === 'true',
-                'is_private_email' => $payload['is_private_email'] ?? false,
+                'email_verified' => $this->parseBoolean($payload['email_verified'] ?? false),
+                'is_private_email' => $this->parseBoolean($payload['is_private_email'] ?? false),
             ];
         } catch (\Exception $e) {
             $this->logger->error('Apple Sign-In token verification failed', [
@@ -98,96 +109,71 @@ class AppleSignInService
     }
 
     /**
+     * Parse boolean value from Apple's response (can be string or bool)
+     */
+    private function parseBoolean(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+        if (is_string($value)) {
+            return strtolower($value) === 'true';
+        }
+        return (bool) $value;
+    }
+
+    /**
      * Get Apple's public keys for JWT verification
      *
-     * @return array<string, string> Array of public keys indexed by kid
+     * @return array<string, Key> Array of Key objects for JWT verification
      */
     private function getApplePublicKeys(): array
     {
-        // In production, you should cache these keys
-        // They don't change often, so caching for 24 hours is reasonable
+        // Return cached keys if available
+        if ($this->cachedPublicKeys !== null) {
+            return $this->cachedPublicKeys;
+        }
 
         try {
-            $response = file_get_contents(self::APPLE_PUBLIC_KEYS_URL);
+            $context = stream_context_create([
+                'http' => [
+                    'timeout' => 10,
+                    'header' => 'Accept: application/json',
+                ],
+            ]);
+
+            $response = file_get_contents(self::APPLE_PUBLIC_KEYS_URL, false, $context);
             if ($response === false) {
                 throw new \RuntimeException('Failed to fetch Apple public keys');
             }
 
-            $keys = json_decode($response, true);
-            if (!$keys || !isset($keys['keys'])) {
-                throw new \RuntimeException('Invalid public keys response');
+            $jwks = json_decode($response, true);
+            if (!$jwks || !isset($jwks['keys']) || empty($jwks['keys'])) {
+                throw new \RuntimeException('Invalid public keys response from Apple');
             }
 
-            // Convert JWK to PEM format
-            $publicKeys = [];
-            foreach ($keys['keys'] as $key) {
-                if (isset($key['kid'])) {
-                    $publicKeys[$key['kid']] = $this->jwkToPem($key);
-                }
-            }
+            // Use firebase/php-jwt JWK::parseKeySet to convert JWKs to Keys
+            $this->cachedPublicKeys = JWK::parseKeySet($jwks, 'RS256');
 
-            return $publicKeys;
+            $this->logger->debug('Apple public keys fetched successfully', [
+                'key_count' => count($this->cachedPublicKeys),
+            ]);
+
+            return $this->cachedPublicKeys;
         } catch (\Exception $e) {
             $this->logger->error('Failed to get Apple public keys', [
                 'error' => $e->getMessage(),
             ]);
-            throw $e;
+            throw new \RuntimeException('Failed to fetch Apple public keys: ' . $e->getMessage(), 0, $e);
         }
     }
 
     /**
-     * Convert JWK (JSON Web Key) to PEM format
+     * Clear cached public keys (useful for testing or key rotation)
      */
-    private function jwkToPem(array $jwk): string
+    public function clearKeyCache(): void
     {
-        // This is a simplified version. In production, use a library like web-token/jwt-framework
-        // or firebase/php-jwt that handles JWK to PEM conversion properly
-
-        if (!isset($jwk['n']) || !isset($jwk['e'])) {
-            throw new \InvalidArgumentException('Invalid JWK format');
-        }
-
-        // Decode base64url encoded values
-        $n = $this->base64UrlDecode($jwk['n']);
-        $e = $this->base64UrlDecode($jwk['e']);
-
-        // Create RSA key components
-        // Note: This is a placeholder. In production, use a proper crypto library
-        throw new \RuntimeException(
-            'JWK to PEM conversion requires a crypto library. ' .
-            'Please install firebase/php-jwt or web-token/jwt-framework'
-        );
-    }
-
-    /**
-     * Verify JWT token signature
-     *
-     * @param string $token The JWT token
-     * @param string $publicKey The public key in PEM format
-     * @return array|null The payload if valid, null otherwise
-     */
-    private function verifyJWT(string $token, string $publicKey): ?array
-    {
-        // In production, use a proper JWT library like firebase/php-jwt
-        // This is a placeholder implementation
-
-        // Example with firebase/php-jwt (requires: composer require firebase/php-jwt)
-        /*
-        use Firebase\JWT\JWT;
-        use Firebase\JWT\Key;
-
-        try {
-            $decoded = JWT::decode($token, new Key($publicKey, 'RS256'));
-            return (array) $decoded;
-        } catch (\Exception $e) {
-            return null;
-        }
-        */
-
-        throw new \RuntimeException(
-            'JWT verification requires firebase/php-jwt library. ' .
-            'Install with: composer require firebase/php-jwt'
-        );
+        $this->cachedPublicKeys = null;
     }
 
     /**
@@ -256,31 +242,126 @@ class AppleSignInService
     }
 
     /**
-     * Base64 URL decode
-     */
-    private function base64UrlDecode(string $input): string
-    {
-        $remainder = strlen($input) % 4;
-        if ($remainder) {
-            $padlen = 4 - $remainder;
-            $input .= str_repeat('=', $padlen);
-        }
-        return base64_decode(strtr($input, '-_', '+/'));
-    }
-
-    /**
      * Generate a client secret for Apple Sign-In (server-to-server authentication)
      *
-     * This is used for the authorization code flow, not needed for ID token validation
+     * Apple requires a JWT signed with your private key for server-to-server auth.
+     * This is needed for the authorization code exchange flow.
+     *
+     * @return string The generated client secret (JWT)
+     * @throws \RuntimeException If required configuration is missing
      */
     public function generateClientSecret(): string
     {
-        // Requires: composer require firebase/php-jwt
-        // and Apple Sign-In private key (.p8 file)
+        if (empty($this->appleTeamId)) {
+            throw new \RuntimeException('APPLE_TEAM_ID is required to generate client secret');
+        }
+        if (empty($this->appleKeyId)) {
+            throw new \RuntimeException('APPLE_KEY_ID is required to generate client secret');
+        }
+        if (empty($this->applePrivateKeyPath)) {
+            throw new \RuntimeException('APPLE_PRIVATE_KEY_PATH is required to generate client secret');
+        }
+        if (!file_exists($this->applePrivateKeyPath)) {
+            throw new \RuntimeException('Apple private key file not found: ' . $this->applePrivateKeyPath);
+        }
 
-        throw new \RuntimeException(
-            'Client secret generation requires additional setup. ' .
-            'See Apple Sign-In documentation for details.'
-        );
+        $privateKey = file_get_contents($this->applePrivateKeyPath);
+        if ($privateKey === false) {
+            throw new \RuntimeException('Failed to read Apple private key file');
+        }
+
+        $now = time();
+        $payload = [
+            'iss' => $this->appleTeamId,
+            'iat' => $now,
+            'exp' => $now + 15777000, // 6 months (max allowed by Apple)
+            'aud' => 'https://appleid.apple.com',
+            'sub' => $this->appleClientId,
+        ];
+
+        try {
+            return JWT::encode($payload, $privateKey, 'ES256', $this->appleKeyId);
+        } catch (\Exception $e) {
+            $this->logger->error('Failed to generate Apple client secret', [
+                'error' => $e->getMessage(),
+            ]);
+            throw new \RuntimeException('Failed to generate client secret: ' . $e->getMessage(), 0, $e);
+        }
+    }
+
+    /**
+     * Exchange authorization code for tokens (optional - for refresh token flow)
+     *
+     * @param string $authorizationCode The authorization code from Apple
+     * @return array The token response from Apple
+     * @throws \RuntimeException If the exchange fails
+     */
+    public function exchangeAuthorizationCode(string $authorizationCode): array
+    {
+        $clientSecret = $this->generateClientSecret();
+
+        $postData = [
+            'client_id' => $this->appleClientId,
+            'client_secret' => $clientSecret,
+            'code' => $authorizationCode,
+            'grant_type' => 'authorization_code',
+        ];
+
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'POST',
+                'header' => 'Content-Type: application/x-www-form-urlencoded',
+                'content' => http_build_query($postData),
+                'timeout' => 30,
+            ],
+        ]);
+
+        $response = file_get_contents('https://appleid.apple.com/auth/token', false, $context);
+        if ($response === false) {
+            throw new \RuntimeException('Failed to exchange authorization code with Apple');
+        }
+
+        $data = json_decode($response, true);
+        if (!$data) {
+            throw new \RuntimeException('Invalid response from Apple token endpoint');
+        }
+
+        if (isset($data['error'])) {
+            throw new \RuntimeException('Apple token exchange failed: ' . ($data['error_description'] ?? $data['error']));
+        }
+
+        return $data;
+    }
+
+    /**
+     * Check if Apple Sign-In is properly configured
+     *
+     * @return array{configured: bool, missing: string[]}
+     */
+    public function checkConfiguration(): array
+    {
+        $missing = [];
+
+        if (empty($this->appleClientId)) {
+            $missing[] = 'APPLE_CLIENT_ID';
+        }
+
+        // These are optional for basic ID token verification, but needed for full flow
+        $optionalMissing = [];
+        if (empty($this->appleTeamId)) {
+            $optionalMissing[] = 'APPLE_TEAM_ID';
+        }
+        if (empty($this->appleKeyId)) {
+            $optionalMissing[] = 'APPLE_KEY_ID';
+        }
+        if (empty($this->applePrivateKeyPath)) {
+            $optionalMissing[] = 'APPLE_PRIVATE_KEY_PATH';
+        }
+
+        return [
+            'configured' => empty($missing),
+            'missing' => $missing,
+            'optional_missing' => $optionalMissing,
+        ];
     }
 }

--- a/api/tests/Unit/Service/AppleSignInServiceTest.php
+++ b/api/tests/Unit/Service/AppleSignInServiceTest.php
@@ -253,39 +253,6 @@ class AppleSignInServiceTest extends TestCase
     }
 
     // =========================================================================
-    // Base64 URL Decode Tests
-    // =========================================================================
-
-    public function testBase64UrlDecode(): void
-    {
-        $reflection = new \ReflectionClass($this->service);
-        $method = $reflection->getMethod('base64UrlDecode');
-        $method->setAccessible(true);
-
-        $original = 'Hello, World!';
-        $encoded = rtrim(strtr(base64_encode($original), '+/', '-_'), '=');
-
-        $decoded = $method->invoke($this->service, $encoded);
-
-        $this->assertEquals($original, $decoded);
-    }
-
-    public function testBase64UrlDecodeWithPadding(): void
-    {
-        $reflection = new \ReflectionClass($this->service);
-        $method = $reflection->getMethod('base64UrlDecode');
-        $method->setAccessible(true);
-
-        // Test string that requires padding
-        $original = 'Test';
-        $encoded = rtrim(strtr(base64_encode($original), '+/', '-_'), '=');
-
-        $decoded = $method->invoke($this->service, $encoded);
-
-        $this->assertEquals($original, $decoded);
-    }
-
-    // =========================================================================
     // Error Handling Tests
     // =========================================================================
 
@@ -301,14 +268,89 @@ class AppleSignInServiceTest extends TestCase
     }
 
     // =========================================================================
-    // Library Requirement Tests
+    // Configuration Tests
     // =========================================================================
 
-    public function testGenerateClientSecretThrowsException(): void
+    public function testGenerateClientSecretRequiresPrivateKeyPath(): void
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Client secret generation requires additional setup');
+        $this->expectExceptionMessage('APPLE_PRIVATE_KEY_PATH is required to generate client secret');
 
         $this->service->generateClientSecret();
+    }
+
+    public function testCheckConfigurationWithValidConfig(): void
+    {
+        $result = $this->service->checkConfiguration();
+
+        $this->assertTrue($result['configured']);
+        $this->assertEmpty($result['missing']);
+        $this->assertArrayHasKey('optional_missing', $result);
+    }
+
+    public function testCheckConfigurationWithMissingClientId(): void
+    {
+        $service = new AppleSignInService(
+            $this->logger,
+            '', // Empty client ID
+            'TEAM_ID',
+            'KEY_ID'
+        );
+
+        $result = $service->checkConfiguration();
+
+        $this->assertFalse($result['configured']);
+        $this->assertContains('APPLE_CLIENT_ID', $result['missing']);
+    }
+
+    public function testClearKeyCache(): void
+    {
+        // Just verify the method exists and doesn't throw
+        $this->service->clearKeyCache();
+        $this->assertTrue(true);
+    }
+
+    // =========================================================================
+    // Boolean Parsing Tests
+    // =========================================================================
+
+    public function testParseBooleanWithBooleanTrue(): void
+    {
+        $reflection = new \ReflectionClass($this->service);
+        $method = $reflection->getMethod('parseBoolean');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($this->service, true));
+    }
+
+    public function testParseBooleanWithBooleanFalse(): void
+    {
+        $reflection = new \ReflectionClass($this->service);
+        $method = $reflection->getMethod('parseBoolean');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invoke($this->service, false));
+    }
+
+    public function testParseBooleanWithStringTrue(): void
+    {
+        $reflection = new \ReflectionClass($this->service);
+        $method = $reflection->getMethod('parseBoolean');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($this->service, 'true'));
+        $this->assertTrue($method->invoke($this->service, 'TRUE'));
+        $this->assertTrue($method->invoke($this->service, 'True'));
+    }
+
+    public function testParseBooleanWithStringFalse(): void
+    {
+        $reflection = new \ReflectionClass($this->service);
+        $method = $reflection->getMethod('parseBoolean');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invoke($this->service, 'false'));
+        $this->assertFalse($method->invoke($this->service, 'FALSE'));
+        $this->assertFalse($method->invoke($this->service, ''));
     }
 }

--- a/render.yaml
+++ b/render.yaml
@@ -48,6 +48,15 @@ services:
         generateValue: true
       - key: CORS_ALLOW_ORIGIN
         value: https://gtd-web-staging.onrender.com
+      # Apple Sign-In Configuration (set manually in Render dashboard)
+      - key: APPLE_CLIENT_ID
+        sync: false  # Set to your Apple Service ID (e.g., com.gtd.app.staging)
+      - key: APPLE_TEAM_ID
+        sync: false  # Your Apple Developer Team ID (10 characters)
+      - key: APPLE_KEY_ID
+        sync: false  # Your Sign in with Apple Key ID (10 characters)
+      - key: APPLE_PRIVATE_KEY_PATH
+        sync: false  # Path to .p8 file or use APPLE_PRIVATE_KEY env var
     healthCheckPath: /api/health
     autoDeploy: true
 


### PR DESCRIPTION
## Summary
- Add `firebase/php-jwt` package for proper JWT token verification
- Implement complete Apple identity token verification with signature validation
- Add JWK to Key conversion using `JWK::parseKeySet`
- Add key caching for performance optimization
- Implement `generateClientSecret()` for server-to-server authentication
- Add `exchangeAuthorizationCode()` for authorization code flow
- Add `checkConfiguration()` helper method
- Configure Apple Sign-In environment variables in `render.yaml` for staging
- Update unit tests (22 tests passing)

## Configuration requise après merge

### Render Dashboard (gtd-api-staging)
```
APPLE_CLIENT_ID=com.gtd.app.staging
APPLE_TEAM_ID=XXXXXXXXXX
APPLE_KEY_ID=XXXXXXXXXX
APPLE_PRIVATE_KEY_PATH=/etc/secrets/apple-key.p8
```

### Apple Developer Console
1. Créer un Service ID avec domaine `gtd-web-staging.onrender.com`
2. Créer une clé "Sign in with Apple" et télécharger le fichier .p8

## Test plan
- [x] Tests unitaires passent (22/22)
- [x] PHPStan niveau 5 OK
- [ ] Configurer les credentials Apple dans Render
- [ ] Tester le flow Apple Sign-In sur staging
- [ ] Vérifier la création/connexion d'utilisateur

🤖 Generated with [Claude Code](https://claude.com/claude-code)