### PR TITLE
fix(web): use correct VITE_API_URL environment variable

### DIFF
--- a/web/src/services/api.js
+++ b/web/src/services/api.js
@@ -1,7 +1,8 @@
 import axios from 'axios';
 
 // Get API base URL from environment variable
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000/api/v1';
+// Note: VITE_API_URL is set in render.yaml for staging/production
+const API_BASE_URL = import.meta.env.VITE_API_URL || import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000/api/v1';
 
 // Create axios instance with default config
 const apiClient = axios.create({


### PR DESCRIPTION
## Problem
Le frontend staging appelait `localhost:8000` au lieu de l'API staging, causant des erreurs CORS :
```
Access to XMLHttpRequest at 'http://localhost:8000/api/v1/auth/register' from origin 'https://gtd-web-staging.onrender.com' has been blocked by CORS policy
```

## Cause
- `render.yaml` définit `VITE_API_URL`
- `api.js` cherchait `VITE_API_BASE_URL`
- Le build utilisait donc le fallback `localhost:8000`

## Solution
Le code supporte maintenant les deux variables :
```javascript
const API_BASE_URL = import.meta.env.VITE_API_URL || import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000/api/v1';
```

## Test plan
- [ ] Merger et attendre le redéploiement sur Render
- [ ] Tester l'inscription sur staging
- [ ] Tester la connexion sur staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)