### PR TITLE
feat(web): add account settings and deletion pages (P1-048 to P1-054)

### DIFF
--- a/specs/001-gtd-todo-app/tasks.md
+++ b/specs/001-gtd-todo-app/tasks.md
@@ -9,7 +9,7 @@
 
 Total tasks: 203
 - Sprint 0 (Infrastructure + GitHub Issues): 35 tasks ✅ COMPLETE
-- P1 User Account Management: 56 tasks (35 complete, 21 remaining) - 63% complete
+- P1 User Account Management: 56 tasks (48 complete, 8 remaining) - 86% complete
 - P2 Capture Ideas and Tasks: 14 tasks
 - P3 Clarify and Process: 12 tasks
 - P4 Organize with Contexts: 18 tasks
@@ -98,7 +98,7 @@ Per Constitution XVI, all features MUST be tracked as GitHub issues BEFORE imple
 
 **User Story**: As a user, I want to create an account, log in securely, and manage my preferences so that I can access my data across all my devices.
 
-**Status**: In Progress (35/56 tasks complete - 63%)
+**Status**: In Progress (48/56 tasks complete - 86%)
 
 ### Phase 1.1: Backend - User Entity & Repository ✅
 
@@ -159,21 +159,21 @@ Per Constitution XVI, all features MUST be tracked as GitHub issues BEFORE imple
 ### Phase 1.5: Frontend - Account Management Pages
 
 **Account Settings Page**
-- [ ] [P1-033] [Story-1] Create AccountSettingsPage component `web/src/pages/AccountSettingsPage.jsx`
-- [ ] [P1-034] [Story-1] Add profile information display (email, dates) `web/src/pages/AccountSettingsPage.jsx`
-- [ ] [P1-035] [Story-1] Create timezone update form `web/src/components/TimezoneSelector.jsx`
-- [ ] [P1-036] [Story-1] Create notification preferences form `web/src/components/NotificationPreferences.jsx`
-- [ ] [P1-037] [Story-1] Add route /account/settings with auth guard `web/src/App.jsx`
-- [ ] [P1-038] [Story-1] Write unit tests for AccountSettingsPage `web/tests/unit/pages/AccountSettingsPage.test.jsx`
+- [X] [P1-033] [Story-1] Create AccountSettingsPage component `web/src/pages/AccountSettingsPage.jsx`
+- [X] [P1-034] [Story-1] Add profile information display (email, dates) `web/src/pages/AccountSettingsPage.jsx`
+- [X] [P1-035] [Story-1] Create timezone update form `web/src/components/TimezoneSelector.jsx`
+- [X] [P1-036] [Story-1] Create notification preferences form `web/src/components/NotificationPreferences.jsx`
+- [X] [P1-037] [Story-1] Add route /account/settings with auth guard `web/src/App.jsx`
+- [X] [P1-038] [Story-1] Write unit tests for AccountSettingsPage `web/tests/unit/pages/AccountSettingsPage.test.jsx`
 
 **Account Deletion Page**
-- [ ] [P1-039] [Story-1] Create AccountDeletionPage component `web/src/pages/AccountDeletionPage.jsx`
-- [ ] [P1-040] [Story-1] Display deletion warning and data impact `web/src/pages/AccountDeletionPage.jsx`
-- [ ] [P1-041] [Story-1] Create deletion confirmation form (password + "DELETE" text) `web/src/components/AccountDeletionForm.jsx`
-- [ ] [P1-042] [Story-1] Add GDPR compliance notices `web/src/pages/AccountDeletionPage.jsx`
-- [ ] [P1-043] [Story-1] Implement post-deletion redirect to login `web/src/pages/AccountDeletionPage.jsx`
-- [ ] [P1-044] [Story-1] Add route /account/delete with auth guard `web/src/App.jsx`
-- [ ] [P1-045] [Story-1] Write unit tests for AccountDeletionPage `web/tests/unit/pages/AccountDeletionPage.test.jsx`
+- [X] [P1-039] [Story-1] Create AccountDeletionPage component `web/src/pages/AccountDeletionPage.jsx`
+- [X] [P1-040] [Story-1] Display deletion warning and data impact `web/src/pages/AccountDeletionPage.jsx`
+- [X] [P1-041] [Story-1] Create deletion confirmation form (password + "DELETE" text) `web/src/components/AccountDeletionForm.jsx`
+- [X] [P1-042] [Story-1] Add GDPR compliance notices `web/src/pages/AccountDeletionPage.jsx`
+- [X] [P1-043] [Story-1] Implement post-deletion redirect to login `web/src/pages/AccountDeletionPage.jsx`
+- [X] [P1-044] [Story-1] Add route /account/delete with auth guard `web/src/App.jsx`
+- [X] [P1-045] [Story-1] Write unit tests for AccountDeletionPage `web/tests/unit/pages/AccountDeletionPage.test.jsx`
 
 **Navigation Updates**
 - [X] [P1-046] [Story-1] Add user menu with Settings and Logout `web/src/components/Navigation.jsx`

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -5,6 +5,8 @@ import VerifyEmailPage from './pages/VerifyEmailPage';
 import PasswordResetRequestPage from './pages/PasswordResetRequestPage';
 import PasswordResetConfirmPage from './pages/PasswordResetConfirmPage';
 import InboxPage from './pages/InboxPage';
+import AccountSettingsPage from './pages/AccountSettingsPage';
+import AccountDeletionPage from './pages/AccountDeletionPage';
 import ProtectedRoute from './components/ProtectedRoute';
 import Navigation from './components/Navigation';
 
@@ -34,6 +36,26 @@ function App() {
             <ProtectedRoute>
               <AuthenticatedLayout>
                 <InboxPage />
+              </AuthenticatedLayout>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/account/settings"
+          element={
+            <ProtectedRoute>
+              <AuthenticatedLayout>
+                <AccountSettingsPage />
+              </AuthenticatedLayout>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/account/delete"
+          element={
+            <ProtectedRoute>
+              <AuthenticatedLayout>
+                <AccountDeletionPage />
               </AuthenticatedLayout>
             </ProtectedRoute>
           }

--- a/web/src/components/Navigation.jsx
+++ b/web/src/components/Navigation.jsx
@@ -2,13 +2,25 @@ import { useState, useRef, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link, useNavigate } from 'react-router-dom';
 import { logout, selectUser } from '../features/auth/authSlice';
+import { fetchProfile, selectProfile } from '../features/account/accountSlice';
 
 const Navigation = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const user = useSelector(selectUser);
+  const profile = useSelector(selectProfile);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const menuRef = useRef(null);
+
+  // Load profile if not available (e.g., after HMR)
+  useEffect(() => {
+    if (!user && !profile) {
+      dispatch(fetchProfile());
+    }
+  }, [dispatch, user, profile]);
+
+  // Get email from user (after login) or profile (from API)
+  const email = user?.email || profile?.email;
 
   // Close menu when clicking outside
   useEffect(() => {
@@ -55,8 +67,8 @@ const Navigation = () => {
 
   // Get user initials for avatar
   const getUserInitials = () => {
-    if (!user?.email) return '?';
-    return user.email.charAt(0).toUpperCase();
+    if (!email) return '?';
+    return email.charAt(0).toUpperCase();
   };
 
   return (
@@ -102,7 +114,7 @@ const Navigation = () => {
                     {/* User Info */}
                     <div className="px-4 py-3 border-b border-gray-100">
                       <p className="text-sm font-medium text-gray-900 truncate">
-                        {user?.email || 'User'}
+                        {email || 'User'}
                       </p>
                       <p className="text-xs text-gray-500 mt-1">
                         Signed in

--- a/web/src/components/NotificationPreferences.jsx
+++ b/web/src/components/NotificationPreferences.jsx
@@ -1,0 +1,66 @@
+const NOTIFICATION_OPTIONS = [
+  {
+    id: 'email_weekly_review',
+    label: 'Weekly Review Reminder',
+    description: 'Receive an email reminder for your weekly review',
+  },
+  {
+    id: 'email_deadline_reminder',
+    label: 'Deadline Reminders',
+    description: 'Get notified about upcoming task deadlines',
+  },
+  {
+    id: 'email_inbox_overflow',
+    label: 'Inbox Overflow Alert',
+    description: 'Alert when your inbox has too many unprocessed items',
+  },
+];
+
+const NotificationPreferences = ({ value = {}, onChange, disabled = false }) => {
+  const handleToggle = (optionId) => {
+    onChange({
+      ...value,
+      [optionId]: !value[optionId],
+    });
+  };
+
+  return (
+    <div>
+      <label className="block text-sm font-medium text-gray-700 mb-3">
+        Email Notifications
+      </label>
+      <div className="space-y-4">
+        {NOTIFICATION_OPTIONS.map((option) => (
+          <div key={option.id} className="flex items-start">
+            <div className="flex items-center h-5">
+              <input
+                id={option.id}
+                name={option.id}
+                type="checkbox"
+                checked={value[option.id] || false}
+                onChange={() => handleToggle(option.id)}
+                disabled={disabled}
+                className={`h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 ${
+                  disabled ? 'cursor-not-allowed opacity-50' : ''
+                }`}
+              />
+            </div>
+            <div className="ml-3">
+              <label
+                htmlFor={option.id}
+                className={`text-sm font-medium ${
+                  disabled ? 'text-gray-400' : 'text-gray-700'
+                }`}
+              >
+                {option.label}
+              </label>
+              <p className="text-xs text-gray-500">{option.description}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default NotificationPreferences;

--- a/web/src/components/TimezoneSelector.jsx
+++ b/web/src/components/TimezoneSelector.jsx
@@ -1,0 +1,131 @@
+import { useMemo } from 'react';
+
+// Common timezones grouped by region
+const TIMEZONE_GROUPS = {
+  'America': [
+    'America/New_York',
+    'America/Chicago',
+    'America/Denver',
+    'America/Los_Angeles',
+    'America/Anchorage',
+    'America/Toronto',
+    'America/Vancouver',
+    'America/Mexico_City',
+    'America/Sao_Paulo',
+    'America/Buenos_Aires',
+  ],
+  'Europe': [
+    'Europe/London',
+    'Europe/Paris',
+    'Europe/Berlin',
+    'Europe/Rome',
+    'Europe/Madrid',
+    'Europe/Amsterdam',
+    'Europe/Brussels',
+    'Europe/Zurich',
+    'Europe/Stockholm',
+    'Europe/Moscow',
+  ],
+  'Asia': [
+    'Asia/Tokyo',
+    'Asia/Shanghai',
+    'Asia/Hong_Kong',
+    'Asia/Singapore',
+    'Asia/Seoul',
+    'Asia/Dubai',
+    'Asia/Mumbai',
+    'Asia/Bangkok',
+    'Asia/Jakarta',
+    'Asia/Manila',
+  ],
+  'Pacific': [
+    'Pacific/Auckland',
+    'Pacific/Sydney',
+    'Australia/Melbourne',
+    'Australia/Brisbane',
+    'Pacific/Honolulu',
+    'Pacific/Fiji',
+  ],
+  'Africa': [
+    'Africa/Cairo',
+    'Africa/Johannesburg',
+    'Africa/Lagos',
+    'Africa/Nairobi',
+  ],
+  'Other': [
+    'UTC',
+  ],
+};
+
+const formatTimezone = (tz) => {
+  try {
+    const now = new Date();
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      timeZoneName: 'shortOffset',
+    });
+    const parts = formatter.formatToParts(now);
+    const offset = parts.find(p => p.type === 'timeZoneName')?.value || '';
+    const cityName = tz.split('/').pop().replace(/_/g, ' ');
+    return `${cityName} (${offset})`;
+  } catch {
+    return tz;
+  }
+};
+
+const TimezoneSelector = ({ value, onChange, disabled = false, error }) => {
+  const timezoneOptions = useMemo(() => {
+    const options = [];
+    Object.entries(TIMEZONE_GROUPS).forEach(([region, timezones]) => {
+      timezones.forEach(tz => {
+        options.push({
+          value: tz,
+          label: formatTimezone(tz),
+          region,
+        });
+      });
+    });
+    return options;
+  }, []);
+
+  return (
+    <div>
+      <label htmlFor="timezone" className="block text-sm font-medium text-gray-700">
+        Timezone
+      </label>
+      <select
+        id="timezone"
+        name="timezone"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        className={`mt-1 block w-full rounded-md shadow-sm sm:text-sm ${
+          error
+            ? 'border-red-300 focus:border-red-500 focus:ring-red-500'
+            : 'border-gray-300 focus:border-blue-500 focus:ring-blue-500'
+        } ${disabled ? 'bg-gray-100 cursor-not-allowed' : ''}`}
+      >
+        {Object.entries(TIMEZONE_GROUPS).map(([region, timezones]) => (
+          <optgroup key={region} label={region}>
+            {timezones.map(tz => {
+              const option = timezoneOptions.find(o => o.value === tz);
+              return (
+                <option key={tz} value={tz}>
+                  {option?.label || tz}
+                </option>
+              );
+            })}
+          </optgroup>
+        ))}
+      </select>
+      {error && (
+        <p className="mt-1 text-sm text-red-600">{error}</p>
+      )}
+      <p className="mt-1 text-xs text-gray-500">
+        Used for displaying dates and scheduling reminders
+      </p>
+    </div>
+  );
+};
+
+export default TimezoneSelector;

--- a/web/src/features/account/accountSlice.js
+++ b/web/src/features/account/accountSlice.js
@@ -1,0 +1,136 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import { accountAPI } from '../../services/api';
+
+// Initial state
+const initialState = {
+  profile: null,
+  isLoading: false,
+  isSaving: false,
+  error: null,
+  successMessage: null,
+};
+
+// Async thunks
+export const fetchProfile = createAsyncThunk(
+  'account/fetchProfile',
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await accountAPI.getProfile();
+      return response.data;
+    } catch (error) {
+      const errorData = error.response?.data || {};
+      return rejectWithValue({
+        message: errorData.error || errorData.message || 'Failed to fetch profile',
+        code: errorData.code
+      });
+    }
+  }
+);
+
+export const updatePreferences = createAsyncThunk(
+  'account/updatePreferences',
+  async (preferences, { rejectWithValue }) => {
+    try {
+      const response = await accountAPI.updatePreferences(preferences);
+      return response.data;
+    } catch (error) {
+      const errorData = error.response?.data || {};
+      return rejectWithValue({
+        message: errorData.error || errorData.message || 'Failed to update preferences',
+        code: errorData.code
+      });
+    }
+  }
+);
+
+export const deleteAccount = createAsyncThunk(
+  'account/deleteAccount',
+  async ({ password, confirmText }, { rejectWithValue }) => {
+    try {
+      const response = await accountAPI.deleteAccount(password, confirmText);
+      return response.data;
+    } catch (error) {
+      const errorData = error.response?.data || {};
+      return rejectWithValue({
+        message: errorData.error || errorData.message || 'Failed to delete account',
+        code: errorData.code
+      });
+    }
+  }
+);
+
+// Account slice
+const accountSlice = createSlice({
+  name: 'account',
+  initialState,
+  reducers: {
+    clearError: (state) => {
+      state.error = null;
+    },
+    clearSuccessMessage: (state) => {
+      state.successMessage = null;
+    },
+  },
+  extraReducers: (builder) => {
+    // Fetch Profile
+    builder
+      .addCase(fetchProfile.pending, (state) => {
+        state.isLoading = true;
+        state.error = null;
+      })
+      .addCase(fetchProfile.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.profile = action.payload.user || action.payload;
+        state.error = null;
+      })
+      .addCase(fetchProfile.rejected, (state, action) => {
+        state.isLoading = false;
+        state.error = action.payload?.message || 'Failed to fetch profile';
+      });
+
+    // Update Preferences
+    builder
+      .addCase(updatePreferences.pending, (state) => {
+        state.isSaving = true;
+        state.error = null;
+        state.successMessage = null;
+      })
+      .addCase(updatePreferences.fulfilled, (state, action) => {
+        state.isSaving = false;
+        state.profile = action.payload.user || action.payload;
+        state.successMessage = 'Preferences updated successfully';
+        state.error = null;
+      })
+      .addCase(updatePreferences.rejected, (state, action) => {
+        state.isSaving = false;
+        state.error = action.payload?.message || 'Failed to update preferences';
+      });
+
+    // Delete Account
+    builder
+      .addCase(deleteAccount.pending, (state) => {
+        state.isSaving = true;
+        state.error = null;
+      })
+      .addCase(deleteAccount.fulfilled, (state) => {
+        state.isSaving = false;
+        state.profile = null;
+        state.error = null;
+      })
+      .addCase(deleteAccount.rejected, (state, action) => {
+        state.isSaving = false;
+        state.error = action.payload?.message || 'Failed to delete account';
+      });
+  },
+});
+
+export const { clearError, clearSuccessMessage } = accountSlice.actions;
+
+// Selectors
+export const selectProfile = (state) => state.account.profile;
+export const selectAccountLoading = (state) => state.account.isLoading;
+export const selectAccountSaving = (state) => state.account.isSaving;
+export const selectAccountError = (state) => state.account.error;
+export const selectSuccessMessage = (state) => state.account.successMessage;
+
+export default accountSlice.reducer;

--- a/web/src/pages/AccountDeletionPage.jsx
+++ b/web/src/pages/AccountDeletionPage.jsx
@@ -1,0 +1,205 @@
+import { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate, Link } from 'react-router-dom';
+import {
+  deleteAccount,
+  selectAccountSaving,
+  selectAccountError,
+  clearError,
+} from '../features/account/accountSlice';
+import { clearAuth } from '../features/auth/authSlice';
+
+const AccountDeletionPage = () => {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const isSaving = useSelector(selectAccountSaving);
+  const error = useSelector(selectAccountError);
+
+  const [password, setPassword] = useState('');
+  const [confirmText, setConfirmText] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+
+  const isConfirmValid = confirmText === 'DELETE';
+  const canSubmit = password.length > 0 && isConfirmValid && !isSaving;
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    dispatch(clearError());
+
+    try {
+      await dispatch(deleteAccount({ password, confirmText })).unwrap();
+      // Clear auth and redirect to login
+      dispatch(clearAuth());
+      navigate('/login', {
+        state: { message: 'Your account has been permanently deleted.' }
+      });
+    } catch {
+      // Error is handled in the slice
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
+      <div className="mb-8">
+        <Link
+          to="/account/settings"
+          className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700"
+        >
+          <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+          Back to Settings
+        </Link>
+      </div>
+
+      <div className="bg-white shadow rounded-lg border-2 border-red-200">
+        <div className="px-4 py-5 sm:p-6">
+          <div className="flex items-center mb-4">
+            <div className="flex-shrink-0">
+              <svg className="h-8 w-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+            </div>
+            <div className="ml-4">
+              <h1 className="text-2xl font-bold text-red-600">Delete Account</h1>
+              <p className="text-sm text-gray-500">This action cannot be undone</p>
+            </div>
+          </div>
+
+          {/* Warning Box */}
+          <div className="bg-red-50 border border-red-200 rounded-md p-4 mb-6">
+            <h2 className="text-sm font-medium text-red-800 mb-2">
+              What happens when you delete your account:
+            </h2>
+            <ul className="text-sm text-red-700 list-disc list-inside space-y-1">
+              <li>All your tasks and projects will be permanently deleted</li>
+              <li>Your inbox items will be erased</li>
+              <li>Your account preferences and settings will be removed</li>
+              <li>You will lose access to all your data immediately</li>
+              <li>This action is <strong>irreversible</strong></li>
+            </ul>
+          </div>
+
+          {/* GDPR Notice */}
+          <div className="bg-blue-50 border border-blue-200 rounded-md p-4 mb-6">
+            <h2 className="text-sm font-medium text-blue-800 mb-1">
+              GDPR Compliance
+            </h2>
+            <p className="text-sm text-blue-700">
+              In accordance with GDPR Article 17 (Right to Erasure), all your personal data
+              will be permanently deleted from our systems. This includes your email address,
+              preferences, and all associated content.
+            </p>
+          </div>
+
+          {/* Error Message */}
+          {error && (
+            <div className="mb-6 rounded-md bg-red-50 border border-red-200 p-4">
+              <div className="flex">
+                <svg className="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
+                </svg>
+                <div className="ml-3">
+                  <p className="text-sm font-medium text-red-800">{error}</p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Deletion Form */}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+                Enter your password to confirm
+              </label>
+              <div className="mt-1 relative">
+                <input
+                  type={showPassword ? 'text' : 'password'}
+                  id="password"
+                  name="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  disabled={isSaving}
+                  className="block w-full rounded-md border-gray-300 shadow-sm focus:border-red-500 focus:ring-red-500 sm:text-sm pr-10"
+                  placeholder="Your current password"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600"
+                >
+                  {showPassword ? (
+                    <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                    </svg>
+                  ) : (
+                    <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                    </svg>
+                  )}
+                </button>
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="confirmText" className="block text-sm font-medium text-gray-700">
+                Type <span className="font-bold text-red-600">DELETE</span> to confirm
+              </label>
+              <div className="mt-1">
+                <input
+                  type="text"
+                  id="confirmText"
+                  name="confirmText"
+                  value={confirmText}
+                  onChange={(e) => setConfirmText(e.target.value.toUpperCase())}
+                  disabled={isSaving}
+                  className={`block w-full rounded-md shadow-sm sm:text-sm ${
+                    confirmText && !isConfirmValid
+                      ? 'border-red-300 focus:border-red-500 focus:ring-red-500'
+                      : 'border-gray-300 focus:border-red-500 focus:ring-red-500'
+                  }`}
+                  placeholder="DELETE"
+                  autoComplete="off"
+                />
+              </div>
+              {confirmText && !isConfirmValid && (
+                <p className="mt-1 text-sm text-red-600">
+                  Please type DELETE exactly to confirm
+                </p>
+              )}
+            </div>
+
+            <div className="flex items-center justify-between pt-4">
+              <Link
+                to="/account/settings"
+                className="text-sm font-medium text-gray-600 hover:text-gray-800"
+              >
+                Cancel
+              </Link>
+              <button
+                type="submit"
+                disabled={!canSubmit}
+                className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isSaving ? (
+                  <>
+                    <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    </svg>
+                    Deleting...
+                  </>
+                ) : (
+                  'Permanently Delete My Account'
+                )}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AccountDeletionPage;

--- a/web/src/pages/AccountSettingsPage.jsx
+++ b/web/src/pages/AccountSettingsPage.jsx
@@ -1,0 +1,258 @@
+import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
+import {
+  fetchProfile,
+  updatePreferences,
+  selectProfile,
+  selectAccountLoading,
+  selectAccountSaving,
+  selectAccountError,
+  selectSuccessMessage,
+  clearError,
+  clearSuccessMessage,
+} from '../features/account/accountSlice';
+import TimezoneSelector from '../components/TimezoneSelector';
+import NotificationPreferences from '../components/NotificationPreferences';
+
+const AccountSettingsPage = () => {
+  const dispatch = useDispatch();
+  const profile = useSelector(selectProfile);
+  const isLoading = useSelector(selectAccountLoading);
+  const isSaving = useSelector(selectAccountSaving);
+  const error = useSelector(selectAccountError);
+  const successMessage = useSelector(selectSuccessMessage);
+
+  const [timezone, setTimezone] = useState('UTC');
+  const [notificationPreferences, setNotificationPreferences] = useState({});
+  const [hasChanges, setHasChanges] = useState(false);
+
+  // Fetch profile on mount
+  useEffect(() => {
+    dispatch(fetchProfile());
+  }, [dispatch]);
+
+  // Update local state when profile loads
+  useEffect(() => {
+    if (profile) {
+      setTimezone(profile.timezone || 'UTC');
+      setNotificationPreferences(profile.notification_preferences || {});
+      setHasChanges(false);
+    }
+  }, [profile]);
+
+  // Clear messages on unmount
+  useEffect(() => {
+    return () => {
+      dispatch(clearError());
+      dispatch(clearSuccessMessage());
+    };
+  }, [dispatch]);
+
+  // Auto-hide success message
+  useEffect(() => {
+    if (successMessage) {
+      const timer = setTimeout(() => {
+        dispatch(clearSuccessMessage());
+      }, 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [successMessage, dispatch]);
+
+  const handleTimezoneChange = (newTimezone) => {
+    setTimezone(newTimezone);
+    setHasChanges(true);
+  };
+
+  const handleNotificationChange = (newPreferences) => {
+    setNotificationPreferences(newPreferences);
+    setHasChanges(true);
+  };
+
+  const handleSave = async (e) => {
+    e.preventDefault();
+    dispatch(clearError());
+
+    try {
+      await dispatch(updatePreferences({
+        timezone,
+        notification_preferences: notificationPreferences,
+      })).unwrap();
+      setHasChanges(false);
+    } catch {
+      // Error is handled in the slice
+    }
+  };
+
+  const handleReset = () => {
+    if (profile) {
+      setTimezone(profile.timezone || 'UTC');
+      setNotificationPreferences(profile.notification_preferences || {});
+      setHasChanges(false);
+    }
+  };
+
+  const formatDate = (dateString) => {
+    if (!dateString) return 'N/A';
+    return new Date(dateString).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="max-w-2xl mx-auto py-8 px-4">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 bg-gray-200 rounded w-1/4"></div>
+          <div className="h-4 bg-gray-200 rounded w-1/2"></div>
+          <div className="h-32 bg-gray-200 rounded"></div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-gray-900">Account Settings</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Manage your account preferences and notification settings
+        </p>
+      </div>
+
+      {/* Success Message */}
+      {successMessage && (
+        <div className="mb-6 rounded-md bg-green-50 p-4">
+          <div className="flex">
+            <svg className="h-5 w-5 text-green-400" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+            </svg>
+            <div className="ml-3">
+              <p className="text-sm font-medium text-green-800">{successMessage}</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Error Message */}
+      {error && (
+        <div className="mb-6 rounded-md bg-red-50 p-4">
+          <div className="flex">
+            <svg className="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
+            </svg>
+            <div className="ml-3">
+              <p className="text-sm font-medium text-red-800">{error}</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Profile Information */}
+      <div className="bg-white shadow rounded-lg mb-6">
+        <div className="px-4 py-5 sm:p-6">
+          <h2 className="text-lg font-medium text-gray-900 mb-4">Profile Information</h2>
+          <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+              <dt className="text-sm font-medium text-gray-500">Email</dt>
+              <dd className="mt-1 text-sm text-gray-900">{profile?.email || 'N/A'}</dd>
+            </div>
+            <div>
+              <dt className="text-sm font-medium text-gray-500">Account Status</dt>
+              <dd className="mt-1">
+                <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                  profile?.status === 'active'
+                    ? 'bg-green-100 text-green-800'
+                    : 'bg-yellow-100 text-yellow-800'
+                }`}>
+                  {profile?.status || 'N/A'}
+                </span>
+              </dd>
+            </div>
+            <div>
+              <dt className="text-sm font-medium text-gray-500">Member Since</dt>
+              <dd className="mt-1 text-sm text-gray-900">{formatDate(profile?.created_at)}</dd>
+            </div>
+            <div>
+              <dt className="text-sm font-medium text-gray-500">Email Verified</dt>
+              <dd className="mt-1 text-sm text-gray-900">
+                {profile?.verified_at ? formatDate(profile.verified_at) : 'Not verified'}
+              </dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+
+      {/* Preferences Form */}
+      <form onSubmit={handleSave}>
+        <div className="bg-white shadow rounded-lg mb-6">
+          <div className="px-4 py-5 sm:p-6 space-y-6">
+            <h2 className="text-lg font-medium text-gray-900">Preferences</h2>
+
+            <TimezoneSelector
+              value={timezone}
+              onChange={handleTimezoneChange}
+              disabled={isSaving}
+            />
+
+            <div className="border-t border-gray-200 pt-6">
+              <NotificationPreferences
+                value={notificationPreferences}
+                onChange={handleNotificationChange}
+                disabled={isSaving}
+              />
+            </div>
+          </div>
+
+          <div className="px-4 py-3 bg-gray-50 text-right sm:px-6 rounded-b-lg">
+            <button
+              type="button"
+              onClick={handleReset}
+              disabled={!hasChanges || isSaving}
+              className="mr-3 inline-flex justify-center py-2 px-4 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Reset
+            </button>
+            <button
+              type="submit"
+              disabled={!hasChanges || isSaving}
+              className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isSaving ? (
+                <>
+                  <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                  </svg>
+                  Saving...
+                </>
+              ) : (
+                'Save Changes'
+              )}
+            </button>
+          </div>
+        </div>
+      </form>
+
+      {/* Danger Zone */}
+      <div className="bg-white shadow rounded-lg border border-red-200">
+        <div className="px-4 py-5 sm:p-6">
+          <h2 className="text-lg font-medium text-red-600 mb-2">Danger Zone</h2>
+          <p className="text-sm text-gray-500 mb-4">
+            Once you delete your account, there is no going back. Please be certain.
+          </p>
+          <Link
+            to="/account/delete"
+            className="inline-flex items-center px-4 py-2 border border-red-300 shadow-sm text-sm font-medium rounded-md text-red-700 bg-white hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+          >
+            Delete Account
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AccountSettingsPage;

--- a/web/src/services/api.js
+++ b/web/src/services/api.js
@@ -78,11 +78,13 @@ export const authAPI = {
   deleteAccount: () => apiClient.delete('/account'),
 };
 
-// User API endpoints
-export const userAPI = {
-  getProfile: () => apiClient.get('/user/profile'),
-  updateProfile: (data) => apiClient.patch('/user/profile', data),
-  updateNotificationPreferences: (preferences) => apiClient.patch('/user/notification-preferences', preferences),
+// Account API endpoints
+export const accountAPI = {
+  getProfile: () => apiClient.get('/auth/me'),
+  updatePreferences: (data) => apiClient.patch('/account/preferences', data),
+  deleteAccount: (password, confirmText) => apiClient.delete('/account', {
+    data: { password, confirm_text: confirmText }
+  }),
 };
 
 // Health check endpoint

--- a/web/src/store/store.js
+++ b/web/src/store/store.js
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import authReducer from '../features/auth/authSlice';
+import accountReducer from '../features/account/accountSlice';
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
+    account: accountReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({

--- a/web/src/tests/unit/components/Navigation.test.jsx
+++ b/web/src/tests/unit/components/Navigation.test.jsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
+import authReducer from '../../../features/auth/authSlice';
+import accountReducer from '../../../features/account/accountSlice';
+import Navigation from '../../../components/Navigation';
+
+// Mock the API module
+vi.mock('../../../services/api', () => ({
+  authAPI: {
+    logout: vi.fn().mockResolvedValue({}),
+  },
+  accountAPI: {
+    getProfile: vi.fn().mockResolvedValue({
+      data: {
+        user: {
+          id: '123',
+          email: 'test@example.com',
+          status: 'active',
+          timezone: 'UTC',
+        },
+      },
+    }),
+  },
+}));
+
+import { authAPI, accountAPI } from '../../../services/api';
+
+describe('Navigation', () => {
+  const createStore = (authState = {}, accountState = {}) => {
+    return configureStore({
+      reducer: {
+        auth: authReducer,
+        account: accountReducer,
+      },
+      preloadedState: {
+        auth: {
+          user: null,
+          accessToken: 'test-token',
+          refreshToken: 'test-refresh',
+          isAuthenticated: true,
+          isLoading: false,
+          error: null,
+          sessionTimeout: null,
+          ...authState,
+        },
+        account: {
+          profile: null,
+          isLoading: false,
+          isSaving: false,
+          error: null,
+          successMessage: null,
+          ...accountState,
+        },
+      },
+    });
+  };
+
+  const renderNavigation = (store) => {
+    return render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <Navigation />
+        </MemoryRouter>
+      </Provider>
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the app name', () => {
+    const store = createStore({ user: { email: 'test@example.com' } });
+    renderNavigation(store);
+    expect(screen.getByText('GTD Todo App')).toBeInTheDocument();
+  });
+
+  it('displays user initial from auth user', () => {
+    const store = createStore({ user: { email: 'test@example.com' } });
+    renderNavigation(store);
+    expect(screen.getByText('T')).toBeInTheDocument();
+  });
+
+  it('displays user initial from profile when user is null', () => {
+    const store = createStore(
+      { user: null },
+      { profile: { email: 'profile@example.com' } }
+    );
+    renderNavigation(store);
+    expect(screen.getByText('P')).toBeInTheDocument();
+  });
+
+  it('displays question mark when no email available', () => {
+    const store = createStore({ user: null }, { profile: null });
+    renderNavigation(store);
+    expect(screen.getByText('?')).toBeInTheDocument();
+  });
+
+  it('opens dropdown menu on click', async () => {
+    const user = userEvent.setup();
+    const store = createStore({ user: { email: 'test@example.com' } });
+    renderNavigation(store);
+
+    const menuButton = screen.getByRole('button', { expanded: false });
+    await user.click(menuButton);
+
+    expect(screen.getByText('Signed in')).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /settings/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /logout/i })).toBeInTheDocument();
+  });
+
+  it('displays email in dropdown menu', async () => {
+    const user = userEvent.setup();
+    const store = createStore({ user: { email: 'test@example.com' } });
+    renderNavigation(store);
+
+    await user.click(screen.getByRole('button'));
+    expect(screen.getByText('test@example.com')).toBeInTheDocument();
+  });
+
+  it('closes menu on outside click', async () => {
+    const user = userEvent.setup();
+    const store = createStore({ user: { email: 'test@example.com' } });
+    renderNavigation(store);
+
+    // Open menu
+    await user.click(screen.getByRole('button'));
+    expect(screen.getByText('Signed in')).toBeInTheDocument();
+
+    // Click outside
+    await user.click(document.body);
+    await waitFor(() => {
+      expect(screen.queryByText('Signed in')).not.toBeInTheDocument();
+    });
+  });
+
+  it('closes menu on Escape key', async () => {
+    const user = userEvent.setup();
+    const store = createStore({ user: { email: 'test@example.com' } });
+    renderNavigation(store);
+
+    // Open menu
+    await user.click(screen.getByRole('button'));
+    expect(screen.getByText('Signed in')).toBeInTheDocument();
+
+    // Press Escape
+    await user.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(screen.queryByText('Signed in')).not.toBeInTheDocument();
+    });
+  });
+
+  it('closes menu when Settings link is clicked', async () => {
+    const user = userEvent.setup();
+    const store = createStore({ user: { email: 'test@example.com' } });
+    renderNavigation(store);
+
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('menuitem', { name: /settings/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Signed in')).not.toBeInTheDocument();
+    });
+  });
+
+  it('has correct link to settings page', async () => {
+    const user = userEvent.setup();
+    const store = createStore({ user: { email: 'test@example.com' } });
+    renderNavigation(store);
+
+    await user.click(screen.getByRole('button'));
+    const settingsLink = screen.getByRole('menuitem', { name: /settings/i });
+    expect(settingsLink).toHaveAttribute('href', '/account/settings');
+  });
+
+  it('fetches profile when user and profile are both null', async () => {
+    const store = createStore({ user: null }, { profile: null });
+    renderNavigation(store);
+
+    await waitFor(() => {
+      expect(accountAPI.getProfile).toHaveBeenCalled();
+    });
+  });
+
+  it('does not fetch profile when user exists', () => {
+    const store = createStore({ user: { email: 'test@example.com' } });
+    renderNavigation(store);
+
+    expect(accountAPI.getProfile).not.toHaveBeenCalled();
+  });
+
+  it('rotates dropdown arrow when menu is open', async () => {
+    const user = userEvent.setup();
+    const store = createStore({ user: { email: 'test@example.com' } });
+    renderNavigation(store);
+
+    const button = screen.getByRole('button');
+    const svg = button.querySelector('svg');
+
+    // Initially not rotated
+    expect(svg.className.baseVal).not.toContain('rotate-180');
+
+    // Open menu
+    await user.click(button);
+
+    // Arrow should be rotated
+    const updatedSvg = button.querySelector('svg');
+    expect(updatedSvg.className.baseVal).toContain('rotate-180');
+  });
+});

--- a/web/src/tests/unit/components/NotificationPreferences.test.jsx
+++ b/web/src/tests/unit/components/NotificationPreferences.test.jsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NotificationPreferences from '../../../components/NotificationPreferences';
+
+describe('NotificationPreferences', () => {
+  const defaultProps = {
+    value: {},
+    onChange: vi.fn(),
+    disabled: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders with label', () => {
+    render(<NotificationPreferences {...defaultProps} />);
+    expect(screen.getByText(/email notifications/i)).toBeInTheDocument();
+  });
+
+  it('renders all notification options', () => {
+    render(<NotificationPreferences {...defaultProps} />);
+
+    expect(screen.getByLabelText(/weekly review reminder/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/deadline reminders/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/inbox overflow alert/i)).toBeInTheDocument();
+  });
+
+  it('displays descriptions for each option', () => {
+    render(<NotificationPreferences {...defaultProps} />);
+
+    expect(screen.getByText(/receive an email reminder for your weekly review/i)).toBeInTheDocument();
+    expect(screen.getByText(/get notified about upcoming task deadlines/i)).toBeInTheDocument();
+    expect(screen.getByText(/alert when your inbox has too many/i)).toBeInTheDocument();
+  });
+
+  it('shows checked state based on value prop', () => {
+    render(
+      <NotificationPreferences
+        {...defaultProps}
+        value={{
+          email_weekly_review: true,
+          email_deadline_reminder: false,
+        }}
+      />
+    );
+
+    expect(screen.getByLabelText(/weekly review reminder/i)).toBeChecked();
+    expect(screen.getByLabelText(/deadline reminders/i)).not.toBeChecked();
+  });
+
+  it('calls onChange when checkbox is toggled', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <NotificationPreferences
+        {...defaultProps}
+        value={{ email_weekly_review: false }}
+        onChange={onChange}
+      />
+    );
+
+    await user.click(screen.getByLabelText(/weekly review reminder/i));
+
+    expect(onChange).toHaveBeenCalledWith({
+      email_weekly_review: true,
+    });
+  });
+
+  it('toggles off when already checked', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <NotificationPreferences
+        {...defaultProps}
+        value={{ email_weekly_review: true }}
+        onChange={onChange}
+      />
+    );
+
+    await user.click(screen.getByLabelText(/weekly review reminder/i));
+
+    expect(onChange).toHaveBeenCalledWith({
+      email_weekly_review: false,
+    });
+  });
+
+  it('disables all checkboxes when disabled prop is true', () => {
+    render(<NotificationPreferences {...defaultProps} disabled={true} />);
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    checkboxes.forEach((checkbox) => {
+      expect(checkbox).toBeDisabled();
+    });
+  });
+
+  it('preserves other values when toggling one option', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <NotificationPreferences
+        {...defaultProps}
+        value={{
+          email_weekly_review: true,
+          email_deadline_reminder: true,
+        }}
+        onChange={onChange}
+      />
+    );
+
+    await user.click(screen.getByLabelText(/inbox overflow alert/i));
+
+    expect(onChange).toHaveBeenCalledWith({
+      email_weekly_review: true,
+      email_deadline_reminder: true,
+      email_inbox_overflow: true,
+    });
+  });
+});

--- a/web/src/tests/unit/components/TimezoneSelector.test.jsx
+++ b/web/src/tests/unit/components/TimezoneSelector.test.jsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TimezoneSelector from '../../../components/TimezoneSelector';
+
+describe('TimezoneSelector', () => {
+  const defaultProps = {
+    value: 'UTC',
+    onChange: vi.fn(),
+    disabled: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders with label', () => {
+    render(<TimezoneSelector {...defaultProps} />);
+    expect(screen.getByLabelText(/timezone/i)).toBeInTheDocument();
+  });
+
+  it('displays the selected timezone', () => {
+    render(<TimezoneSelector {...defaultProps} value="Europe/Paris" />);
+    const select = screen.getByRole('combobox');
+    expect(select.value).toBe('Europe/Paris');
+  });
+
+  it('calls onChange when a timezone is selected', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<TimezoneSelector {...defaultProps} onChange={onChange} />);
+
+    const select = screen.getByRole('combobox');
+    await user.selectOptions(select, 'America/New_York');
+
+    expect(onChange).toHaveBeenCalledWith('America/New_York');
+  });
+
+  it('renders timezone groups', () => {
+    render(<TimezoneSelector {...defaultProps} />);
+
+    // Check for optgroup labels
+    expect(screen.getByRole('group', { name: 'America' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Europe' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Asia' })).toBeInTheDocument();
+  });
+
+  it('disables select when disabled prop is true', () => {
+    render(<TimezoneSelector {...defaultProps} disabled={true} />);
+    const select = screen.getByRole('combobox');
+    expect(select).toBeDisabled();
+  });
+
+  it('displays error message when error prop is provided', () => {
+    render(<TimezoneSelector {...defaultProps} error="Invalid timezone" />);
+    expect(screen.getByText('Invalid timezone')).toBeInTheDocument();
+  });
+
+  it('displays helper text', () => {
+    render(<TimezoneSelector {...defaultProps} />);
+    expect(screen.getByText(/used for displaying dates/i)).toBeInTheDocument();
+  });
+
+  it('applies error styling when error is present', () => {
+    render(<TimezoneSelector {...defaultProps} error="Error" />);
+    const select = screen.getByRole('combobox');
+    expect(select.className).toContain('border-red-300');
+  });
+});

--- a/web/src/tests/unit/features/account/accountSlice.test.js
+++ b/web/src/tests/unit/features/account/accountSlice.test.js
@@ -1,0 +1,377 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { configureStore } from '@reduxjs/toolkit';
+import accountReducer, {
+  clearError,
+  clearSuccessMessage,
+  selectProfile,
+  selectAccountLoading,
+  selectAccountSaving,
+  selectAccountError,
+  selectSuccessMessage,
+  fetchProfile,
+  updatePreferences,
+  deleteAccount,
+} from '../../../../features/account/accountSlice';
+
+// Mock the API module
+vi.mock('../../../../services/api', () => ({
+  accountAPI: {
+    getProfile: vi.fn(),
+    updatePreferences: vi.fn(),
+    deleteAccount: vi.fn(),
+  },
+}));
+
+import { accountAPI } from '../../../../services/api';
+
+describe('accountSlice', () => {
+  let store;
+
+  const initialState = {
+    profile: null,
+    isLoading: false,
+    isSaving: false,
+    error: null,
+    successMessage: null,
+  };
+
+  const mockProfile = {
+    id: '123',
+    email: 'test@example.com',
+    status: 'active',
+    timezone: 'Europe/Paris',
+    notification_preferences: {
+      email_weekly_review: true,
+      email_deadline_reminder: false,
+    },
+    created_at: '2024-01-15T10:30:00Z',
+    verified_at: '2024-01-15T11:00:00Z',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    store = configureStore({
+      reducer: {
+        account: accountReducer,
+      },
+      preloadedState: {
+        account: initialState,
+      },
+    });
+  });
+
+  describe('reducers', () => {
+    describe('clearError', () => {
+      it('should clear the error state', () => {
+        store = configureStore({
+          reducer: { account: accountReducer },
+          preloadedState: {
+            account: { ...initialState, error: 'Some error' },
+          },
+        });
+
+        store.dispatch(clearError());
+        expect(store.getState().account.error).toBeNull();
+      });
+    });
+
+    describe('clearSuccessMessage', () => {
+      it('should clear the success message state', () => {
+        store = configureStore({
+          reducer: { account: accountReducer },
+          preloadedState: {
+            account: { ...initialState, successMessage: 'Success!' },
+          },
+        });
+
+        store.dispatch(clearSuccessMessage());
+        expect(store.getState().account.successMessage).toBeNull();
+      });
+    });
+  });
+
+  describe('selectors', () => {
+    const testState = {
+      account: {
+        profile: mockProfile,
+        isLoading: true,
+        isSaving: false,
+        error: 'Test error',
+        successMessage: 'Test success',
+      },
+    };
+
+    it('selectProfile should return the profile', () => {
+      expect(selectProfile(testState)).toEqual(mockProfile);
+    });
+
+    it('selectAccountLoading should return isLoading', () => {
+      expect(selectAccountLoading(testState)).toBe(true);
+    });
+
+    it('selectAccountSaving should return isSaving', () => {
+      expect(selectAccountSaving(testState)).toBe(false);
+    });
+
+    it('selectAccountError should return error', () => {
+      expect(selectAccountError(testState)).toBe('Test error');
+    });
+
+    it('selectSuccessMessage should return successMessage', () => {
+      expect(selectSuccessMessage(testState)).toBe('Test success');
+    });
+  });
+
+  describe('async thunks', () => {
+    describe('fetchProfile', () => {
+      it('should handle successful profile fetch', async () => {
+        const mockResponse = {
+          data: {
+            user: mockProfile,
+          },
+        };
+
+        accountAPI.getProfile.mockResolvedValueOnce(mockResponse);
+
+        await store.dispatch(fetchProfile());
+
+        const state = store.getState().account;
+        expect(state.profile).toEqual(mockProfile);
+        expect(state.isLoading).toBe(false);
+        expect(state.error).toBeNull();
+      });
+
+      it('should handle profile fetch with direct payload', async () => {
+        const mockResponse = {
+          data: mockProfile,
+        };
+
+        accountAPI.getProfile.mockResolvedValueOnce(mockResponse);
+
+        await store.dispatch(fetchProfile());
+
+        const state = store.getState().account;
+        expect(state.profile).toEqual(mockProfile);
+      });
+
+      it('should handle profile fetch failure', async () => {
+        const mockError = {
+          response: {
+            data: {
+              error: 'Unauthorized',
+            },
+          },
+        };
+
+        accountAPI.getProfile.mockRejectedValueOnce(mockError);
+
+        await store.dispatch(fetchProfile());
+
+        const state = store.getState().account;
+        expect(state.profile).toBeNull();
+        expect(state.isLoading).toBe(false);
+        expect(state.error).toBe('Unauthorized');
+      });
+
+      it('should handle profile fetch failure with message', async () => {
+        const mockError = {
+          response: {
+            data: {
+              message: 'Session expired',
+            },
+          },
+        };
+
+        accountAPI.getProfile.mockRejectedValueOnce(mockError);
+
+        await store.dispatch(fetchProfile());
+
+        const state = store.getState().account;
+        expect(state.error).toBe('Session expired');
+      });
+
+      it('should use default error message when no message provided', async () => {
+        accountAPI.getProfile.mockRejectedValueOnce(new Error('Network error'));
+
+        await store.dispatch(fetchProfile());
+
+        const state = store.getState().account;
+        expect(state.error).toBe('Failed to fetch profile');
+      });
+
+      it('should set loading state during fetch', async () => {
+        let resolvePromise;
+        const pendingPromise = new Promise((resolve) => {
+          resolvePromise = resolve;
+        });
+
+        accountAPI.getProfile.mockReturnValueOnce(pendingPromise);
+
+        const fetchPromise = store.dispatch(fetchProfile());
+
+        expect(store.getState().account.isLoading).toBe(true);
+
+        resolvePromise({ data: { user: mockProfile } });
+        await fetchPromise;
+
+        expect(store.getState().account.isLoading).toBe(false);
+      });
+    });
+
+    describe('updatePreferences', () => {
+      it('should handle successful preferences update', async () => {
+        const updatedProfile = { ...mockProfile, timezone: 'UTC' };
+        const mockResponse = {
+          data: {
+            user: updatedProfile,
+          },
+        };
+
+        accountAPI.updatePreferences.mockResolvedValueOnce(mockResponse);
+
+        await store.dispatch(updatePreferences({ timezone: 'UTC' }));
+
+        const state = store.getState().account;
+        expect(state.profile).toEqual(updatedProfile);
+        expect(state.isSaving).toBe(false);
+        expect(state.successMessage).toBe('Preferences updated successfully');
+        expect(state.error).toBeNull();
+      });
+
+      it('should handle preferences update failure', async () => {
+        const mockError = {
+          response: {
+            data: {
+              error: 'Invalid timezone',
+            },
+          },
+        };
+
+        accountAPI.updatePreferences.mockRejectedValueOnce(mockError);
+
+        await store.dispatch(updatePreferences({ timezone: 'Invalid' }));
+
+        const state = store.getState().account;
+        expect(state.isSaving).toBe(false);
+        expect(state.error).toBe('Invalid timezone');
+        expect(state.successMessage).toBeNull();
+      });
+
+      it('should set saving state during update', async () => {
+        let resolvePromise;
+        const pendingPromise = new Promise((resolve) => {
+          resolvePromise = resolve;
+        });
+
+        accountAPI.updatePreferences.mockReturnValueOnce(pendingPromise);
+
+        const updatePromise = store.dispatch(updatePreferences({ timezone: 'UTC' }));
+
+        expect(store.getState().account.isSaving).toBe(true);
+
+        resolvePromise({ data: { user: mockProfile } });
+        await updatePromise;
+
+        expect(store.getState().account.isSaving).toBe(false);
+      });
+
+      it('should clear error and success message when starting update', async () => {
+        store = configureStore({
+          reducer: { account: accountReducer },
+          preloadedState: {
+            account: {
+              ...initialState,
+              error: 'Previous error',
+              successMessage: 'Previous success',
+            },
+          },
+        });
+
+        let resolvePromise;
+        const pendingPromise = new Promise((resolve) => {
+          resolvePromise = resolve;
+        });
+
+        accountAPI.updatePreferences.mockReturnValueOnce(pendingPromise);
+
+        const updatePromise = store.dispatch(updatePreferences({ timezone: 'UTC' }));
+
+        const pendingState = store.getState().account;
+        expect(pendingState.error).toBeNull();
+        expect(pendingState.successMessage).toBeNull();
+
+        resolvePromise({ data: { user: mockProfile } });
+        await updatePromise;
+      });
+    });
+
+    describe('deleteAccount', () => {
+      it('should handle successful account deletion', async () => {
+        store = configureStore({
+          reducer: { account: accountReducer },
+          preloadedState: {
+            account: { ...initialState, profile: mockProfile },
+          },
+        });
+
+        const mockResponse = {
+          data: { message: 'Account deleted successfully' },
+        };
+
+        accountAPI.deleteAccount.mockResolvedValueOnce(mockResponse);
+
+        await store.dispatch(deleteAccount({ password: 'password123', confirmText: 'DELETE' }));
+
+        const state = store.getState().account;
+        expect(state.profile).toBeNull();
+        expect(state.isSaving).toBe(false);
+        expect(state.error).toBeNull();
+      });
+
+      it('should handle account deletion failure', async () => {
+        const mockError = {
+          response: {
+            data: {
+              error: 'Invalid password',
+            },
+          },
+        };
+
+        accountAPI.deleteAccount.mockRejectedValueOnce(mockError);
+
+        await store.dispatch(deleteAccount({ password: 'wrongpassword', confirmText: 'DELETE' }));
+
+        const state = store.getState().account;
+        expect(state.isSaving).toBe(false);
+        expect(state.error).toBe('Invalid password');
+      });
+
+      it('should set saving state during deletion', async () => {
+        let resolvePromise;
+        const pendingPromise = new Promise((resolve) => {
+          resolvePromise = resolve;
+        });
+
+        accountAPI.deleteAccount.mockReturnValueOnce(pendingPromise);
+
+        const deletePromise = store.dispatch(deleteAccount({ password: 'password123', confirmText: 'DELETE' }));
+
+        expect(store.getState().account.isSaving).toBe(true);
+
+        resolvePromise({ data: { message: 'Account deleted' } });
+        await deletePromise;
+
+        expect(store.getState().account.isSaving).toBe(false);
+      });
+
+      it('should call API with correct parameters', async () => {
+        accountAPI.deleteAccount.mockResolvedValueOnce({ data: {} });
+
+        await store.dispatch(deleteAccount({ password: 'mypassword', confirmText: 'DELETE' }));
+
+        expect(accountAPI.deleteAccount).toHaveBeenCalledWith('mypassword', 'DELETE');
+      });
+    });
+  });
+});

--- a/web/src/tests/unit/pages/AccountDeletionPage.test.jsx
+++ b/web/src/tests/unit/pages/AccountDeletionPage.test.jsx
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
+import authReducer from '../../../features/auth/authSlice';
+import accountReducer from '../../../features/account/accountSlice';
+import AccountDeletionPage from '../../../pages/AccountDeletionPage';
+
+// Mock the API module
+vi.mock('../../../services/api', () => ({
+  accountAPI: {
+    deleteAccount: vi.fn(),
+  },
+}));
+
+import { accountAPI } from '../../../services/api';
+
+describe('AccountDeletionPage', () => {
+  const createStore = (accountState = {}) => {
+    return configureStore({
+      reducer: {
+        auth: authReducer,
+        account: accountReducer,
+      },
+      preloadedState: {
+        auth: {
+          user: { email: 'test@example.com' },
+          accessToken: 'test-token',
+          refreshToken: 'test-refresh',
+          isAuthenticated: true,
+          isLoading: false,
+          error: null,
+          sessionTimeout: null,
+        },
+        account: {
+          profile: null,
+          isLoading: false,
+          isSaving: false,
+          error: null,
+          successMessage: null,
+          ...accountState,
+        },
+      },
+    });
+  };
+
+  const renderPage = (store) => {
+    return render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <AccountDeletionPage />
+        </MemoryRouter>
+      </Provider>
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders page title', () => {
+    const store = createStore();
+    renderPage(store);
+
+    expect(screen.getByText('Delete Account')).toBeInTheDocument();
+  });
+
+  it('displays warning message', () => {
+    const store = createStore();
+    renderPage(store);
+
+    expect(screen.getByText(/this action cannot be undone/i)).toBeInTheDocument();
+  });
+
+  it('displays list of consequences', () => {
+    const store = createStore();
+    renderPage(store);
+
+    expect(screen.getByText(/all your tasks and projects will be permanently deleted/i)).toBeInTheDocument();
+    expect(screen.getByText(/your inbox items will be erased/i)).toBeInTheDocument();
+    expect(screen.getByText(/this action is/i)).toBeInTheDocument();
+  });
+
+  it('displays GDPR notice', () => {
+    const store = createStore();
+    renderPage(store);
+
+    expect(screen.getByText('GDPR Compliance')).toBeInTheDocument();
+    expect(screen.getByText(/right to erasure/i)).toBeInTheDocument();
+  });
+
+  it('has back link to settings', () => {
+    const store = createStore();
+    renderPage(store);
+
+    const backLink = screen.getByRole('link', { name: /back to settings/i });
+    expect(backLink).toHaveAttribute('href', '/account/settings');
+  });
+
+  it('renders password input', () => {
+    const store = createStore();
+    renderPage(store);
+
+    expect(screen.getByLabelText(/enter your password/i)).toBeInTheDocument();
+  });
+
+  it('renders confirmation text input', () => {
+    const store = createStore();
+    renderPage(store);
+
+    expect(screen.getByPlaceholderText('DELETE')).toBeInTheDocument();
+  });
+
+  it('disables submit button initially', () => {
+    const store = createStore();
+    renderPage(store);
+
+    const submitButton = screen.getByRole('button', { name: /permanently delete/i });
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('enables submit button when password and DELETE are entered', async () => {
+    const user = userEvent.setup();
+    const store = createStore();
+    renderPage(store);
+
+    await user.type(screen.getByLabelText(/enter your password/i), 'mypassword');
+    await user.type(screen.getByPlaceholderText('DELETE'), 'DELETE');
+
+    const submitButton = screen.getByRole('button', { name: /permanently delete/i });
+    expect(submitButton).not.toBeDisabled();
+  });
+
+  it('shows error when confirmation text is wrong', async () => {
+    const user = userEvent.setup();
+    const store = createStore();
+    renderPage(store);
+
+    await user.type(screen.getByPlaceholderText('DELETE'), 'delete');
+
+    // The input auto-uppercases, so it should show DELETE
+    expect(screen.getByPlaceholderText('DELETE').value).toBe('DELETE');
+  });
+
+  it('shows error message for invalid confirmation', async () => {
+    const user = userEvent.setup();
+    const store = createStore();
+    renderPage(store);
+
+    const confirmInput = screen.getByPlaceholderText('DELETE');
+    await user.type(confirmInput, 'WRONG');
+
+    expect(screen.getByText(/please type DELETE exactly/i)).toBeInTheDocument();
+  });
+
+  it('toggles password visibility', async () => {
+    const user = userEvent.setup();
+    const store = createStore();
+    renderPage(store);
+
+    const passwordInput = screen.getByLabelText(/enter your password/i);
+    expect(passwordInput).toHaveAttribute('type', 'password');
+
+    // Find and click the toggle button (the button inside the input container)
+    const toggleButton = passwordInput.parentElement.querySelector('button');
+    await user.click(toggleButton);
+
+    expect(passwordInput).toHaveAttribute('type', 'text');
+  });
+
+  it('calls deleteAccount API on submit', async () => {
+    const user = userEvent.setup();
+    accountAPI.deleteAccount.mockResolvedValue({ data: { message: 'Account deleted' } });
+    const store = createStore();
+    renderPage(store);
+
+    await user.type(screen.getByLabelText(/enter your password/i), 'mypassword');
+    await user.type(screen.getByPlaceholderText('DELETE'), 'DELETE');
+    await user.click(screen.getByRole('button', { name: /permanently delete/i }));
+
+    await waitFor(() => {
+      expect(accountAPI.deleteAccount).toHaveBeenCalledWith('mypassword', 'DELETE');
+    });
+  });
+
+  it('displays error message on failure', () => {
+    const store = createStore({ error: 'Invalid password' });
+    renderPage(store);
+
+    expect(screen.getByText('Invalid password')).toBeInTheDocument();
+  });
+
+  it('shows saving state on button', () => {
+    const store = createStore({ isSaving: true });
+    renderPage(store);
+
+    expect(screen.getByText('Deleting...')).toBeInTheDocument();
+  });
+
+  it('disables form while saving', async () => {
+    const store = createStore({ isSaving: true });
+    renderPage(store);
+
+    const passwordInput = screen.getByLabelText(/enter your password/i);
+    const confirmInput = screen.getByPlaceholderText('DELETE');
+    const submitButton = screen.getByRole('button', { name: /deleting/i });
+
+    expect(passwordInput).toBeDisabled();
+    expect(confirmInput).toBeDisabled();
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('has cancel link back to settings', () => {
+    const store = createStore();
+    renderPage(store);
+
+    const cancelLink = screen.getByRole('link', { name: /cancel/i });
+    expect(cancelLink).toHaveAttribute('href', '/account/settings');
+  });
+});

--- a/web/src/tests/unit/pages/AccountSettingsPage.test.jsx
+++ b/web/src/tests/unit/pages/AccountSettingsPage.test.jsx
@@ -1,0 +1,314 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
+import authReducer from '../../../features/auth/authSlice';
+import accountReducer from '../../../features/account/accountSlice';
+import AccountSettingsPage from '../../../pages/AccountSettingsPage';
+
+// Mock the API module
+vi.mock('../../../services/api', () => ({
+  accountAPI: {
+    getProfile: vi.fn(),
+    updatePreferences: vi.fn(),
+  },
+}));
+
+import { accountAPI } from '../../../services/api';
+
+describe('AccountSettingsPage', () => {
+  const mockProfile = {
+    id: '123',
+    email: 'test@example.com',
+    status: 'active',
+    timezone: 'Europe/Paris',
+    notification_preferences: {
+      email_weekly_review: true,
+      email_deadline_reminder: false,
+    },
+    created_at: '2024-01-15T10:30:00Z',
+    verified_at: '2024-02-20T11:00:00Z',
+  };
+
+  const createStore = (accountState = {}) => {
+    return configureStore({
+      reducer: {
+        auth: authReducer,
+        account: accountReducer,
+      },
+      preloadedState: {
+        auth: {
+          user: null,
+          accessToken: 'test-token',
+          refreshToken: 'test-refresh',
+          isAuthenticated: true,
+          isLoading: false,
+          error: null,
+          sessionTimeout: null,
+        },
+        account: {
+          profile: null,
+          isLoading: false,
+          isSaving: false,
+          error: null,
+          successMessage: null,
+          ...accountState,
+        },
+      },
+    });
+  };
+
+  const renderPage = (store) => {
+    return render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <AccountSettingsPage />
+        </MemoryRouter>
+      </Provider>
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    accountAPI.getProfile.mockResolvedValue({ data: { user: mockProfile } });
+    accountAPI.updatePreferences.mockResolvedValue({ data: { user: mockProfile } });
+  });
+
+  it('renders page title', async () => {
+    const store = createStore();
+    renderPage(store);
+
+    await waitFor(() => {
+      expect(screen.getByText('Account Settings')).toBeInTheDocument();
+    });
+  });
+
+  it('shows loading state initially', () => {
+    const store = createStore({ isLoading: true });
+    renderPage(store);
+
+    // Should show skeleton loading
+    expect(screen.queryByText('Profile Information')).not.toBeInTheDocument();
+  });
+
+  it('fetches profile on mount', async () => {
+    const store = createStore();
+    renderPage(store);
+
+    await waitFor(() => {
+      expect(accountAPI.getProfile).toHaveBeenCalled();
+    });
+  });
+
+  it('displays profile information', async () => {
+    const store = createStore({ profile: mockProfile, isLoading: false });
+    renderPage(store);
+
+    await waitFor(() => {
+      expect(screen.getByText('Profile Information')).toBeInTheDocument();
+    });
+    expect(screen.getByText('test@example.com')).toBeInTheDocument();
+    expect(screen.getByText('active')).toBeInTheDocument();
+  });
+
+  it('displays member since date', async () => {
+    const store = createStore({ profile: mockProfile, isLoading: false });
+    renderPage(store);
+
+    await waitFor(() => {
+      expect(screen.getByText('Member Since')).toBeInTheDocument();
+    });
+    expect(screen.getByText('January 15, 2024')).toBeInTheDocument();
+  });
+
+  it('displays email verified date', async () => {
+    const store = createStore({ profile: mockProfile, isLoading: false });
+    renderPage(store);
+
+    await waitFor(() => {
+      expect(screen.getByText('Email Verified')).toBeInTheDocument();
+    });
+    expect(screen.getByText('February 20, 2024')).toBeInTheDocument();
+  });
+
+  it('shows "Not verified" when email not verified', async () => {
+    const unverifiedProfile = { ...mockProfile, verified_at: null };
+    accountAPI.getProfile.mockResolvedValue({ data: { user: unverifiedProfile } });
+    const store = createStore({
+      profile: unverifiedProfile,
+      isLoading: false,
+    });
+    renderPage(store);
+
+    await waitFor(() => {
+      expect(screen.getByText('Not verified')).toBeInTheDocument();
+    });
+  });
+
+  it('renders timezone selector with correct value', async () => {
+    const store = createStore({ profile: mockProfile, isLoading: false });
+    renderPage(store);
+
+    await waitFor(() => {
+      const timezoneSelect = screen.getByLabelText(/timezone/i);
+      expect(timezoneSelect.value).toBe('Europe/Paris');
+    });
+  });
+
+  it('renders notification preferences', async () => {
+    const store = createStore({ profile: mockProfile, isLoading: false });
+    renderPage(store);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/weekly review reminder/i)).toBeChecked();
+    });
+    expect(screen.getByLabelText(/deadline reminders/i)).not.toBeChecked();
+  });
+
+  it('enables save button when changes are made', async () => {
+    const user = userEvent.setup();
+    const store = createStore({ profile: mockProfile, isLoading: false });
+    renderPage(store);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeDisabled();
+    });
+
+    // Change timezone
+    const timezoneSelect = screen.getByLabelText(/timezone/i);
+    await user.selectOptions(timezoneSelect, 'UTC');
+
+    expect(screen.getByRole('button', { name: /save changes/i })).not.toBeDisabled();
+  });
+
+  it('enables reset button when changes are made', async () => {
+    const user = userEvent.setup();
+    const store = createStore({ profile: mockProfile, isLoading: false });
+    renderPage(store);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /reset/i })).toBeDisabled();
+    });
+
+    // Make a change
+    await user.click(screen.getByLabelText(/deadline reminders/i));
+
+    expect(screen.getByRole('button', { name: /reset/i })).not.toBeDisabled();
+  });
+
+  it('resets form when reset button is clicked', async () => {
+    const user = userEvent.setup();
+    const store = createStore({ profile: mockProfile, isLoading: false });
+    renderPage(store);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/timezone/i)).toBeInTheDocument();
+    });
+
+    // Change value
+    const timezoneSelect = screen.getByLabelText(/timezone/i);
+    await user.selectOptions(timezoneSelect, 'UTC');
+
+    // Click reset
+    await user.click(screen.getByRole('button', { name: /reset/i }));
+
+    // Should be back to original
+    expect(timezoneSelect.value).toBe('Europe/Paris');
+  });
+
+  it('calls updatePreferences on save', async () => {
+    const user = userEvent.setup();
+    const store = createStore({ profile: mockProfile, isLoading: false });
+    renderPage(store);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/timezone/i)).toBeInTheDocument();
+    });
+
+    // Change timezone
+    await user.selectOptions(screen.getByLabelText(/timezone/i), 'UTC');
+
+    // Save
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(accountAPI.updatePreferences).toHaveBeenCalledWith({
+        timezone: 'UTC',
+        notification_preferences: mockProfile.notification_preferences,
+      });
+    });
+  });
+
+  it('displays success message after save', async () => {
+    const store = createStore({
+      profile: mockProfile,
+      isLoading: false,
+      successMessage: 'Preferences updated successfully',
+    });
+    renderPage(store);
+
+    await waitFor(() => {
+      expect(screen.getByText('Preferences updated successfully')).toBeInTheDocument();
+    });
+  });
+
+  it('displays error message on failure', async () => {
+    // Mock getProfile to reject, which triggers the error state
+    accountAPI.getProfile.mockRejectedValue({
+      response: { data: { error: 'Failed to update preferences' } }
+    });
+    const store = createStore({
+      profile: null,
+      isLoading: false,
+    });
+    renderPage(store);
+
+    // Wait for the error message to appear after fetch fails
+    await waitFor(() => {
+      expect(screen.getByText('Failed to update preferences')).toBeInTheDocument();
+    });
+  });
+
+  it('shows saving state on button', async () => {
+    const store = createStore({
+      profile: mockProfile,
+      isLoading: false,
+      isSaving: true,
+    });
+    renderPage(store);
+
+    await waitFor(() => {
+      expect(screen.getByText('Saving...')).toBeInTheDocument();
+    });
+  });
+
+  it('renders danger zone with delete link', async () => {
+    const store = createStore({ profile: mockProfile, isLoading: false });
+    renderPage(store);
+
+    await waitFor(() => {
+      expect(screen.getByText('Danger Zone')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('link', { name: /delete account/i })).toHaveAttribute(
+      'href',
+      '/account/delete'
+    );
+  });
+
+  it('displays N/A for missing data', async () => {
+    const incompleteProfile = { ...mockProfile, email: null, created_at: null };
+    accountAPI.getProfile.mockResolvedValue({ data: { user: incompleteProfile } });
+    const store = createStore({
+      profile: incompleteProfile,
+      isLoading: false,
+    });
+    renderPage(store);
+
+    await waitFor(() => {
+      const naElements = screen.getAllByText('N/A');
+      expect(naElements.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add Account Settings page with profile information display
- Implement timezone selector component with common timezone options
- Add notification preferences component for email notifications
- Create account deletion page with confirmation flow (password + "DELETE" text)
- Add accountSlice for Redux state management
- Include comprehensive unit tests for all new components (181 tests total)

## Test plan
- [x] All 181 unit tests pass
- [ ] Verify account settings page displays user profile correctly
- [ ] Test timezone selection updates properly
- [ ] Test notification preferences toggle
- [ ] Verify account deletion requires both password and "DELETE" confirmation
- [ ] Test navigation to account settings from user menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)