### PR TITLE
fix(docker): add PostgreSQL driver for Render database

### DIFF
--- a/infra/docker/api/Dockerfile
+++ b/infra/docker/api/Dockerfile
@@ -14,12 +14,14 @@ RUN apk add --no-cache \
     libpng-dev \
     libjpeg-turbo-dev \
     freetype-dev \
+    postgresql-dev \
     bash
 
 # Install PHP extensions
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) \
         pdo_mysql \
+        pdo_pgsql \
         intl \
         zip \
         gd \


### PR DESCRIPTION
## Summary
Add `pdo_pgsql` PHP extension to support Render's default PostgreSQL database.

## Problem
Render uses PostgreSQL by default, but the Dockerfile only included `pdo_mysql`. 
This caused 500 errors on `/api/v1/auth/register` and other database operations.

## Solution
- Add `postgresql-dev` system dependency
- Add `pdo_pgsql` PHP extension

## Test plan
- [ ] Verify Docker build succeeds
- [ ] Verify `/api/health` returns healthy
- [ ] Verify `/api/v1/auth/register` works on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)