### PR TITLE
feat(web): add navigation with user menu dropdown (P1-046, P1-047)

### DIFF
--- a/specs/001-gtd-todo-app/tasks.md
+++ b/specs/001-gtd-todo-app/tasks.md
@@ -9,7 +9,7 @@
 
 Total tasks: 203
 - Sprint 0 (Infrastructure + GitHub Issues): 35 tasks ✅ COMPLETE
-- P1 User Account Management: 56 tasks (33 complete, 23 remaining) - 59% complete
+- P1 User Account Management: 56 tasks (35 complete, 21 remaining) - 63% complete
 - P2 Capture Ideas and Tasks: 14 tasks
 - P3 Clarify and Process: 12 tasks
 - P4 Organize with Contexts: 18 tasks
@@ -98,7 +98,7 @@ Per Constitution XVI, all features MUST be tracked as GitHub issues BEFORE imple
 
 **User Story**: As a user, I want to create an account, log in securely, and manage my preferences so that I can access my data across all my devices.
 
-**Status**: In Progress (33/56 tasks complete - 59%)
+**Status**: In Progress (35/56 tasks complete - 63%)
 
 ### Phase 1.1: Backend - User Entity & Repository ✅
 
@@ -176,8 +176,8 @@ Per Constitution XVI, all features MUST be tracked as GitHub issues BEFORE imple
 - [ ] [P1-045] [Story-1] Write unit tests for AccountDeletionPage `web/tests/unit/pages/AccountDeletionPage.test.jsx`
 
 **Navigation Updates**
-- [ ] [P1-046] [Story-1] Add user menu with Settings and Logout `web/src/components/Navigation.jsx`
-- [ ] [P1-047] [Story-1] Add link to account settings in navigation `web/src/components/Navigation.jsx`
+- [X] [P1-046] [Story-1] Add user menu with Settings and Logout `web/src/components/Navigation.jsx`
+- [X] [P1-047] [Story-1] Add link to account settings in navigation `web/src/components/Navigation.jsx`
 
 ### Phase 1.6: End-to-End Testing
 

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -6,6 +6,15 @@ import PasswordResetRequestPage from './pages/PasswordResetRequestPage';
 import PasswordResetConfirmPage from './pages/PasswordResetConfirmPage';
 import InboxPage from './pages/InboxPage';
 import ProtectedRoute from './components/ProtectedRoute';
+import Navigation from './components/Navigation';
+
+// Layout component for authenticated pages
+const AuthenticatedLayout = ({ children }) => (
+  <div className="min-h-screen bg-gray-50">
+    <Navigation />
+    <main>{children}</main>
+  </div>
+);
 
 function App() {
   return (
@@ -23,7 +32,9 @@ function App() {
           path="/inbox"
           element={
             <ProtectedRoute>
-              <InboxPage />
+              <AuthenticatedLayout>
+                <InboxPage />
+              </AuthenticatedLayout>
             </ProtectedRoute>
           }
         />

--- a/web/src/components/Navigation.jsx
+++ b/web/src/components/Navigation.jsx
@@ -1,0 +1,149 @@
+import { useState, useRef, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Link, useNavigate } from 'react-router-dom';
+import { logout, selectUser } from '../features/auth/authSlice';
+
+const Navigation = () => {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const user = useSelector(selectUser);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const menuRef = useRef(null);
+
+  // Close menu when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (menuRef.current && !menuRef.current.contains(event.target)) {
+        setIsMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  // Close menu on escape key
+  useEffect(() => {
+    const handleEscape = (event) => {
+      if (event.key === 'Escape') {
+        setIsMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, []);
+
+  const handleLogout = async () => {
+    try {
+      await dispatch(logout()).unwrap();
+      navigate('/login');
+    } catch (error) {
+      console.error('Logout failed:', error);
+      // Navigate anyway since we clear local state on failure
+      navigate('/login');
+    }
+  };
+
+  const toggleMenu = () => {
+    setIsMenuOpen(!isMenuOpen);
+  };
+
+  // Get user initials for avatar
+  const getUserInitials = () => {
+    if (!user?.email) return '?';
+    return user.email.charAt(0).toUpperCase();
+  };
+
+  return (
+    <nav className="bg-white shadow-sm">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between h-16">
+          {/* Logo / App Name */}
+          <div className="flex items-center">
+            <Link to="/inbox" className="flex items-center">
+              <h1 className="text-xl font-bold text-gray-900">GTD Todo App</h1>
+            </Link>
+          </div>
+
+          {/* User Menu */}
+          <div className="flex items-center">
+            <div className="relative" ref={menuRef}>
+              {/* User Menu Button */}
+              <button
+                onClick={toggleMenu}
+                className="flex items-center space-x-2 text-gray-700 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 rounded-full p-1"
+                aria-expanded={isMenuOpen}
+                aria-haspopup="true"
+              >
+                {/* Avatar */}
+                <div className="w-8 h-8 rounded-full bg-blue-600 flex items-center justify-center text-white text-sm font-medium">
+                  {getUserInitials()}
+                </div>
+                {/* Dropdown Arrow */}
+                <svg
+                  className={`w-4 h-4 transition-transform duration-200 ${isMenuOpen ? 'rotate-180' : ''}`}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+
+              {/* Dropdown Menu */}
+              {isMenuOpen && (
+                <div className="absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50">
+                  <div className="py-1" role="menu" aria-orientation="vertical">
+                    {/* User Info */}
+                    <div className="px-4 py-3 border-b border-gray-100">
+                      <p className="text-sm font-medium text-gray-900 truncate">
+                        {user?.email || 'User'}
+                      </p>
+                      <p className="text-xs text-gray-500 mt-1">
+                        Signed in
+                      </p>
+                    </div>
+
+                    {/* Menu Items */}
+                    <Link
+                      to="/account/settings"
+                      className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                      role="menuitem"
+                      onClick={() => setIsMenuOpen(false)}
+                    >
+                      <svg className="w-4 h-4 mr-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                      </svg>
+                      Settings
+                    </Link>
+
+                    <div className="border-t border-gray-100">
+                      <button
+                        onClick={handleLogout}
+                        className="flex items-center w-full px-4 py-2 text-sm text-red-600 hover:bg-gray-100"
+                        role="menuitem"
+                      >
+                        <svg className="w-4 h-4 mr-3 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+                        </svg>
+                        Logout
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </nav>
+  );
+};
+
+export default Navigation;

--- a/web/src/pages/InboxPage.jsx
+++ b/web/src/pages/InboxPage.jsx
@@ -1,53 +1,17 @@
-import { useDispatch } from 'react-redux';
-import { logout } from '../features/auth/authSlice';
-import { useNavigate } from 'react-router-dom';
-
 const InboxPage = () => {
-  const dispatch = useDispatch();
-  const navigate = useNavigate();
-
-  const handleLogout = async () => {
-    try {
-      await dispatch(logout()).unwrap();
-      navigate('/login');
-    } catch (error) {
-      console.error('Logout failed:', error);
-    }
-  };
-
   return (
-    <div className="min-h-screen bg-gray-100">
-      <nav className="bg-white shadow-sm">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between h-16">
-            <div className="flex items-center">
-              <h1 className="text-xl font-bold text-gray-900">GTD Todo App</h1>
-            </div>
-            <div className="flex items-center">
-              <button
-                onClick={handleLogout}
-                className="ml-4 px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-              >
-                Logout
-              </button>
-            </div>
-          </div>
+    <div className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+      <div className="px-4 py-6 sm:px-0">
+        <div className="bg-white shadow rounded-lg p-6">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">Inbox</h2>
+          <p className="text-gray-600">
+            Welcome to your GTD Inbox! This is where you'll capture all your tasks and ideas.
+          </p>
+          <p className="text-gray-500 mt-4 text-sm">
+            Phase 2 implementation coming soon: Quick capture, task list, and more.
+          </p>
         </div>
-      </nav>
-
-      <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
-        <div className="px-4 py-6 sm:px-0">
-          <div className="bg-white shadow rounded-lg p-6">
-            <h2 className="text-2xl font-bold text-gray-900 mb-4">Inbox</h2>
-            <p className="text-gray-600">
-              Welcome to your GTD Inbox! This is where you'll capture all your tasks and ideas.
-            </p>
-            <p className="text-gray-500 mt-4 text-sm">
-              Phase 2 implementation coming soon: Quick capture, task list, and more.
-            </p>
-          </div>
-        </div>
-      </main>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Create `Navigation` component with user avatar and dropdown menu
- Add `AuthenticatedLayout` wrapper for protected routes in `App.jsx`
- Include Settings link and Logout button in dropdown
- Remove duplicate navigation from `InboxPage`

## Features
- User avatar displays first letter of email
- Dropdown menu with user info, Settings link, and Logout
- Menu closes on outside click or Escape key
- Accessible with ARIA attributes

## Tasks Completed
- [X] P1-046: Add user menu with Settings and Logout
- [X] P1-047: Add link to account settings in navigation

P1 progress: 35/56 tasks (63%)

## Test plan
- [ ] Login and verify navigation bar appears
- [ ] Click avatar to open dropdown menu
- [ ] Verify user email displayed in menu
- [ ] Click outside menu to close it
- [ ] Press Escape to close menu
- [ ] Click Logout and verify redirect to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)