### PR TITLE
feat(web): add LoadingButton component with spinner

### DIFF
--- a/web/src/components/AppleSignInButton.jsx
+++ b/web/src/components/AppleSignInButton.jsx
@@ -1,5 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { appleSignIn, selectAuthLoading } from '../features/auth/authSlice';
+import { Spinner } from './LoadingButton';
 
 /**
  * AppleSignInButton component
@@ -71,7 +72,14 @@ const AppleSignInButton = () => {
       >
         <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
       </svg>
-      {isLoading ? 'Signing in...' : 'Continue with Apple'}
+      {isLoading ? (
+        <>
+          <Spinner className="h-5 w-5 mr-2 text-gray-500" />
+          Signing in...
+        </>
+      ) : (
+        'Continue with Apple'
+      )}
     </button>
   );
 };

--- a/web/src/components/LoadingButton.jsx
+++ b/web/src/components/LoadingButton.jsx
@@ -1,0 +1,124 @@
+import PropTypes from 'prop-types';
+
+/**
+ * Spinner component - SVG animated spinner
+ */
+const Spinner = ({ className = 'h-5 w-5' }) => (
+  <svg
+    className={`animate-spin ${className}`}
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    data-testid="loading-spinner"
+  >
+    <circle
+      className="opacity-25"
+      cx="12"
+      cy="12"
+      r="10"
+      stroke="currentColor"
+      strokeWidth="4"
+    />
+    <path
+      className="opacity-75"
+      fill="currentColor"
+      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+    />
+  </svg>
+);
+
+Spinner.propTypes = {
+  className: PropTypes.string,
+};
+
+/**
+ * LoadingButton component
+ *
+ * A button that displays a loading spinner when in loading state.
+ * Supports different variants (primary, secondary, danger) and sizes.
+ *
+ * @param {Object} props
+ * @param {React.ReactNode} props.children - Button content when not loading
+ * @param {boolean} props.isLoading - Whether the button is in loading state
+ * @param {string} props.loadingText - Text to display while loading
+ * @param {string} props.variant - Button variant (primary, secondary, danger)
+ * @param {string} props.size - Button size (sm, md, lg)
+ * @param {boolean} props.fullWidth - Whether button should take full width
+ * @param {string} props.type - Button type (button, submit, reset)
+ * @param {boolean} props.disabled - Whether button is disabled
+ * @param {string} props.className - Additional CSS classes
+ * @param {Function} props.onClick - Click handler
+ */
+const LoadingButton = ({
+  children,
+  isLoading = false,
+  loadingText,
+  variant = 'primary',
+  size = 'md',
+  fullWidth = false,
+  type = 'button',
+  disabled = false,
+  className = '',
+  onClick,
+  ...rest
+}) => {
+  const baseClasses = 'inline-flex justify-center items-center font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 transition-colors';
+
+  const variantClasses = {
+    primary: 'border border-transparent text-white bg-blue-600 hover:bg-blue-700 focus:ring-blue-500 disabled:bg-gray-400',
+    secondary: 'border border-gray-300 text-gray-700 bg-white hover:bg-gray-50 focus:ring-blue-500 disabled:bg-gray-100',
+    danger: 'border border-transparent text-white bg-red-600 hover:bg-red-700 focus:ring-red-500 disabled:bg-gray-400',
+  };
+
+  const sizeClasses = {
+    sm: 'py-1.5 px-3 text-xs',
+    md: 'py-2 px-4 text-sm',
+    lg: 'py-3 px-6 text-base',
+  };
+
+  const spinnerSizes = {
+    sm: 'h-4 w-4',
+    md: 'h-5 w-5',
+    lg: 'h-6 w-6',
+  };
+
+  const widthClass = fullWidth ? 'w-full' : '';
+  const disabledClass = 'disabled:cursor-not-allowed disabled:opacity-50';
+
+  const combinedClassName = `${baseClasses} ${variantClasses[variant]} ${sizeClasses[size]} ${widthClass} ${disabledClass} ${className}`.trim();
+
+  return (
+    <button
+      type={type}
+      disabled={disabled || isLoading}
+      onClick={onClick}
+      className={combinedClassName}
+      {...rest}
+    >
+      {isLoading ? (
+        <span className="flex items-center">
+          <Spinner className={`${spinnerSizes[size]} ${loadingText ? '-ml-1 mr-2' : ''}`} />
+          {loadingText}
+        </span>
+      ) : (
+        children
+      )}
+    </button>
+  );
+};
+
+LoadingButton.propTypes = {
+  children: PropTypes.node.isRequired,
+  isLoading: PropTypes.bool,
+  loadingText: PropTypes.string,
+  variant: PropTypes.oneOf(['primary', 'secondary', 'danger']),
+  size: PropTypes.oneOf(['sm', 'md', 'lg']),
+  fullWidth: PropTypes.bool,
+  type: PropTypes.oneOf(['button', 'submit', 'reset']),
+  disabled: PropTypes.bool,
+  className: PropTypes.string,
+  onClick: PropTypes.func,
+};
+
+export { Spinner };
+export default LoadingButton;

--- a/web/src/tests/unit/components/LoadingButton.test.jsx
+++ b/web/src/tests/unit/components/LoadingButton.test.jsx
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LoadingButton, { Spinner } from '../../../components/LoadingButton';
+
+describe('Spinner', () => {
+  it('renders with default className', () => {
+    render(<Spinner />);
+
+    const spinner = screen.getByTestId('loading-spinner');
+    expect(spinner).toBeInTheDocument();
+    expect(spinner).toHaveClass('animate-spin', 'h-5', 'w-5');
+  });
+
+  it('renders with custom className', () => {
+    render(<Spinner className="h-8 w-8 text-red-500" />);
+
+    const spinner = screen.getByTestId('loading-spinner');
+    expect(spinner).toHaveClass('animate-spin', 'h-8', 'w-8', 'text-red-500');
+  });
+});
+
+describe('LoadingButton', () => {
+  it('renders children when not loading', () => {
+    render(<LoadingButton>Click me</LoadingButton>);
+
+    expect(screen.getByRole('button')).toHaveTextContent('Click me');
+  });
+
+  it('renders loading spinner and text when loading', () => {
+    render(
+      <LoadingButton isLoading loadingText="Loading...">
+        Click me
+      </LoadingButton>
+    );
+
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toHaveTextContent('Loading...');
+    expect(screen.queryByText('Click me')).not.toBeInTheDocument();
+  });
+
+  it('renders only spinner when loading without loadingText', () => {
+    render(<LoadingButton isLoading>Click me</LoadingButton>);
+
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+    expect(screen.queryByText('Click me')).not.toBeInTheDocument();
+  });
+
+  it('is disabled when loading', () => {
+    render(<LoadingButton isLoading>Click me</LoadingButton>);
+
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('is disabled when disabled prop is true', () => {
+    render(<LoadingButton disabled>Click me</LoadingButton>);
+
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('is not disabled by default', () => {
+    render(<LoadingButton>Click me</LoadingButton>);
+
+    expect(screen.getByRole('button')).not.toBeDisabled();
+  });
+
+  it('calls onClick when clicked', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(<LoadingButton onClick={handleClick}>Click me</LoadingButton>);
+
+    await user.click(screen.getByRole('button'));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClick when disabled', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(
+      <LoadingButton onClick={handleClick} disabled>
+        Click me
+      </LoadingButton>
+    );
+
+    await user.click(screen.getByRole('button'));
+
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('does not call onClick when loading', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(
+      <LoadingButton onClick={handleClick} isLoading>
+        Click me
+      </LoadingButton>
+    );
+
+    await user.click(screen.getByRole('button'));
+
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  describe('variants', () => {
+    it('renders primary variant by default', () => {
+      render(<LoadingButton>Click me</LoadingButton>);
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('bg-blue-600', 'text-white');
+    });
+
+    it('renders secondary variant', () => {
+      render(<LoadingButton variant="secondary">Click me</LoadingButton>);
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('bg-white', 'text-gray-700', 'border-gray-300');
+    });
+
+    it('renders danger variant', () => {
+      render(<LoadingButton variant="danger">Click me</LoadingButton>);
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('bg-red-600', 'text-white');
+    });
+  });
+
+  describe('sizes', () => {
+    it('renders medium size by default', () => {
+      render(<LoadingButton>Click me</LoadingButton>);
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('py-2', 'px-4', 'text-sm');
+    });
+
+    it('renders small size', () => {
+      render(<LoadingButton size="sm">Click me</LoadingButton>);
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('py-1.5', 'px-3', 'text-xs');
+    });
+
+    it('renders large size', () => {
+      render(<LoadingButton size="lg">Click me</LoadingButton>);
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('py-3', 'px-6', 'text-base');
+    });
+  });
+
+  describe('fullWidth', () => {
+    it('is not full width by default', () => {
+      render(<LoadingButton>Click me</LoadingButton>);
+
+      const button = screen.getByRole('button');
+      expect(button).not.toHaveClass('w-full');
+    });
+
+    it('is full width when fullWidth prop is true', () => {
+      render(<LoadingButton fullWidth>Click me</LoadingButton>);
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('w-full');
+    });
+  });
+
+  describe('type', () => {
+    it('has type="button" by default', () => {
+      render(<LoadingButton>Click me</LoadingButton>);
+
+      expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+    });
+
+    it('can have type="submit"', () => {
+      render(<LoadingButton type="submit">Submit</LoadingButton>);
+
+      expect(screen.getByRole('button')).toHaveAttribute('type', 'submit');
+    });
+
+    it('can have type="reset"', () => {
+      render(<LoadingButton type="reset">Reset</LoadingButton>);
+
+      expect(screen.getByRole('button')).toHaveAttribute('type', 'reset');
+    });
+  });
+
+  it('applies additional className', () => {
+    render(<LoadingButton className="my-custom-class">Click me</LoadingButton>);
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('my-custom-class');
+  });
+
+  it('passes additional props to button element', () => {
+    render(
+      <LoadingButton data-testid="my-button" aria-label="Custom label">
+        Click me
+      </LoadingButton>
+    );
+
+    const button = screen.getByTestId('my-button');
+    expect(button).toHaveAttribute('aria-label', 'Custom label');
+  });
+});


### PR DESCRIPTION
## Summary

- Create reusable `LoadingButton` component with animated spinner
- Support variants (primary, secondary, danger) and sizes (sm, md, lg)
- Export standalone `Spinner` component for reuse
- Add animated spinner to `AppleSignInButton` loading state
- Add comprehensive unit tests (24 tests)

## Test plan

- [x] All 205 unit tests pass
- [x] LoadingButton renders correctly with all variants
- [x] LoadingButton shows spinner when `isLoading` is true
- [x] AppleSignInButton shows animated spinner during authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)