### PR TITLE
feat(api): P2 Backend - Task Capture and Inbox Endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,8 @@ jobs:
           cp .env.test.example .env.test
           echo "APP_ENV=test" >> .env
           echo "APP_SECRET=test-secret-for-ci" >> .env
-          echo "DATABASE_URL=pgsql://gtd_test:gtd_test@127.0.0.1:5432/gtd?serverVersion=16&charset=utf8" >> .env
-          echo "DATABASE_URL=pgsql://gtd_test:gtd_test@127.0.0.1:5432/gtd?serverVersion=16&charset=utf8" >> .env.test
+          echo "DATABASE_URL=pgsql://gtd_test:gtd_test@127.0.0.1:5432/gtd_test?serverVersion=16&charset=utf8" >> .env
+          echo "DATABASE_URL=pgsql://gtd_test:gtd_test@127.0.0.1:5432/gtd_test?serverVersion=16&charset=utf8" >> .env.test
           echo "JWT_PASSPHRASE=test-jwt-passphrase-for-ci" >> .env
         working-directory: ./api
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
         ports:
           - 5432:5432
         options: --health-cmd="pg_isready -U gtd_test -d gtd_test" --health-interval=10s --health-timeout=5s --health-retries=5
+        # Note: Doctrine adds '_test' suffix in test env, so we use 'gtd' in DATABASE_URL
+        # which becomes 'gtd_test' after the suffix is applied
 
     steps:
       - uses: actions/checkout@v4
@@ -96,8 +98,9 @@ jobs:
           cp .env.test.example .env.test
           echo "APP_ENV=test" >> .env
           echo "APP_SECRET=test-secret-for-ci" >> .env
-          echo "DATABASE_URL=pgsql://gtd_test:gtd_test@127.0.0.1:5432/gtd_test?serverVersion=16&charset=utf8" >> .env
-          echo "DATABASE_URL=pgsql://gtd_test:gtd_test@127.0.0.1:5432/gtd_test?serverVersion=16&charset=utf8" >> .env.test
+          # Use 'gtd' as DB name - Doctrine adds '_test' suffix in test env -> 'gtd_test'
+          echo "DATABASE_URL=pgsql://gtd_test:gtd_test@127.0.0.1:5432/gtd?serverVersion=16&charset=utf8" >> .env
+          echo "DATABASE_URL=pgsql://gtd_test:gtd_test@127.0.0.1:5432/gtd?serverVersion=16&charset=utf8" >> .env.test
           echo "JWT_PASSPHRASE=test-jwt-passphrase-for-ci" >> .env
         working-directory: ./api
 

--- a/api/migrations/Version003CreateProjectsTable.php
+++ b/api/migrations/Version003CreateProjectsTable.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Migration: Create projects table (Stub for P2)
+ *
+ * Creates a minimal projects table to satisfy the Task->Project relation.
+ * Full project features will be implemented in P5: Project Management.
+ */
+final class Version003CreateProjectsTable extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create projects table (stub for Task relation)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Create projects table for PostgreSQL
+        $this->addSql('
+            CREATE TABLE projects (
+                id CHAR(36) NOT NULL,
+                user_id CHAR(36) NOT NULL,
+                name VARCHAR(255) NOT NULL,
+                created_at TIMESTAMP NOT NULL,
+                updated_at TIMESTAMP NOT NULL,
+                PRIMARY KEY(id)
+            )
+        ');
+
+        // Create indexes
+        $this->addSql('CREATE INDEX idx_project_user ON projects (user_id)');
+
+        // Add foreign key constraint to users table
+        $this->addSql('
+            ALTER TABLE projects
+            ADD CONSTRAINT fk_project_user
+            FOREIGN KEY (user_id) REFERENCES users(id)
+            ON DELETE CASCADE
+        ');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE projects');
+    }
+}

--- a/api/migrations/Version004CreateTasksTable.php
+++ b/api/migrations/Version004CreateTasksTable.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Migration: Create tasks table
+ *
+ * Creates the tasks table with GTD workflow statuses, energy levels,
+ * time estimates, due dates, and position for ordering.
+ */
+final class Version004CreateTasksTable extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create tasks table with GTD workflow support';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Create tasks table for PostgreSQL
+        $this->addSql('
+            CREATE TABLE tasks (
+                id CHAR(36) NOT NULL,
+                user_id CHAR(36) NOT NULL,
+                project_id CHAR(36) DEFAULT NULL,
+                title VARCHAR(500) NOT NULL,
+                notes TEXT DEFAULT NULL,
+                status VARCHAR(20) NOT NULL DEFAULT \'inbox\',
+                energy_level VARCHAR(10) DEFAULT NULL,
+                time_estimate INTEGER DEFAULT NULL,
+                due_date DATE DEFAULT NULL,
+                due_time TIME DEFAULT NULL,
+                position INTEGER NOT NULL DEFAULT 0,
+                version INTEGER NOT NULL DEFAULT 1,
+                created_at TIMESTAMP NOT NULL,
+                updated_at TIMESTAMP NOT NULL,
+                completed_at TIMESTAMP DEFAULT NULL,
+                deleted_at TIMESTAMP DEFAULT NULL,
+                PRIMARY KEY(id)
+            )
+        ');
+
+        // Create indexes for performance
+        $this->addSql('CREATE INDEX idx_task_user_status ON tasks (user_id, status)');
+        $this->addSql('CREATE INDEX idx_task_user_due ON tasks (user_id, due_date)');
+        $this->addSql('CREATE INDEX idx_task_project ON tasks (project_id)');
+        $this->addSql('CREATE INDEX idx_task_updated ON tasks (updated_at)');
+
+        // Add foreign key constraint to users table
+        $this->addSql('
+            ALTER TABLE tasks
+            ADD CONSTRAINT fk_task_user
+            FOREIGN KEY (user_id) REFERENCES users(id)
+            ON DELETE CASCADE
+        ');
+
+        // Add check constraint for status enum
+        $this->addSql('
+            ALTER TABLE tasks
+            ADD CONSTRAINT check_task_status
+            CHECK (status IN (
+                \'inbox\',
+                \'clarified\',
+                \'next_action\',
+                \'waiting_for\',
+                \'someday_maybe\',
+                \'reference\',
+                \'completed\',
+                \'deleted\'
+            ))
+        ');
+
+        // Add check constraint for energy_level enum
+        $this->addSql('
+            ALTER TABLE tasks
+            ADD CONSTRAINT check_task_energy_level
+            CHECK (energy_level IS NULL OR energy_level IN (
+                \'low\',
+                \'medium\',
+                \'high\'
+            ))
+        ');
+
+        // Add check constraint for positive time_estimate
+        $this->addSql('
+            ALTER TABLE tasks
+            ADD CONSTRAINT check_task_time_estimate
+            CHECK (time_estimate IS NULL OR time_estimate > 0)
+        ');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE tasks');
+    }
+}

--- a/api/migrations/Version004CreateTasksTable.php
+++ b/api/migrations/Version004CreateTasksTable.php
@@ -59,6 +59,14 @@ final class Version004CreateTasksTable extends AbstractMigration
             ON DELETE CASCADE
         ');
 
+        // Add foreign key constraint to projects table (optional relation)
+        $this->addSql('
+            ALTER TABLE tasks
+            ADD CONSTRAINT fk_task_project
+            FOREIGN KEY (project_id) REFERENCES projects(id)
+            ON DELETE SET NULL
+        ');
+
         // Add check constraint for status enum
         $this->addSql('
             ALTER TABLE tasks

--- a/api/phpunit.xml.dist
+++ b/api/phpunit.xml.dist
@@ -54,11 +54,9 @@
         <testsuite name="Unit Tests">
             <directory>tests/Unit</directory>
         </testsuite>
-        <!-- Functional tests disabled until framework.test config issue is resolved
         <testsuite name="Functional Tests">
             <directory>tests/Functional</directory>
         </testsuite>
-        -->
     </testsuites>
 
     <coverage processUncoveredFiles="true">

--- a/api/src/Controller/TaskController.php
+++ b/api/src/Controller/TaskController.php
@@ -15,6 +15,9 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 #[Route('/api/v1')]
 class TaskController extends AbstractController
 {
@@ -25,10 +28,6 @@ class TaskController extends AbstractController
         private readonly ValidatorInterface $validator,
     ) {
     }
-
-    // =========================================================================
-    // Capture Endpoints (FR-007)
-    // =========================================================================
 
     #[Route('/tasks', name: 'api_tasks_create', methods: ['POST'])]
     public function create(Request $request): JsonResponse
@@ -55,22 +54,8 @@ class TaskController extends AbstractController
         $maxPosition = $this->taskRepository->getMaxPositionByUserAndStatus($user, Task::STATUS_INBOX);
         $task->setPosition($maxPosition + 1);
 
-        $validationError = $this->validateAndReturnError($task);
-        if ($validationError !== null) {
-            return $validationError;
-        }
-
-        $this->taskRepository->save($task);
-
-        return $this->json([
-            'message' => 'Task created successfully',
-            'task' => $task->toArray(),
-        ], Response::HTTP_CREATED);
+        return $this->saveTaskWithValidation($task, 'Task created successfully', Response::HTTP_CREATED);
     }
-
-    // =========================================================================
-    // Inbox Endpoints (FR-008)
-    // =========================================================================
 
     #[Route('/tasks/inbox', name: 'api_tasks_inbox', methods: ['GET'])]
     public function inbox(): JsonResponse
@@ -81,13 +66,8 @@ class TaskController extends AbstractController
         }
 
         $tasks = $this->taskRepository->findInboxByUser($user);
-        $count = count($tasks);
 
-        return $this->json([
-            'tasks' => array_map(fn(Task $task) => $task->toArray(), $tasks),
-            'count' => $count,
-            'has_overflow' => $count > 100,
-        ]);
+        return $this->taskListResponse($tasks);
     }
 
     #[Route('/tasks/inbox/count', name: 'api_tasks_inbox_count', methods: ['GET'])]
@@ -105,10 +85,6 @@ class TaskController extends AbstractController
             'has_overflow' => $count > 100,
         ]);
     }
-
-    // =========================================================================
-    // Task CRUD Endpoints
-    // =========================================================================
 
     #[Route('/tasks/{id}', name: 'api_tasks_get', methods: ['GET'], requirements: ['id' => self::UUID_PATTERN])]
     public function get(string $id): JsonResponse
@@ -130,24 +106,14 @@ class TaskController extends AbstractController
         }
 
         $task = $result['task'];
-        $data = json_decode($request->getContent(), true);
+        $data = json_decode($request->getContent(), true) ?? [];
 
         $updateError = $this->applyTaskUpdates($task, $data);
         if ($updateError !== null) {
             return $updateError;
         }
 
-        $validationError = $this->validateAndReturnError($task);
-        if ($validationError !== null) {
-            return $validationError;
-        }
-
-        $this->taskRepository->save($task);
-
-        return $this->json([
-            'message' => 'Task updated successfully',
-            'task' => $task->toArray(),
-        ]);
+        return $this->saveTaskWithValidation($task, 'Task updated successfully');
     }
 
     #[Route('/tasks/{id}', name: 'api_tasks_delete', methods: ['DELETE'], requirements: ['id' => self::UUID_PATTERN])]
@@ -163,10 +129,6 @@ class TaskController extends AbstractController
 
         return $this->json(['message' => 'Task deleted successfully']);
     }
-
-    // =========================================================================
-    // Quick Actions
-    // =========================================================================
 
     #[Route('/tasks/{id}/complete', name: 'api_tasks_complete', methods: ['POST'], requirements: ['id' => self::UUID_PATTERN])]
     public function complete(string $id): JsonResponse
@@ -208,10 +170,6 @@ class TaskController extends AbstractController
         ]);
     }
 
-    // =========================================================================
-    // List Endpoints
-    // =========================================================================
-
     #[Route('/tasks', name: 'api_tasks_list', methods: ['GET'])]
     public function list(Request $request): JsonResponse
     {
@@ -234,10 +192,7 @@ class TaskController extends AbstractController
             ? $this->taskRepository->findByUserAndStatus($user, $status)
             : $this->taskRepository->findAllActiveByUser($user);
 
-        return $this->json([
-            'tasks' => array_map(fn(Task $task) => $task->toArray(), $tasks),
-            'count' => count($tasks),
-        ]);
+        return $this->taskListResponse($tasks);
     }
 
     #[Route('/tasks/stats', name: 'api_tasks_stats', methods: ['GET'])]
@@ -249,31 +204,23 @@ class TaskController extends AbstractController
         }
 
         $countsByStatus = $this->taskRepository->countByStatusForUser($user);
-        $overdueTasks = $this->taskRepository->findOverdueByUser($user);
-        $dueTodayTasks = $this->taskRepository->findDueTodayByUser($user);
 
         return $this->json([
             'by_status' => $countsByStatus,
-            'overdue_count' => count($overdueTasks),
-            'due_today_count' => count($dueTodayTasks),
+            'overdue_count' => count($this->taskRepository->findOverdueByUser($user)),
+            'due_today_count' => count($this->taskRepository->findDueTodayByUser($user)),
             'inbox_count' => $countsByStatus[Task::STATUS_INBOX] ?? 0,
             'next_actions_count' => $countsByStatus[Task::STATUS_NEXT_ACTION] ?? 0,
         ]);
     }
 
-    // =========================================================================
-    // Private Helper Methods
-    // =========================================================================
-
     private function getAuthenticatedUser(): User|JsonResponse
     {
         $user = $this->getUser();
 
-        if (!$user instanceof User) {
-            return $this->errorResponse('Not authenticated', 'NOT_AUTHENTICATED', Response::HTTP_UNAUTHORIZED);
-        }
-
-        return $user;
+        return $user instanceof User
+            ? $user
+            : $this->errorResponse('Not authenticated', 'NOT_AUTHENTICATED', Response::HTTP_UNAUTHORIZED);
     }
 
     /**
@@ -291,12 +238,11 @@ class TaskController extends AbstractController
         }
 
         $task = $this->taskRepository->findById(Uuid::fromString($id));
+        $isOwner = $task && $task->getUser()->getId()->toRfc4122() === $user->getId()->toRfc4122();
 
-        if (!$task || $task->getUser()->getId()->toRfc4122() !== $user->getId()->toRfc4122()) {
-            return $this->errorResponse('Task not found', 'NOT_FOUND', Response::HTTP_NOT_FOUND);
-        }
-
-        return ['user' => $user, 'task' => $task];
+        return $isOwner
+            ? ['user' => $user, 'task' => $task]
+            : $this->errorResponse('Task not found', 'NOT_FOUND', Response::HTTP_NOT_FOUND);
     }
 
     private function errorResponse(string $message, string $code, int $status): JsonResponse
@@ -304,176 +250,137 @@ class TaskController extends AbstractController
         return $this->json(['error' => $message, 'code' => $code], $status);
     }
 
-    private function validateAndReturnError(Task $task): ?JsonResponse
+    /**
+     * @param Task[] $tasks
+     */
+    private function taskListResponse(array $tasks): JsonResponse
+    {
+        $count = count($tasks);
+
+        return $this->json([
+            'tasks' => array_map(static fn(Task $task) => $task->toArray(), $tasks),
+            'count' => $count,
+            'has_overflow' => $count > 100,
+        ]);
+    }
+
+    private function saveTaskWithValidation(Task $task, string $message, int $status = Response::HTTP_OK): JsonResponse
     {
         $errors = $this->validator->validate($task);
 
-        if (count($errors) === 0) {
-            return null;
+        if (count($errors) > 0) {
+            $errorMessages = [];
+            foreach ($errors as $error) {
+                $errorMessages[$error->getPropertyPath()] = $error->getMessage();
+            }
+
+            return $this->json([
+                'error' => 'Validation failed',
+                'code' => 'VALIDATION_ERROR',
+                'details' => $errorMessages,
+            ], Response::HTTP_BAD_REQUEST);
         }
 
-        $errorMessages = [];
-        foreach ($errors as $error) {
-            $errorMessages[$error->getPropertyPath()] = $error->getMessage();
-        }
+        $this->taskRepository->save($task);
 
         return $this->json([
-            'error' => 'Validation failed',
-            'code' => 'VALIDATION_ERROR',
-            'details' => $errorMessages,
-        ], Response::HTTP_BAD_REQUEST);
+            'message' => $message,
+            'task' => $task->toArray(),
+        ], $status);
     }
 
-    private function applyTaskUpdates(Task $task, ?array $data): ?JsonResponse
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function applyTaskUpdates(Task $task, array $data): ?JsonResponse
     {
-        if ($data === null) {
-            return null;
-        }
-
-        if (isset($data['title'])) {
-            $error = $this->updateTitle($task, $data['title']);
-            if ($error !== null) {
-                return $error;
-            }
-        }
+        $fieldUpdaters = [
+            'title' => fn($v) => $this->validateAndSetTitle($task, $v),
+            'status' => fn($v) => $this->validateAndSetEnum($task, 'setStatus', $v, Task::STATUSES, 'status'),
+            'energy_level' => fn($v) => $this->validateAndSetEnum($task, 'setEnergyLevel', $v, Task::ENERGY_LEVELS, 'energy level'),
+            'time_estimate' => fn($v) => $this->validateAndSetTimeEstimate($task, $v),
+            'due_date' => fn($v) => $this->validateAndSetDateTime($task, 'setDueDate', $v, 'due date'),
+            'due_time' => fn($v) => $this->validateAndSetDateTime($task, 'setDueTime', $v, 'due time'),
+            'position' => fn($v) => $this->validateAndSetPosition($task, $v),
+        ];
 
         if (array_key_exists('notes', $data)) {
             $task->setNotes($data['notes']);
         }
 
-        if (isset($data['status'])) {
-            $error = $this->updateStatus($task, $data['status']);
-            if ($error !== null) {
-                return $error;
-            }
-        }
-
-        if (array_key_exists('energy_level', $data)) {
-            $error = $this->updateEnergyLevel($task, $data['energy_level']);
-            if ($error !== null) {
-                return $error;
-            }
-        }
-
-        if (array_key_exists('time_estimate', $data)) {
-            $error = $this->updateTimeEstimate($task, $data['time_estimate']);
-            if ($error !== null) {
-                return $error;
-            }
-        }
-
-        if (array_key_exists('due_date', $data)) {
-            $error = $this->updateDueDate($task, $data['due_date']);
-            if ($error !== null) {
-                return $error;
-            }
-        }
-
-        if (array_key_exists('due_time', $data)) {
-            $error = $this->updateDueTime($task, $data['due_time']);
-            if ($error !== null) {
-                return $error;
-            }
-        }
-
-        if (isset($data['position'])) {
-            $error = $this->updatePosition($task, $data['position']);
-            if ($error !== null) {
-                return $error;
+        foreach ($fieldUpdaters as $field => $updater) {
+            if (array_key_exists($field, $data)) {
+                $error = $updater($data[$field]);
+                if ($error !== null) {
+                    return $error;
+                }
             }
         }
 
         return null;
     }
 
-    private function updateTitle(Task $task, mixed $title): ?JsonResponse
+    private function validateAndSetTitle(Task $task, mixed $title): ?JsonResponse
     {
         if (!is_string($title) || trim($title) === '') {
             return $this->errorResponse('Title cannot be empty', 'INVALID_TITLE', Response::HTTP_BAD_REQUEST);
         }
         $task->setTitle(trim($title));
+
         return null;
     }
 
-    private function updateStatus(Task $task, mixed $status): ?JsonResponse
+    /**
+     * @param string[] $allowedValues
+     */
+    private function validateAndSetEnum(Task $task, string $setter, mixed $value, array $allowedValues, string $fieldName): ?JsonResponse
     {
-        if (!in_array($status, Task::STATUSES, true)) {
+        if ($value !== null && !in_array($value, $allowedValues, true)) {
             return $this->json([
-                'error' => 'Invalid status',
-                'code' => 'INVALID_STATUS',
-                'allowed_values' => Task::STATUSES,
+                'error' => "Invalid $fieldName",
+                'code' => 'INVALID_' . strtoupper(str_replace(' ', '_', $fieldName)),
+                'allowed_values' => $allowedValues,
             ], Response::HTTP_BAD_REQUEST);
         }
-        $task->setStatus($status);
+        $task->$setter($value);
+
         return null;
     }
 
-    private function updateEnergyLevel(Task $task, mixed $energyLevel): ?JsonResponse
+    private function validateAndSetTimeEstimate(Task $task, mixed $value): ?JsonResponse
     {
-        if ($energyLevel !== null && !in_array($energyLevel, Task::ENERGY_LEVELS, true)) {
-            return $this->json([
-                'error' => 'Invalid energy level',
-                'code' => 'INVALID_ENERGY_LEVEL',
-                'allowed_values' => Task::ENERGY_LEVELS,
-            ], Response::HTTP_BAD_REQUEST);
+        if ($value !== null && (!is_int($value) || $value <= 0)) {
+            return $this->errorResponse('Time estimate must be a positive integer', 'INVALID_TIME_ESTIMATE', Response::HTTP_BAD_REQUEST);
         }
-        $task->setEnergyLevel($energyLevel);
+        $task->setTimeEstimate($value);
+
         return null;
     }
 
-    private function updateTimeEstimate(Task $task, mixed $timeEstimate): ?JsonResponse
+    private function validateAndSetDateTime(Task $task, string $setter, mixed $value, string $fieldName): ?JsonResponse
     {
-        if ($timeEstimate !== null && (!is_int($timeEstimate) || $timeEstimate <= 0)) {
-            return $this->errorResponse(
-                'Time estimate must be a positive integer',
-                'INVALID_TIME_ESTIMATE',
-                Response::HTTP_BAD_REQUEST
-            );
-        }
-        $task->setTimeEstimate($timeEstimate);
-        return null;
-    }
+        if ($value === null) {
+            $task->$setter(null);
 
-    private function updateDueDate(Task $task, mixed $dueDate): ?JsonResponse
-    {
-        if ($dueDate === null) {
-            $task->setDueDate(null);
             return null;
         }
 
         try {
-            $task->setDueDate(new \DateTimeImmutable($dueDate));
+            $task->$setter(new \DateTimeImmutable($value));
+
             return null;
         } catch (\Exception) {
-            return $this->errorResponse('Invalid due date format', 'INVALID_DUE_DATE', Response::HTTP_BAD_REQUEST);
+            return $this->errorResponse("Invalid $fieldName format", 'INVALID_' . strtoupper(str_replace(' ', '_', $fieldName)), Response::HTTP_BAD_REQUEST);
         }
     }
 
-    private function updateDueTime(Task $task, mixed $dueTime): ?JsonResponse
+    private function validateAndSetPosition(Task $task, mixed $value): ?JsonResponse
     {
-        if ($dueTime === null) {
-            $task->setDueTime(null);
-            return null;
+        if (!is_int($value) || $value < 0) {
+            return $this->errorResponse('Position must be a non-negative integer', 'INVALID_POSITION', Response::HTTP_BAD_REQUEST);
         }
+        $task->setPosition($value);
 
-        try {
-            $task->setDueTime(new \DateTimeImmutable($dueTime));
-            return null;
-        } catch (\Exception) {
-            return $this->errorResponse('Invalid due time format', 'INVALID_DUE_TIME', Response::HTTP_BAD_REQUEST);
-        }
-    }
-
-    private function updatePosition(Task $task, mixed $position): ?JsonResponse
-    {
-        if (!is_int($position) || $position < 0) {
-            return $this->errorResponse(
-                'Position must be a non-negative integer',
-                'INVALID_POSITION',
-                Response::HTTP_BAD_REQUEST
-            );
-        }
-        $task->setPosition($position);
         return null;
     }
 }

--- a/api/src/Controller/TaskController.php
+++ b/api/src/Controller/TaskController.php
@@ -18,6 +18,8 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 #[Route('/api/v1')]
 class TaskController extends AbstractController
 {
+    private const UUID_PATTERN = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+
     public function __construct(
         private readonly TaskRepository $taskRepository,
         private readonly ValidatorInterface $validator,
@@ -28,57 +30,34 @@ class TaskController extends AbstractController
     // Capture Endpoints (FR-007)
     // =========================================================================
 
-    /**
-     * Create a new task (quick capture)
-     *
-     * POST /api/v1/tasks
-     */
     #[Route('/tasks', name: 'api_tasks_create', methods: ['POST'])]
     public function create(Request $request): JsonResponse
     {
-        $user = $this->getUser();
-
-        if (!$user instanceof User) {
-            return $this->json([
-                'error' => 'Not authenticated',
-                'code' => 'NOT_AUTHENTICATED',
-            ], Response::HTTP_UNAUTHORIZED);
+        $user = $this->getAuthenticatedUser();
+        if ($user instanceof JsonResponse) {
+            return $user;
         }
 
         $data = json_decode($request->getContent(), true);
 
         if (!isset($data['title']) || trim($data['title']) === '') {
-            return $this->json([
-                'error' => 'Title is required',
-                'code' => 'MISSING_TITLE',
-            ], Response::HTTP_BAD_REQUEST);
+            return $this->errorResponse('Title is required', 'MISSING_TITLE', Response::HTTP_BAD_REQUEST);
         }
 
         $task = new Task();
         $task->setUser($user);
         $task->setTitle(trim($data['title']));
 
-        // Optional fields
         if (isset($data['notes'])) {
             $task->setNotes($data['notes']);
         }
 
-        // Set position to end of inbox
         $maxPosition = $this->taskRepository->getMaxPositionByUserAndStatus($user, Task::STATUS_INBOX);
         $task->setPosition($maxPosition + 1);
 
-        // Validate entity
-        $errors = $this->validator->validate($task);
-        if (count($errors) > 0) {
-            $errorMessages = [];
-            foreach ($errors as $error) {
-                $errorMessages[$error->getPropertyPath()] = $error->getMessage();
-            }
-            return $this->json([
-                'error' => 'Validation failed',
-                'code' => 'VALIDATION_ERROR',
-                'details' => $errorMessages,
-            ], Response::HTTP_BAD_REQUEST);
+        $validationError = $this->validateAndReturnError($task);
+        if ($validationError !== null) {
+            return $validationError;
         }
 
         $this->taskRepository->save($task);
@@ -93,21 +72,12 @@ class TaskController extends AbstractController
     // Inbox Endpoints (FR-008)
     // =========================================================================
 
-    /**
-     * Get all inbox tasks for the current user
-     *
-     * GET /api/v1/tasks/inbox
-     */
     #[Route('/tasks/inbox', name: 'api_tasks_inbox', methods: ['GET'])]
     public function inbox(): JsonResponse
     {
-        $user = $this->getUser();
-
-        if (!$user instanceof User) {
-            return $this->json([
-                'error' => 'Not authenticated',
-                'code' => 'NOT_AUTHENTICATED',
-            ], Response::HTTP_UNAUTHORIZED);
+        $user = $this->getAuthenticatedUser();
+        if ($user instanceof JsonResponse) {
+            return $user;
         }
 
         $tasks = $this->taskRepository->findInboxByUser($user);
@@ -120,21 +90,12 @@ class TaskController extends AbstractController
         ]);
     }
 
-    /**
-     * Get inbox count for the current user
-     *
-     * GET /api/v1/tasks/inbox/count
-     */
     #[Route('/tasks/inbox/count', name: 'api_tasks_inbox_count', methods: ['GET'])]
     public function inboxCount(): JsonResponse
     {
-        $user = $this->getUser();
-
-        if (!$user instanceof User) {
-            return $this->json([
-                'error' => 'Not authenticated',
-                'code' => 'NOT_AUTHENTICATED',
-            ], Response::HTTP_UNAUTHORIZED);
+        $user = $this->getAuthenticatedUser();
+        if ($user instanceof JsonResponse) {
+            return $user;
         }
 
         $count = $this->taskRepository->countInboxByUser($user);
@@ -149,196 +110,36 @@ class TaskController extends AbstractController
     // Task CRUD Endpoints
     // =========================================================================
 
-    /**
-     * Get a single task by ID
-     *
-     * GET /api/v1/tasks/{id}
-     */
-    #[Route('/tasks/{id}', name: 'api_tasks_get', methods: ['GET'], requirements: ['id' => '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'])]
+    #[Route('/tasks/{id}', name: 'api_tasks_get', methods: ['GET'], requirements: ['id' => self::UUID_PATTERN])]
     public function get(string $id): JsonResponse
     {
-        $user = $this->getUser();
-
-        if (!$user instanceof User) {
-            return $this->json([
-                'error' => 'Not authenticated',
-                'code' => 'NOT_AUTHENTICATED',
-            ], Response::HTTP_UNAUTHORIZED);
+        $result = $this->getAuthenticatedUserAndTask($id);
+        if ($result instanceof JsonResponse) {
+            return $result;
         }
 
-        if (!Uuid::isValid($id)) {
-            return $this->json([
-                'error' => 'Invalid task ID',
-                'code' => 'INVALID_ID',
-            ], Response::HTTP_BAD_REQUEST);
-        }
-
-        $task = $this->taskRepository->findById(Uuid::fromString($id));
-
-        if (!$task) {
-            return $this->json([
-                'error' => 'Task not found',
-                'code' => 'NOT_FOUND',
-            ], Response::HTTP_NOT_FOUND);
-        }
-
-        // Ensure task belongs to current user
-        if ($task->getUser()->getId()->toRfc4122() !== $user->getId()->toRfc4122()) {
-            return $this->json([
-                'error' => 'Task not found',
-                'code' => 'NOT_FOUND',
-            ], Response::HTTP_NOT_FOUND);
-        }
-
-        return $this->json([
-            'task' => $task->toArray(),
-        ]);
+        return $this->json(['task' => $result['task']->toArray()]);
     }
 
-    /**
-     * Update a task
-     *
-     * PATCH /api/v1/tasks/{id}
-     */
-    #[Route('/tasks/{id}', name: 'api_tasks_update', methods: ['PATCH'], requirements: ['id' => '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'])]
+    #[Route('/tasks/{id}', name: 'api_tasks_update', methods: ['PATCH'], requirements: ['id' => self::UUID_PATTERN])]
     public function update(string $id, Request $request): JsonResponse
     {
-        $user = $this->getUser();
-
-        if (!$user instanceof User) {
-            return $this->json([
-                'error' => 'Not authenticated',
-                'code' => 'NOT_AUTHENTICATED',
-            ], Response::HTTP_UNAUTHORIZED);
+        $result = $this->getAuthenticatedUserAndTask($id);
+        if ($result instanceof JsonResponse) {
+            return $result;
         }
 
-        if (!Uuid::isValid($id)) {
-            return $this->json([
-                'error' => 'Invalid task ID',
-                'code' => 'INVALID_ID',
-            ], Response::HTTP_BAD_REQUEST);
-        }
-
-        $task = $this->taskRepository->findById(Uuid::fromString($id));
-
-        if (!$task) {
-            return $this->json([
-                'error' => 'Task not found',
-                'code' => 'NOT_FOUND',
-            ], Response::HTTP_NOT_FOUND);
-        }
-
-        // Ensure task belongs to current user
-        if ($task->getUser()->getId()->toRfc4122() !== $user->getId()->toRfc4122()) {
-            return $this->json([
-                'error' => 'Task not found',
-                'code' => 'NOT_FOUND',
-            ], Response::HTTP_NOT_FOUND);
-        }
-
+        $task = $result['task'];
         $data = json_decode($request->getContent(), true);
 
-        // Update allowed fields
-        if (isset($data['title'])) {
-            if (trim($data['title']) === '') {
-                return $this->json([
-                    'error' => 'Title cannot be empty',
-                    'code' => 'INVALID_TITLE',
-                ], Response::HTTP_BAD_REQUEST);
-            }
-            $task->setTitle(trim($data['title']));
+        $updateError = $this->applyTaskUpdates($task, $data);
+        if ($updateError !== null) {
+            return $updateError;
         }
 
-        if (array_key_exists('notes', $data)) {
-            $task->setNotes($data['notes']);
-        }
-
-        if (isset($data['status'])) {
-            if (!in_array($data['status'], Task::STATUSES, true)) {
-                return $this->json([
-                    'error' => 'Invalid status',
-                    'code' => 'INVALID_STATUS',
-                    'allowed_values' => Task::STATUSES,
-                ], Response::HTTP_BAD_REQUEST);
-            }
-            $task->setStatus($data['status']);
-        }
-
-        if (array_key_exists('energy_level', $data)) {
-            if ($data['energy_level'] !== null && !in_array($data['energy_level'], Task::ENERGY_LEVELS, true)) {
-                return $this->json([
-                    'error' => 'Invalid energy level',
-                    'code' => 'INVALID_ENERGY_LEVEL',
-                    'allowed_values' => Task::ENERGY_LEVELS,
-                ], Response::HTTP_BAD_REQUEST);
-            }
-            $task->setEnergyLevel($data['energy_level']);
-        }
-
-        if (array_key_exists('time_estimate', $data)) {
-            if ($data['time_estimate'] !== null && (!is_int($data['time_estimate']) || $data['time_estimate'] <= 0)) {
-                return $this->json([
-                    'error' => 'Time estimate must be a positive integer',
-                    'code' => 'INVALID_TIME_ESTIMATE',
-                ], Response::HTTP_BAD_REQUEST);
-            }
-            $task->setTimeEstimate($data['time_estimate']);
-        }
-
-        if (array_key_exists('due_date', $data)) {
-            if ($data['due_date'] !== null) {
-                try {
-                    $dueDate = new \DateTimeImmutable($data['due_date']);
-                    $task->setDueDate($dueDate);
-                } catch (\Exception $e) {
-                    return $this->json([
-                        'error' => 'Invalid due date format',
-                        'code' => 'INVALID_DUE_DATE',
-                    ], Response::HTTP_BAD_REQUEST);
-                }
-            } else {
-                $task->setDueDate(null);
-            }
-        }
-
-        if (array_key_exists('due_time', $data)) {
-            if ($data['due_time'] !== null) {
-                try {
-                    $dueTime = new \DateTimeImmutable($data['due_time']);
-                    $task->setDueTime($dueTime);
-                } catch (\Exception $e) {
-                    return $this->json([
-                        'error' => 'Invalid due time format',
-                        'code' => 'INVALID_DUE_TIME',
-                    ], Response::HTTP_BAD_REQUEST);
-                }
-            } else {
-                $task->setDueTime(null);
-            }
-        }
-
-        if (isset($data['position'])) {
-            if (!is_int($data['position']) || $data['position'] < 0) {
-                return $this->json([
-                    'error' => 'Position must be a non-negative integer',
-                    'code' => 'INVALID_POSITION',
-                ], Response::HTTP_BAD_REQUEST);
-            }
-            $task->setPosition($data['position']);
-        }
-
-        // Validate entity
-        $errors = $this->validator->validate($task);
-        if (count($errors) > 0) {
-            $errorMessages = [];
-            foreach ($errors as $error) {
-                $errorMessages[$error->getPropertyPath()] = $error->getMessage();
-            }
-            return $this->json([
-                'error' => 'Validation failed',
-                'code' => 'VALIDATION_ERROR',
-                'details' => $errorMessages,
-            ], Response::HTTP_BAD_REQUEST);
+        $validationError = $this->validateAndReturnError($task);
+        if ($validationError !== null) {
+            return $validationError;
         }
 
         $this->taskRepository->save($task);
@@ -349,156 +150,53 @@ class TaskController extends AbstractController
         ]);
     }
 
-    /**
-     * Delete a task (soft delete)
-     *
-     * DELETE /api/v1/tasks/{id}
-     */
-    #[Route('/tasks/{id}', name: 'api_tasks_delete', methods: ['DELETE'], requirements: ['id' => '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'])]
+    #[Route('/tasks/{id}', name: 'api_tasks_delete', methods: ['DELETE'], requirements: ['id' => self::UUID_PATTERN])]
     public function delete(string $id): JsonResponse
     {
-        $user = $this->getUser();
-
-        if (!$user instanceof User) {
-            return $this->json([
-                'error' => 'Not authenticated',
-                'code' => 'NOT_AUTHENTICATED',
-            ], Response::HTTP_UNAUTHORIZED);
+        $result = $this->getAuthenticatedUserAndTask($id);
+        if ($result instanceof JsonResponse) {
+            return $result;
         }
 
-        if (!Uuid::isValid($id)) {
-            return $this->json([
-                'error' => 'Invalid task ID',
-                'code' => 'INVALID_ID',
-            ], Response::HTTP_BAD_REQUEST);
-        }
+        $result['task']->markAsDeleted();
+        $this->taskRepository->save($result['task']);
 
-        $task = $this->taskRepository->findById(Uuid::fromString($id));
-
-        if (!$task) {
-            return $this->json([
-                'error' => 'Task not found',
-                'code' => 'NOT_FOUND',
-            ], Response::HTTP_NOT_FOUND);
-        }
-
-        // Ensure task belongs to current user
-        if ($task->getUser()->getId()->toRfc4122() !== $user->getId()->toRfc4122()) {
-            return $this->json([
-                'error' => 'Task not found',
-                'code' => 'NOT_FOUND',
-            ], Response::HTTP_NOT_FOUND);
-        }
-
-        // Soft delete
-        $task->markAsDeleted();
-        $this->taskRepository->save($task);
-
-        return $this->json([
-            'message' => 'Task deleted successfully',
-        ]);
+        return $this->json(['message' => 'Task deleted successfully']);
     }
 
     // =========================================================================
     // Quick Actions
     // =========================================================================
 
-    /**
-     * Mark a task as completed
-     *
-     * POST /api/v1/tasks/{id}/complete
-     */
-    #[Route('/tasks/{id}/complete', name: 'api_tasks_complete', methods: ['POST'], requirements: ['id' => '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'])]
+    #[Route('/tasks/{id}/complete', name: 'api_tasks_complete', methods: ['POST'], requirements: ['id' => self::UUID_PATTERN])]
     public function complete(string $id): JsonResponse
     {
-        $user = $this->getUser();
-
-        if (!$user instanceof User) {
-            return $this->json([
-                'error' => 'Not authenticated',
-                'code' => 'NOT_AUTHENTICATED',
-            ], Response::HTTP_UNAUTHORIZED);
+        $result = $this->getAuthenticatedUserAndTask($id);
+        if ($result instanceof JsonResponse) {
+            return $result;
         }
 
-        if (!Uuid::isValid($id)) {
-            return $this->json([
-                'error' => 'Invalid task ID',
-                'code' => 'INVALID_ID',
-            ], Response::HTTP_BAD_REQUEST);
-        }
-
-        $task = $this->taskRepository->findById(Uuid::fromString($id));
-
-        if (!$task) {
-            return $this->json([
-                'error' => 'Task not found',
-                'code' => 'NOT_FOUND',
-            ], Response::HTTP_NOT_FOUND);
-        }
-
-        // Ensure task belongs to current user
-        if ($task->getUser()->getId()->toRfc4122() !== $user->getId()->toRfc4122()) {
-            return $this->json([
-                'error' => 'Task not found',
-                'code' => 'NOT_FOUND',
-            ], Response::HTTP_NOT_FOUND);
-        }
-
-        $task->markAsCompleted();
-        $this->taskRepository->save($task);
+        $result['task']->markAsCompleted();
+        $this->taskRepository->save($result['task']);
 
         return $this->json([
             'message' => 'Task completed',
-            'task' => $task->toArray(),
+            'task' => $result['task']->toArray(),
         ]);
     }
 
-    /**
-     * Restore a deleted task
-     *
-     * POST /api/v1/tasks/{id}/restore
-     */
-    #[Route('/tasks/{id}/restore', name: 'api_tasks_restore', methods: ['POST'], requirements: ['id' => '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'])]
+    #[Route('/tasks/{id}/restore', name: 'api_tasks_restore', methods: ['POST'], requirements: ['id' => self::UUID_PATTERN])]
     public function restore(string $id): JsonResponse
     {
-        $user = $this->getUser();
-
-        if (!$user instanceof User) {
-            return $this->json([
-                'error' => 'Not authenticated',
-                'code' => 'NOT_AUTHENTICATED',
-            ], Response::HTTP_UNAUTHORIZED);
+        $result = $this->getAuthenticatedUserAndTask($id);
+        if ($result instanceof JsonResponse) {
+            return $result;
         }
 
-        if (!Uuid::isValid($id)) {
-            return $this->json([
-                'error' => 'Invalid task ID',
-                'code' => 'INVALID_ID',
-            ], Response::HTTP_BAD_REQUEST);
-        }
-
-        $task = $this->taskRepository->findById(Uuid::fromString($id));
-
-        if (!$task) {
-            return $this->json([
-                'error' => 'Task not found',
-                'code' => 'NOT_FOUND',
-            ], Response::HTTP_NOT_FOUND);
-        }
-
-        // Ensure task belongs to current user
-        if ($task->getUser()->getId()->toRfc4122() !== $user->getId()->toRfc4122()) {
-            return $this->json([
-                'error' => 'Task not found',
-                'code' => 'NOT_FOUND',
-            ], Response::HTTP_NOT_FOUND);
-        }
+        $task = $result['task'];
 
         if (!$task->isDeleted()) {
-            return $this->json([
-                'error' => 'Task is not deleted',
-                'code' => 'NOT_DELETED',
-            ], Response::HTTP_BAD_REQUEST);
+            return $this->errorResponse('Task is not deleted', 'NOT_DELETED', Response::HTTP_BAD_REQUEST);
         }
 
         $task->restore();
@@ -514,46 +212,27 @@ class TaskController extends AbstractController
     // List Endpoints
     // =========================================================================
 
-    /**
-     * Get all tasks for the current user (with optional filters)
-     *
-     * GET /api/v1/tasks
-     */
     #[Route('/tasks', name: 'api_tasks_list', methods: ['GET'])]
     public function list(Request $request): JsonResponse
     {
-        $user = $this->getUser();
-
-        if (!$user instanceof User) {
-            return $this->json([
-                'error' => 'Not authenticated',
-                'code' => 'NOT_AUTHENTICATED',
-            ], Response::HTTP_UNAUTHORIZED);
+        $user = $this->getAuthenticatedUser();
+        if ($user instanceof JsonResponse) {
+            return $user;
         }
 
         $status = $request->query->get('status');
 
-        if ($status !== null) {
-            if (!in_array($status, Task::STATUSES, true)) {
-                return $this->json([
-                    'error' => 'Invalid status filter',
-                    'code' => 'INVALID_STATUS',
-                    'allowed_values' => Task::STATUSES,
-                ], Response::HTTP_BAD_REQUEST);
-            }
-            $tasks = $this->taskRepository->findByUserAndStatus($user, $status);
-        } else {
-            // Return all non-deleted tasks by default
-            $tasks = $this->taskRepository->createQueryBuilder('t')
-                ->where('t.user = :user')
-                ->andWhere('t.status != :deleted')
-                ->setParameter('user', $user)
-                ->setParameter('deleted', Task::STATUS_DELETED)
-                ->orderBy('t.position', 'ASC')
-                ->addOrderBy('t.createdAt', 'DESC')
-                ->getQuery()
-                ->getResult();
+        if ($status !== null && !in_array($status, Task::STATUSES, true)) {
+            return $this->json([
+                'error' => 'Invalid status filter',
+                'code' => 'INVALID_STATUS',
+                'allowed_values' => Task::STATUSES,
+            ], Response::HTTP_BAD_REQUEST);
         }
+
+        $tasks = $status !== null
+            ? $this->taskRepository->findByUserAndStatus($user, $status)
+            : $this->taskRepository->findAllActiveByUser($user);
 
         return $this->json([
             'tasks' => array_map(fn(Task $task) => $task->toArray(), $tasks),
@@ -561,21 +240,12 @@ class TaskController extends AbstractController
         ]);
     }
 
-    /**
-     * Get task statistics for the current user
-     *
-     * GET /api/v1/tasks/stats
-     */
     #[Route('/tasks/stats', name: 'api_tasks_stats', methods: ['GET'])]
     public function stats(): JsonResponse
     {
-        $user = $this->getUser();
-
-        if (!$user instanceof User) {
-            return $this->json([
-                'error' => 'Not authenticated',
-                'code' => 'NOT_AUTHENTICATED',
-            ], Response::HTTP_UNAUTHORIZED);
+        $user = $this->getAuthenticatedUser();
+        if ($user instanceof JsonResponse) {
+            return $user;
         }
 
         $countsByStatus = $this->taskRepository->countByStatusForUser($user);
@@ -589,5 +259,221 @@ class TaskController extends AbstractController
             'inbox_count' => $countsByStatus[Task::STATUS_INBOX] ?? 0,
             'next_actions_count' => $countsByStatus[Task::STATUS_NEXT_ACTION] ?? 0,
         ]);
+    }
+
+    // =========================================================================
+    // Private Helper Methods
+    // =========================================================================
+
+    private function getAuthenticatedUser(): User|JsonResponse
+    {
+        $user = $this->getUser();
+
+        if (!$user instanceof User) {
+            return $this->errorResponse('Not authenticated', 'NOT_AUTHENTICATED', Response::HTTP_UNAUTHORIZED);
+        }
+
+        return $user;
+    }
+
+    /**
+     * @return array{user: User, task: Task}|JsonResponse
+     */
+    private function getAuthenticatedUserAndTask(string $id): array|JsonResponse
+    {
+        $user = $this->getAuthenticatedUser();
+        if ($user instanceof JsonResponse) {
+            return $user;
+        }
+
+        if (!Uuid::isValid($id)) {
+            return $this->errorResponse('Invalid task ID', 'INVALID_ID', Response::HTTP_BAD_REQUEST);
+        }
+
+        $task = $this->taskRepository->findById(Uuid::fromString($id));
+
+        if (!$task || $task->getUser()->getId()->toRfc4122() !== $user->getId()->toRfc4122()) {
+            return $this->errorResponse('Task not found', 'NOT_FOUND', Response::HTTP_NOT_FOUND);
+        }
+
+        return ['user' => $user, 'task' => $task];
+    }
+
+    private function errorResponse(string $message, string $code, int $status): JsonResponse
+    {
+        return $this->json(['error' => $message, 'code' => $code], $status);
+    }
+
+    private function validateAndReturnError(Task $task): ?JsonResponse
+    {
+        $errors = $this->validator->validate($task);
+
+        if (count($errors) === 0) {
+            return null;
+        }
+
+        $errorMessages = [];
+        foreach ($errors as $error) {
+            $errorMessages[$error->getPropertyPath()] = $error->getMessage();
+        }
+
+        return $this->json([
+            'error' => 'Validation failed',
+            'code' => 'VALIDATION_ERROR',
+            'details' => $errorMessages,
+        ], Response::HTTP_BAD_REQUEST);
+    }
+
+    private function applyTaskUpdates(Task $task, ?array $data): ?JsonResponse
+    {
+        if ($data === null) {
+            return null;
+        }
+
+        if (isset($data['title'])) {
+            $error = $this->updateTitle($task, $data['title']);
+            if ($error !== null) {
+                return $error;
+            }
+        }
+
+        if (array_key_exists('notes', $data)) {
+            $task->setNotes($data['notes']);
+        }
+
+        if (isset($data['status'])) {
+            $error = $this->updateStatus($task, $data['status']);
+            if ($error !== null) {
+                return $error;
+            }
+        }
+
+        if (array_key_exists('energy_level', $data)) {
+            $error = $this->updateEnergyLevel($task, $data['energy_level']);
+            if ($error !== null) {
+                return $error;
+            }
+        }
+
+        if (array_key_exists('time_estimate', $data)) {
+            $error = $this->updateTimeEstimate($task, $data['time_estimate']);
+            if ($error !== null) {
+                return $error;
+            }
+        }
+
+        if (array_key_exists('due_date', $data)) {
+            $error = $this->updateDueDate($task, $data['due_date']);
+            if ($error !== null) {
+                return $error;
+            }
+        }
+
+        if (array_key_exists('due_time', $data)) {
+            $error = $this->updateDueTime($task, $data['due_time']);
+            if ($error !== null) {
+                return $error;
+            }
+        }
+
+        if (isset($data['position'])) {
+            $error = $this->updatePosition($task, $data['position']);
+            if ($error !== null) {
+                return $error;
+            }
+        }
+
+        return null;
+    }
+
+    private function updateTitle(Task $task, mixed $title): ?JsonResponse
+    {
+        if (!is_string($title) || trim($title) === '') {
+            return $this->errorResponse('Title cannot be empty', 'INVALID_TITLE', Response::HTTP_BAD_REQUEST);
+        }
+        $task->setTitle(trim($title));
+        return null;
+    }
+
+    private function updateStatus(Task $task, mixed $status): ?JsonResponse
+    {
+        if (!in_array($status, Task::STATUSES, true)) {
+            return $this->json([
+                'error' => 'Invalid status',
+                'code' => 'INVALID_STATUS',
+                'allowed_values' => Task::STATUSES,
+            ], Response::HTTP_BAD_REQUEST);
+        }
+        $task->setStatus($status);
+        return null;
+    }
+
+    private function updateEnergyLevel(Task $task, mixed $energyLevel): ?JsonResponse
+    {
+        if ($energyLevel !== null && !in_array($energyLevel, Task::ENERGY_LEVELS, true)) {
+            return $this->json([
+                'error' => 'Invalid energy level',
+                'code' => 'INVALID_ENERGY_LEVEL',
+                'allowed_values' => Task::ENERGY_LEVELS,
+            ], Response::HTTP_BAD_REQUEST);
+        }
+        $task->setEnergyLevel($energyLevel);
+        return null;
+    }
+
+    private function updateTimeEstimate(Task $task, mixed $timeEstimate): ?JsonResponse
+    {
+        if ($timeEstimate !== null && (!is_int($timeEstimate) || $timeEstimate <= 0)) {
+            return $this->errorResponse(
+                'Time estimate must be a positive integer',
+                'INVALID_TIME_ESTIMATE',
+                Response::HTTP_BAD_REQUEST
+            );
+        }
+        $task->setTimeEstimate($timeEstimate);
+        return null;
+    }
+
+    private function updateDueDate(Task $task, mixed $dueDate): ?JsonResponse
+    {
+        if ($dueDate === null) {
+            $task->setDueDate(null);
+            return null;
+        }
+
+        try {
+            $task->setDueDate(new \DateTimeImmutable($dueDate));
+            return null;
+        } catch (\Exception) {
+            return $this->errorResponse('Invalid due date format', 'INVALID_DUE_DATE', Response::HTTP_BAD_REQUEST);
+        }
+    }
+
+    private function updateDueTime(Task $task, mixed $dueTime): ?JsonResponse
+    {
+        if ($dueTime === null) {
+            $task->setDueTime(null);
+            return null;
+        }
+
+        try {
+            $task->setDueTime(new \DateTimeImmutable($dueTime));
+            return null;
+        } catch (\Exception) {
+            return $this->errorResponse('Invalid due time format', 'INVALID_DUE_TIME', Response::HTTP_BAD_REQUEST);
+        }
+    }
+
+    private function updatePosition(Task $task, mixed $position): ?JsonResponse
+    {
+        if (!is_int($position) || $position < 0) {
+            return $this->errorResponse(
+                'Position must be a non-negative integer',
+                'INVALID_POSITION',
+                Response::HTTP_BAD_REQUEST
+            );
+        }
+        $task->setPosition($position);
+        return null;
     }
 }

--- a/api/src/Controller/TaskController.php
+++ b/api/src/Controller/TaskController.php
@@ -1,0 +1,593 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\Task;
+use App\Entity\User;
+use App\Repository\TaskRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[Route('/api/v1')]
+class TaskController extends AbstractController
+{
+    public function __construct(
+        private readonly TaskRepository $taskRepository,
+        private readonly ValidatorInterface $validator,
+    ) {
+    }
+
+    // =========================================================================
+    // Capture Endpoints (FR-007)
+    // =========================================================================
+
+    /**
+     * Create a new task (quick capture)
+     *
+     * POST /api/v1/tasks
+     */
+    #[Route('/tasks', name: 'api_tasks_create', methods: ['POST'])]
+    public function create(Request $request): JsonResponse
+    {
+        $user = $this->getUser();
+
+        if (!$user instanceof User) {
+            return $this->json([
+                'error' => 'Not authenticated',
+                'code' => 'NOT_AUTHENTICATED',
+            ], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $data = json_decode($request->getContent(), true);
+
+        if (!isset($data['title']) || trim($data['title']) === '') {
+            return $this->json([
+                'error' => 'Title is required',
+                'code' => 'MISSING_TITLE',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $task = new Task();
+        $task->setUser($user);
+        $task->setTitle(trim($data['title']));
+
+        // Optional fields
+        if (isset($data['notes'])) {
+            $task->setNotes($data['notes']);
+        }
+
+        // Set position to end of inbox
+        $maxPosition = $this->taskRepository->getMaxPositionByUserAndStatus($user, Task::STATUS_INBOX);
+        $task->setPosition($maxPosition + 1);
+
+        // Validate entity
+        $errors = $this->validator->validate($task);
+        if (count($errors) > 0) {
+            $errorMessages = [];
+            foreach ($errors as $error) {
+                $errorMessages[$error->getPropertyPath()] = $error->getMessage();
+            }
+            return $this->json([
+                'error' => 'Validation failed',
+                'code' => 'VALIDATION_ERROR',
+                'details' => $errorMessages,
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $this->taskRepository->save($task);
+
+        return $this->json([
+            'message' => 'Task created successfully',
+            'task' => $task->toArray(),
+        ], Response::HTTP_CREATED);
+    }
+
+    // =========================================================================
+    // Inbox Endpoints (FR-008)
+    // =========================================================================
+
+    /**
+     * Get all inbox tasks for the current user
+     *
+     * GET /api/v1/tasks/inbox
+     */
+    #[Route('/tasks/inbox', name: 'api_tasks_inbox', methods: ['GET'])]
+    public function inbox(): JsonResponse
+    {
+        $user = $this->getUser();
+
+        if (!$user instanceof User) {
+            return $this->json([
+                'error' => 'Not authenticated',
+                'code' => 'NOT_AUTHENTICATED',
+            ], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $tasks = $this->taskRepository->findInboxByUser($user);
+        $count = count($tasks);
+
+        return $this->json([
+            'tasks' => array_map(fn(Task $task) => $task->toArray(), $tasks),
+            'count' => $count,
+            'has_overflow' => $count > 100,
+        ]);
+    }
+
+    /**
+     * Get inbox count for the current user
+     *
+     * GET /api/v1/tasks/inbox/count
+     */
+    #[Route('/tasks/inbox/count', name: 'api_tasks_inbox_count', methods: ['GET'])]
+    public function inboxCount(): JsonResponse
+    {
+        $user = $this->getUser();
+
+        if (!$user instanceof User) {
+            return $this->json([
+                'error' => 'Not authenticated',
+                'code' => 'NOT_AUTHENTICATED',
+            ], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $count = $this->taskRepository->countInboxByUser($user);
+
+        return $this->json([
+            'count' => $count,
+            'has_overflow' => $count > 100,
+        ]);
+    }
+
+    // =========================================================================
+    // Task CRUD Endpoints
+    // =========================================================================
+
+    /**
+     * Get a single task by ID
+     *
+     * GET /api/v1/tasks/{id}
+     */
+    #[Route('/tasks/{id}', name: 'api_tasks_get', methods: ['GET'], requirements: ['id' => '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'])]
+    public function get(string $id): JsonResponse
+    {
+        $user = $this->getUser();
+
+        if (!$user instanceof User) {
+            return $this->json([
+                'error' => 'Not authenticated',
+                'code' => 'NOT_AUTHENTICATED',
+            ], Response::HTTP_UNAUTHORIZED);
+        }
+
+        if (!Uuid::isValid($id)) {
+            return $this->json([
+                'error' => 'Invalid task ID',
+                'code' => 'INVALID_ID',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $task = $this->taskRepository->findById(Uuid::fromString($id));
+
+        if (!$task) {
+            return $this->json([
+                'error' => 'Task not found',
+                'code' => 'NOT_FOUND',
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        // Ensure task belongs to current user
+        if ($task->getUser()->getId()->toRfc4122() !== $user->getId()->toRfc4122()) {
+            return $this->json([
+                'error' => 'Task not found',
+                'code' => 'NOT_FOUND',
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        return $this->json([
+            'task' => $task->toArray(),
+        ]);
+    }
+
+    /**
+     * Update a task
+     *
+     * PATCH /api/v1/tasks/{id}
+     */
+    #[Route('/tasks/{id}', name: 'api_tasks_update', methods: ['PATCH'], requirements: ['id' => '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'])]
+    public function update(string $id, Request $request): JsonResponse
+    {
+        $user = $this->getUser();
+
+        if (!$user instanceof User) {
+            return $this->json([
+                'error' => 'Not authenticated',
+                'code' => 'NOT_AUTHENTICATED',
+            ], Response::HTTP_UNAUTHORIZED);
+        }
+
+        if (!Uuid::isValid($id)) {
+            return $this->json([
+                'error' => 'Invalid task ID',
+                'code' => 'INVALID_ID',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $task = $this->taskRepository->findById(Uuid::fromString($id));
+
+        if (!$task) {
+            return $this->json([
+                'error' => 'Task not found',
+                'code' => 'NOT_FOUND',
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        // Ensure task belongs to current user
+        if ($task->getUser()->getId()->toRfc4122() !== $user->getId()->toRfc4122()) {
+            return $this->json([
+                'error' => 'Task not found',
+                'code' => 'NOT_FOUND',
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        $data = json_decode($request->getContent(), true);
+
+        // Update allowed fields
+        if (isset($data['title'])) {
+            if (trim($data['title']) === '') {
+                return $this->json([
+                    'error' => 'Title cannot be empty',
+                    'code' => 'INVALID_TITLE',
+                ], Response::HTTP_BAD_REQUEST);
+            }
+            $task->setTitle(trim($data['title']));
+        }
+
+        if (array_key_exists('notes', $data)) {
+            $task->setNotes($data['notes']);
+        }
+
+        if (isset($data['status'])) {
+            if (!in_array($data['status'], Task::STATUSES, true)) {
+                return $this->json([
+                    'error' => 'Invalid status',
+                    'code' => 'INVALID_STATUS',
+                    'allowed_values' => Task::STATUSES,
+                ], Response::HTTP_BAD_REQUEST);
+            }
+            $task->setStatus($data['status']);
+        }
+
+        if (array_key_exists('energy_level', $data)) {
+            if ($data['energy_level'] !== null && !in_array($data['energy_level'], Task::ENERGY_LEVELS, true)) {
+                return $this->json([
+                    'error' => 'Invalid energy level',
+                    'code' => 'INVALID_ENERGY_LEVEL',
+                    'allowed_values' => Task::ENERGY_LEVELS,
+                ], Response::HTTP_BAD_REQUEST);
+            }
+            $task->setEnergyLevel($data['energy_level']);
+        }
+
+        if (array_key_exists('time_estimate', $data)) {
+            if ($data['time_estimate'] !== null && (!is_int($data['time_estimate']) || $data['time_estimate'] <= 0)) {
+                return $this->json([
+                    'error' => 'Time estimate must be a positive integer',
+                    'code' => 'INVALID_TIME_ESTIMATE',
+                ], Response::HTTP_BAD_REQUEST);
+            }
+            $task->setTimeEstimate($data['time_estimate']);
+        }
+
+        if (array_key_exists('due_date', $data)) {
+            if ($data['due_date'] !== null) {
+                try {
+                    $dueDate = new \DateTimeImmutable($data['due_date']);
+                    $task->setDueDate($dueDate);
+                } catch (\Exception $e) {
+                    return $this->json([
+                        'error' => 'Invalid due date format',
+                        'code' => 'INVALID_DUE_DATE',
+                    ], Response::HTTP_BAD_REQUEST);
+                }
+            } else {
+                $task->setDueDate(null);
+            }
+        }
+
+        if (array_key_exists('due_time', $data)) {
+            if ($data['due_time'] !== null) {
+                try {
+                    $dueTime = new \DateTimeImmutable($data['due_time']);
+                    $task->setDueTime($dueTime);
+                } catch (\Exception $e) {
+                    return $this->json([
+                        'error' => 'Invalid due time format',
+                        'code' => 'INVALID_DUE_TIME',
+                    ], Response::HTTP_BAD_REQUEST);
+                }
+            } else {
+                $task->setDueTime(null);
+            }
+        }
+
+        if (isset($data['position'])) {
+            if (!is_int($data['position']) || $data['position'] < 0) {
+                return $this->json([
+                    'error' => 'Position must be a non-negative integer',
+                    'code' => 'INVALID_POSITION',
+                ], Response::HTTP_BAD_REQUEST);
+            }
+            $task->setPosition($data['position']);
+        }
+
+        // Validate entity
+        $errors = $this->validator->validate($task);
+        if (count($errors) > 0) {
+            $errorMessages = [];
+            foreach ($errors as $error) {
+                $errorMessages[$error->getPropertyPath()] = $error->getMessage();
+            }
+            return $this->json([
+                'error' => 'Validation failed',
+                'code' => 'VALIDATION_ERROR',
+                'details' => $errorMessages,
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $this->taskRepository->save($task);
+
+        return $this->json([
+            'message' => 'Task updated successfully',
+            'task' => $task->toArray(),
+        ]);
+    }
+
+    /**
+     * Delete a task (soft delete)
+     *
+     * DELETE /api/v1/tasks/{id}
+     */
+    #[Route('/tasks/{id}', name: 'api_tasks_delete', methods: ['DELETE'], requirements: ['id' => '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'])]
+    public function delete(string $id): JsonResponse
+    {
+        $user = $this->getUser();
+
+        if (!$user instanceof User) {
+            return $this->json([
+                'error' => 'Not authenticated',
+                'code' => 'NOT_AUTHENTICATED',
+            ], Response::HTTP_UNAUTHORIZED);
+        }
+
+        if (!Uuid::isValid($id)) {
+            return $this->json([
+                'error' => 'Invalid task ID',
+                'code' => 'INVALID_ID',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $task = $this->taskRepository->findById(Uuid::fromString($id));
+
+        if (!$task) {
+            return $this->json([
+                'error' => 'Task not found',
+                'code' => 'NOT_FOUND',
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        // Ensure task belongs to current user
+        if ($task->getUser()->getId()->toRfc4122() !== $user->getId()->toRfc4122()) {
+            return $this->json([
+                'error' => 'Task not found',
+                'code' => 'NOT_FOUND',
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        // Soft delete
+        $task->markAsDeleted();
+        $this->taskRepository->save($task);
+
+        return $this->json([
+            'message' => 'Task deleted successfully',
+        ]);
+    }
+
+    // =========================================================================
+    // Quick Actions
+    // =========================================================================
+
+    /**
+     * Mark a task as completed
+     *
+     * POST /api/v1/tasks/{id}/complete
+     */
+    #[Route('/tasks/{id}/complete', name: 'api_tasks_complete', methods: ['POST'], requirements: ['id' => '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'])]
+    public function complete(string $id): JsonResponse
+    {
+        $user = $this->getUser();
+
+        if (!$user instanceof User) {
+            return $this->json([
+                'error' => 'Not authenticated',
+                'code' => 'NOT_AUTHENTICATED',
+            ], Response::HTTP_UNAUTHORIZED);
+        }
+
+        if (!Uuid::isValid($id)) {
+            return $this->json([
+                'error' => 'Invalid task ID',
+                'code' => 'INVALID_ID',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $task = $this->taskRepository->findById(Uuid::fromString($id));
+
+        if (!$task) {
+            return $this->json([
+                'error' => 'Task not found',
+                'code' => 'NOT_FOUND',
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        // Ensure task belongs to current user
+        if ($task->getUser()->getId()->toRfc4122() !== $user->getId()->toRfc4122()) {
+            return $this->json([
+                'error' => 'Task not found',
+                'code' => 'NOT_FOUND',
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        $task->markAsCompleted();
+        $this->taskRepository->save($task);
+
+        return $this->json([
+            'message' => 'Task completed',
+            'task' => $task->toArray(),
+        ]);
+    }
+
+    /**
+     * Restore a deleted task
+     *
+     * POST /api/v1/tasks/{id}/restore
+     */
+    #[Route('/tasks/{id}/restore', name: 'api_tasks_restore', methods: ['POST'], requirements: ['id' => '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'])]
+    public function restore(string $id): JsonResponse
+    {
+        $user = $this->getUser();
+
+        if (!$user instanceof User) {
+            return $this->json([
+                'error' => 'Not authenticated',
+                'code' => 'NOT_AUTHENTICATED',
+            ], Response::HTTP_UNAUTHORIZED);
+        }
+
+        if (!Uuid::isValid($id)) {
+            return $this->json([
+                'error' => 'Invalid task ID',
+                'code' => 'INVALID_ID',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $task = $this->taskRepository->findById(Uuid::fromString($id));
+
+        if (!$task) {
+            return $this->json([
+                'error' => 'Task not found',
+                'code' => 'NOT_FOUND',
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        // Ensure task belongs to current user
+        if ($task->getUser()->getId()->toRfc4122() !== $user->getId()->toRfc4122()) {
+            return $this->json([
+                'error' => 'Task not found',
+                'code' => 'NOT_FOUND',
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        if (!$task->isDeleted()) {
+            return $this->json([
+                'error' => 'Task is not deleted',
+                'code' => 'NOT_DELETED',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $task->restore();
+        $this->taskRepository->save($task);
+
+        return $this->json([
+            'message' => 'Task restored',
+            'task' => $task->toArray(),
+        ]);
+    }
+
+    // =========================================================================
+    // List Endpoints
+    // =========================================================================
+
+    /**
+     * Get all tasks for the current user (with optional filters)
+     *
+     * GET /api/v1/tasks
+     */
+    #[Route('/tasks', name: 'api_tasks_list', methods: ['GET'])]
+    public function list(Request $request): JsonResponse
+    {
+        $user = $this->getUser();
+
+        if (!$user instanceof User) {
+            return $this->json([
+                'error' => 'Not authenticated',
+                'code' => 'NOT_AUTHENTICATED',
+            ], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $status = $request->query->get('status');
+
+        if ($status !== null) {
+            if (!in_array($status, Task::STATUSES, true)) {
+                return $this->json([
+                    'error' => 'Invalid status filter',
+                    'code' => 'INVALID_STATUS',
+                    'allowed_values' => Task::STATUSES,
+                ], Response::HTTP_BAD_REQUEST);
+            }
+            $tasks = $this->taskRepository->findByUserAndStatus($user, $status);
+        } else {
+            // Return all non-deleted tasks by default
+            $tasks = $this->taskRepository->createQueryBuilder('t')
+                ->where('t.user = :user')
+                ->andWhere('t.status != :deleted')
+                ->setParameter('user', $user)
+                ->setParameter('deleted', Task::STATUS_DELETED)
+                ->orderBy('t.position', 'ASC')
+                ->addOrderBy('t.createdAt', 'DESC')
+                ->getQuery()
+                ->getResult();
+        }
+
+        return $this->json([
+            'tasks' => array_map(fn(Task $task) => $task->toArray(), $tasks),
+            'count' => count($tasks),
+        ]);
+    }
+
+    /**
+     * Get task statistics for the current user
+     *
+     * GET /api/v1/tasks/stats
+     */
+    #[Route('/tasks/stats', name: 'api_tasks_stats', methods: ['GET'])]
+    public function stats(): JsonResponse
+    {
+        $user = $this->getUser();
+
+        if (!$user instanceof User) {
+            return $this->json([
+                'error' => 'Not authenticated',
+                'code' => 'NOT_AUTHENTICATED',
+            ], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $countsByStatus = $this->taskRepository->countByStatusForUser($user);
+        $overdueTasks = $this->taskRepository->findOverdueByUser($user);
+        $dueTodayTasks = $this->taskRepository->findDueTodayByUser($user);
+
+        return $this->json([
+            'by_status' => $countsByStatus,
+            'overdue_count' => count($overdueTasks),
+            'due_today_count' => count($dueTodayTasks),
+            'inbox_count' => $countsByStatus[Task::STATUS_INBOX] ?? 0,
+            'next_actions_count' => $countsByStatus[Task::STATUS_NEXT_ACTION] ?? 0,
+        ]);
+    }
+}

--- a/api/src/Entity/Project.php
+++ b/api/src/Entity/Project.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Project Entity (Stub for P2 - will be completed in P5)
+ *
+ * This is a minimal stub to satisfy the Task->Project relation.
+ * Full implementation will be done in P5: Project Management.
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'projects')]
+#[ORM\HasLifecycleCallbacks]
+class Project
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid_string', unique: true)]
+    private Uuid $id;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private User $user;
+
+    #[ORM\Column(type: Types::STRING, length: 255)]
+    #[Assert\NotBlank(message: 'Project name is required')]
+    #[Assert\Length(max: 255, maxMessage: 'Project name cannot exceed {{ limit }} characters')]
+    private string $name;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct()
+    {
+        $this->id = Uuid::v4();
+        $this->createdAt = new \DateTimeImmutable();
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function setUser(User $user): self
+    {
+        $this->user = $user;
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    #[ORM\PreUpdate]
+    public function onPreUpdate(): void
+    {
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+}

--- a/api/src/Entity/Task.php
+++ b/api/src/Entity/Task.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
 
-#[ORM\Entity(repositoryClass: 'App\Repository\TaskRepository')]
+#[ORM\Entity(repositoryClass: \App\Repository\TaskRepository::class)]
 #[ORM\Table(name: 'tasks')]
 #[ORM\Index(name: 'idx_task_user_status', columns: ['user_id', 'status'])]
 #[ORM\Index(name: 'idx_task_user_due', columns: ['user_id', 'due_date'])]

--- a/api/src/Entity/Task.php
+++ b/api/src/Entity/Task.php
@@ -1,0 +1,405 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ORM\Entity(repositoryClass: 'App\Repository\TaskRepository')]
+#[ORM\Table(name: 'tasks')]
+#[ORM\Index(name: 'idx_task_user_status', columns: ['user_id', 'status'])]
+#[ORM\Index(name: 'idx_task_user_due', columns: ['user_id', 'due_date'])]
+#[ORM\Index(name: 'idx_task_project', columns: ['project_id'])]
+#[ORM\Index(name: 'idx_task_updated', columns: ['updated_at'])]
+#[ORM\HasLifecycleCallbacks]
+class Task
+{
+    // GTD Workflow Statuses
+    public const STATUS_INBOX = 'inbox';
+    public const STATUS_CLARIFIED = 'clarified';
+    public const STATUS_NEXT_ACTION = 'next_action';
+    public const STATUS_WAITING_FOR = 'waiting_for';
+    public const STATUS_SOMEDAY_MAYBE = 'someday_maybe';
+    public const STATUS_REFERENCE = 'reference';
+    public const STATUS_COMPLETED = 'completed';
+    public const STATUS_DELETED = 'deleted';
+
+    public const STATUSES = [
+        self::STATUS_INBOX,
+        self::STATUS_CLARIFIED,
+        self::STATUS_NEXT_ACTION,
+        self::STATUS_WAITING_FOR,
+        self::STATUS_SOMEDAY_MAYBE,
+        self::STATUS_REFERENCE,
+        self::STATUS_COMPLETED,
+        self::STATUS_DELETED,
+    ];
+
+    // Energy Levels
+    public const ENERGY_LOW = 'low';
+    public const ENERGY_MEDIUM = 'medium';
+    public const ENERGY_HIGH = 'high';
+
+    public const ENERGY_LEVELS = [
+        self::ENERGY_LOW,
+        self::ENERGY_MEDIUM,
+        self::ENERGY_HIGH,
+    ];
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid_string', unique: true)]
+    private Uuid $id;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private User $user;
+
+    #[ORM\ManyToOne(targetEntity: 'App\Entity\Project')]
+    #[ORM\JoinColumn(name: 'project_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?object $project = null;
+
+    #[ORM\Column(type: Types::STRING, length: 500)]
+    #[Assert\NotBlank(message: 'Task title is required')]
+    #[Assert\Length(max: 500, maxMessage: 'Task title cannot exceed {{ limit }} characters')]
+    private string $title;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $notes = null;
+
+    #[ORM\Column(type: Types::STRING, length: 20)]
+    #[Assert\Choice(choices: self::STATUSES, message: 'Invalid task status')]
+    private string $status = self::STATUS_INBOX;
+
+    #[ORM\Column(type: Types::STRING, length: 10, nullable: true)]
+    #[Assert\Choice(choices: self::ENERGY_LEVELS, message: 'Invalid energy level')]
+    private ?string $energyLevel = null;
+
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    #[Assert\Positive(message: 'Time estimate must be positive')]
+    private ?int $timeEstimate = null;
+
+    #[ORM\Column(type: Types::DATE_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $dueDate = null;
+
+    #[ORM\Column(type: Types::TIME_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $dueTime = null;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    private int $position = 0;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    #[ORM\Version]
+    private int $version = 1;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $updatedAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $completedAt = null;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $deletedAt = null;
+
+    public function __construct()
+    {
+        $this->id = Uuid::v4();
+        $this->createdAt = new \DateTimeImmutable();
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    #[ORM\PreUpdate]
+    public function onPreUpdate(): void
+    {
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    // =========================================================================
+    // Getters and Setters
+    // =========================================================================
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function setUser(User $user): self
+    {
+        $this->user = $user;
+        return $this;
+    }
+
+    public function getProject(): ?object
+    {
+        return $this->project;
+    }
+
+    public function setProject(?object $project): self
+    {
+        $this->project = $project;
+        return $this;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): self
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+    public function getNotes(): ?string
+    {
+        return $this->notes;
+    }
+
+    public function setNotes(?string $notes): self
+    {
+        $this->notes = $notes;
+        return $this;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): self
+    {
+        $this->status = $status;
+
+        // Auto-set completedAt when status changes to completed
+        if ($status === self::STATUS_COMPLETED && $this->completedAt === null) {
+            $this->completedAt = new \DateTimeImmutable();
+        }
+
+        // Auto-set deletedAt when status changes to deleted
+        if ($status === self::STATUS_DELETED && $this->deletedAt === null) {
+            $this->deletedAt = new \DateTimeImmutable();
+        }
+
+        return $this;
+    }
+
+    public function getEnergyLevel(): ?string
+    {
+        return $this->energyLevel;
+    }
+
+    public function setEnergyLevel(?string $energyLevel): self
+    {
+        $this->energyLevel = $energyLevel;
+        return $this;
+    }
+
+    public function getTimeEstimate(): ?int
+    {
+        return $this->timeEstimate;
+    }
+
+    public function setTimeEstimate(?int $timeEstimate): self
+    {
+        $this->timeEstimate = $timeEstimate;
+        return $this;
+    }
+
+    public function getDueDate(): ?\DateTimeImmutable
+    {
+        return $this->dueDate;
+    }
+
+    public function setDueDate(?\DateTimeImmutable $dueDate): self
+    {
+        $this->dueDate = $dueDate;
+        return $this;
+    }
+
+    public function getDueTime(): ?\DateTimeImmutable
+    {
+        return $this->dueTime;
+    }
+
+    public function setDueTime(?\DateTimeImmutable $dueTime): self
+    {
+        $this->dueTime = $dueTime;
+        return $this;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(int $position): self
+    {
+        $this->position = $position;
+        return $this;
+    }
+
+    public function getVersion(): int
+    {
+        return $this->version;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function getCompletedAt(): ?\DateTimeImmutable
+    {
+        return $this->completedAt;
+    }
+
+    public function setCompletedAt(?\DateTimeImmutable $completedAt): self
+    {
+        $this->completedAt = $completedAt;
+        return $this;
+    }
+
+    public function getDeletedAt(): ?\DateTimeImmutable
+    {
+        return $this->deletedAt;
+    }
+
+    public function setDeletedAt(?\DateTimeImmutable $deletedAt): self
+    {
+        $this->deletedAt = $deletedAt;
+        return $this;
+    }
+
+    // =========================================================================
+    // Status Helper Methods
+    // =========================================================================
+
+    public function isInbox(): bool
+    {
+        return $this->status === self::STATUS_INBOX;
+    }
+
+    public function isCompleted(): bool
+    {
+        return $this->status === self::STATUS_COMPLETED;
+    }
+
+    public function isDeleted(): bool
+    {
+        return $this->status === self::STATUS_DELETED;
+    }
+
+    public function isActionable(): bool
+    {
+        return in_array($this->status, [
+            self::STATUS_NEXT_ACTION,
+            self::STATUS_WAITING_FOR,
+        ], true);
+    }
+
+    public function markAsCompleted(): self
+    {
+        $this->status = self::STATUS_COMPLETED;
+        $this->completedAt = new \DateTimeImmutable();
+        return $this;
+    }
+
+    public function markAsDeleted(): self
+    {
+        $this->status = self::STATUS_DELETED;
+        $this->deletedAt = new \DateTimeImmutable();
+        return $this;
+    }
+
+    public function restore(): self
+    {
+        if ($this->status === self::STATUS_DELETED) {
+            $this->status = self::STATUS_INBOX;
+            $this->deletedAt = null;
+        }
+        return $this;
+    }
+
+    // =========================================================================
+    // Due Date Helper Methods
+    // =========================================================================
+
+    public function isOverdue(): bool
+    {
+        if ($this->dueDate === null) {
+            return false;
+        }
+
+        if ($this->isCompleted() || $this->isDeleted()) {
+            return false;
+        }
+
+        $today = new \DateTimeImmutable('today');
+        return $this->dueDate < $today;
+    }
+
+    public function isDueToday(): bool
+    {
+        if ($this->dueDate === null) {
+            return false;
+        }
+
+        $today = new \DateTimeImmutable('today');
+        return $this->dueDate->format('Y-m-d') === $today->format('Y-m-d');
+    }
+
+    public function isDueSoon(int $days = 7): bool
+    {
+        if ($this->dueDate === null) {
+            return false;
+        }
+
+        $today = new \DateTimeImmutable('today');
+        $threshold = $today->modify("+{$days} days");
+
+        return $this->dueDate >= $today && $this->dueDate <= $threshold;
+    }
+
+    // =========================================================================
+    // Serialization
+    // =========================================================================
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id->toRfc4122(),
+            'title' => $this->title,
+            'notes' => $this->notes,
+            'status' => $this->status,
+            'energy_level' => $this->energyLevel,
+            'time_estimate' => $this->timeEstimate,
+            'due_date' => $this->dueDate?->format('Y-m-d'),
+            'due_time' => $this->dueTime?->format('H:i:s'),
+            'position' => $this->position,
+            'version' => $this->version,
+            'project_id' => $this->project?->getId()?->toRfc4122(),
+            'created_at' => $this->createdAt->format(\DateTimeInterface::ATOM),
+            'updated_at' => $this->updatedAt->format(\DateTimeInterface::ATOM),
+            'completed_at' => $this->completedAt?->format(\DateTimeInterface::ATOM),
+            'is_overdue' => $this->isOverdue(),
+            'is_due_today' => $this->isDueToday(),
+        ];
+    }
+}

--- a/api/src/Repository/TaskRepository.php
+++ b/api/src/Repository/TaskRepository.php
@@ -17,6 +17,7 @@ use Symfony\Component\Uid\Uuid;
 class TaskRepository extends ServiceEntityRepository
 {
     private const EXCLUDED_STATUSES = [Task::STATUS_COMPLETED, Task::STATUS_DELETED];
+    private const STATUS_FILTER = 't.status = :status';
 
     public function __construct(ManagerRegistry $registry)
     {
@@ -46,13 +47,7 @@ class TaskRepository extends ServiceEntityRepository
         return $this->find($id);
     }
 
-    // =========================================================================
-    // Core Query Methods
-    // =========================================================================
-
     /**
-     * Find all inbox tasks for a user
-     *
      * @return Task[]
      */
     public function findInboxByUser(User $user): array
@@ -60,29 +55,20 @@ class TaskRepository extends ServiceEntityRepository
         return $this->findByUserAndStatus($user, Task::STATUS_INBOX);
     }
 
-    /**
-     * Count inbox tasks for a user
-     */
     public function countInboxByUser(User $user): int
     {
-        return (int) $this->createUserQueryBuilder($user)
+        return (int) $this->createUserStatusQueryBuilder($user, Task::STATUS_INBOX)
             ->select('COUNT(t.id)')
-            ->andWhere('t.status = :status')
-            ->setParameter('status', Task::STATUS_INBOX)
             ->getQuery()
             ->getSingleScalarResult();
     }
 
     /**
-     * Find tasks by user and status
-     *
      * @return Task[]
      */
     public function findByUserAndStatus(User $user, string $status): array
     {
-        return $this->createUserQueryBuilder($user)
-            ->andWhere('t.status = :status')
-            ->setParameter('status', $status)
+        return $this->createUserStatusQueryBuilder($user, $status)
             ->orderBy('t.position', 'ASC')
             ->addOrderBy('t.createdAt', 'DESC')
             ->getQuery()
@@ -90,8 +76,6 @@ class TaskRepository extends ServiceEntityRepository
     }
 
     /**
-     * Find all non-deleted tasks for a user
-     *
      * @return Task[]
      */
     public function findAllActiveByUser(User $user): array
@@ -106,15 +90,11 @@ class TaskRepository extends ServiceEntityRepository
     }
 
     /**
-     * Find all completed tasks for a user
-     *
      * @return Task[]
      */
     public function findCompletedByUser(User $user, ?int $limit = null): array
     {
-        $qb = $this->createUserQueryBuilder($user)
-            ->andWhere('t.status = :status')
-            ->setParameter('status', Task::STATUS_COMPLETED)
+        $qb = $this->createUserStatusQueryBuilder($user, Task::STATUS_COMPLETED)
             ->orderBy('t.completedAt', 'DESC');
 
         if ($limit !== null) {
@@ -124,13 +104,7 @@ class TaskRepository extends ServiceEntityRepository
         return $qb->getQuery()->getResult();
     }
 
-    // =========================================================================
-    // Due Date Queries
-    // =========================================================================
-
     /**
-     * Find overdue tasks for a user (excludes completed/deleted)
-     *
      * @return Task[]
      */
     public function findOverdueByUser(User $user): array
@@ -144,8 +118,6 @@ class TaskRepository extends ServiceEntityRepository
     }
 
     /**
-     * Find tasks due today for a user (excludes completed/deleted)
-     *
      * @return Task[]
      */
     public function findDueTodayByUser(User $user): array
@@ -160,8 +132,6 @@ class TaskRepository extends ServiceEntityRepository
     }
 
     /**
-     * Find tasks due within a date range for a user
-     *
      * @return Task[]
      */
     public function findDueInRangeByUser(
@@ -180,13 +150,7 @@ class TaskRepository extends ServiceEntityRepository
             ->getResult();
     }
 
-    // =========================================================================
-    // Project Queries
-    // =========================================================================
-
     /**
-     * Find tasks by project (excludes deleted)
-     *
      * @return Task[]
      */
     public function findByProject(object $project): array
@@ -201,14 +165,11 @@ class TaskRepository extends ServiceEntityRepository
             ->getResult();
     }
 
-    /**
-     * Find next action for a project
-     */
     public function findNextActionByProject(object $project): ?Task
     {
         return $this->createQueryBuilder('t')
             ->where('t.project = :project')
-            ->andWhere('t.status = :status')
+            ->andWhere(self::STATUS_FILTER)
             ->setParameter('project', $project)
             ->setParameter('status', Task::STATUS_NEXT_ACTION)
             ->orderBy('t.position', 'ASC')
@@ -217,13 +178,7 @@ class TaskRepository extends ServiceEntityRepository
             ->getOneOrNullResult();
     }
 
-    // =========================================================================
-    // Sync & Statistics
-    // =========================================================================
-
     /**
-     * Find tasks modified since a given date for sync
-     *
      * @return Task[]
      */
     public function findModifiedSince(User $user, \DateTimeImmutable $since): array
@@ -237,8 +192,6 @@ class TaskRepository extends ServiceEntityRepository
     }
 
     /**
-     * Count tasks by status for a user
-     *
      * @return array<string, int>
      */
     public function countByStatusForUser(User $user): array
@@ -257,50 +210,43 @@ class TaskRepository extends ServiceEntityRepository
         return $counts;
     }
 
-    /**
-     * Count completed tasks in a date range for a user
-     */
     public function countCompletedInRange(
         User $user,
         \DateTimeImmutable $startDate,
         \DateTimeImmutable $endDate
     ): int {
-        return (int) $this->createUserQueryBuilder($user)
+        return (int) $this->createUserStatusQueryBuilder($user, Task::STATUS_COMPLETED)
             ->select('COUNT(t.id)')
-            ->andWhere('t.status = :status')
             ->andWhere('t.completedAt >= :startDate')
             ->andWhere('t.completedAt <= :endDate')
-            ->setParameter('status', Task::STATUS_COMPLETED)
             ->setParameter('startDate', $startDate)
             ->setParameter('endDate', $endDate)
             ->getQuery()
             ->getSingleScalarResult();
     }
 
-    /**
-     * Get the maximum position for a user's tasks in a given status
-     */
     public function getMaxPositionByUserAndStatus(User $user, string $status): int
     {
-        $result = $this->createUserQueryBuilder($user)
+        $result = $this->createUserStatusQueryBuilder($user, $status)
             ->select('MAX(t.position)')
-            ->andWhere('t.status = :status')
-            ->setParameter('status', $status)
             ->getQuery()
             ->getSingleScalarResult();
 
         return $result !== null ? (int) $result : 0;
     }
 
-    // =========================================================================
-    // Private Query Builder Helpers
-    // =========================================================================
-
     private function createUserQueryBuilder(User $user): QueryBuilder
     {
         return $this->createQueryBuilder('t')
             ->where('t.user = :user')
             ->setParameter('user', $user);
+    }
+
+    private function createUserStatusQueryBuilder(User $user, string $status): QueryBuilder
+    {
+        return $this->createUserQueryBuilder($user)
+            ->andWhere(self::STATUS_FILTER)
+            ->setParameter('status', $status);
     }
 
     private function createActiveTasksQueryBuilder(User $user): QueryBuilder

--- a/api/src/Repository/TaskRepository.php
+++ b/api/src/Repository/TaskRepository.php
@@ -7,6 +7,7 @@ namespace App\Repository;
 use App\Entity\Task;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Uid\Uuid;
 
@@ -15,6 +16,8 @@ use Symfony\Component\Uid\Uuid;
  */
 class TaskRepository extends ServiceEntityRepository
 {
+    private const EXCLUDED_STATUSES = [Task::STATUS_COMPLETED, Task::STATUS_DELETED];
+
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Task::class);
@@ -44,25 +47,17 @@ class TaskRepository extends ServiceEntityRepository
     }
 
     // =========================================================================
-    // Inbox Queries (FR-007)
+    // Core Query Methods
     // =========================================================================
 
     /**
-     * Find all inbox tasks for a user, ordered by position then creation date
+     * Find all inbox tasks for a user
      *
      * @return Task[]
      */
     public function findInboxByUser(User $user): array
     {
-        return $this->createQueryBuilder('t')
-            ->where('t.user = :user')
-            ->andWhere('t.status = :status')
-            ->setParameter('user', $user)
-            ->setParameter('status', Task::STATUS_INBOX)
-            ->orderBy('t.position', 'ASC')
-            ->addOrderBy('t.createdAt', 'DESC')
-            ->getQuery()
-            ->getResult();
+        return $this->findByUserAndStatus($user, Task::STATUS_INBOX);
     }
 
     /**
@@ -70,19 +65,13 @@ class TaskRepository extends ServiceEntityRepository
      */
     public function countInboxByUser(User $user): int
     {
-        return (int) $this->createQueryBuilder('t')
+        return (int) $this->createUserQueryBuilder($user)
             ->select('COUNT(t.id)')
-            ->where('t.user = :user')
             ->andWhere('t.status = :status')
-            ->setParameter('user', $user)
             ->setParameter('status', Task::STATUS_INBOX)
             ->getQuery()
             ->getSingleScalarResult();
     }
-
-    // =========================================================================
-    // Status-based Queries
-    // =========================================================================
 
     /**
      * Find tasks by user and status
@@ -91,10 +80,8 @@ class TaskRepository extends ServiceEntityRepository
      */
     public function findByUserAndStatus(User $user, string $status): array
     {
-        return $this->createQueryBuilder('t')
-            ->where('t.user = :user')
+        return $this->createUserQueryBuilder($user)
             ->andWhere('t.status = :status')
-            ->setParameter('user', $user)
             ->setParameter('status', $status)
             ->orderBy('t.position', 'ASC')
             ->addOrderBy('t.createdAt', 'DESC')
@@ -103,43 +90,19 @@ class TaskRepository extends ServiceEntityRepository
     }
 
     /**
-     * Find all next actions for a user
+     * Find all non-deleted tasks for a user
      *
      * @return Task[]
      */
-    public function findNextActionsByUser(User $user): array
+    public function findAllActiveByUser(User $user): array
     {
-        return $this->findByUserAndStatus($user, Task::STATUS_NEXT_ACTION);
-    }
-
-    /**
-     * Find all waiting for tasks for a user
-     *
-     * @return Task[]
-     */
-    public function findWaitingForByUser(User $user): array
-    {
-        return $this->findByUserAndStatus($user, Task::STATUS_WAITING_FOR);
-    }
-
-    /**
-     * Find all someday/maybe tasks for a user
-     *
-     * @return Task[]
-     */
-    public function findSomedayMaybeByUser(User $user): array
-    {
-        return $this->findByUserAndStatus($user, Task::STATUS_SOMEDAY_MAYBE);
-    }
-
-    /**
-     * Find all reference items for a user
-     *
-     * @return Task[]
-     */
-    public function findReferenceByUser(User $user): array
-    {
-        return $this->findByUserAndStatus($user, Task::STATUS_REFERENCE);
+        return $this->createUserQueryBuilder($user)
+            ->andWhere('t.status != :deleted')
+            ->setParameter('deleted', Task::STATUS_DELETED)
+            ->orderBy('t.position', 'ASC')
+            ->addOrderBy('t.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
     }
 
     /**
@@ -149,10 +112,8 @@ class TaskRepository extends ServiceEntityRepository
      */
     public function findCompletedByUser(User $user, ?int $limit = null): array
     {
-        $qb = $this->createQueryBuilder('t')
-            ->where('t.user = :user')
+        $qb = $this->createUserQueryBuilder($user)
             ->andWhere('t.status = :status')
-            ->setParameter('user', $user)
             ->setParameter('status', Task::STATUS_COMPLETED)
             ->orderBy('t.completedAt', 'DESC');
 
@@ -161,16 +122,6 @@ class TaskRepository extends ServiceEntityRepository
         }
 
         return $qb->getQuery()->getResult();
-    }
-
-    /**
-     * Find all deleted (soft-deleted) tasks for a user
-     *
-     * @return Task[]
-     */
-    public function findDeletedByUser(User $user): array
-    {
-        return $this->findByUserAndStatus($user, Task::STATUS_DELETED);
     }
 
     // =========================================================================
@@ -184,15 +135,9 @@ class TaskRepository extends ServiceEntityRepository
      */
     public function findOverdueByUser(User $user): array
     {
-        $today = new \DateTimeImmutable('today');
-
-        return $this->createQueryBuilder('t')
-            ->where('t.user = :user')
+        return $this->createActiveTasksQueryBuilder($user)
             ->andWhere('t.dueDate < :today')
-            ->andWhere('t.status NOT IN (:excludedStatuses)')
-            ->setParameter('user', $user)
-            ->setParameter('today', $today)
-            ->setParameter('excludedStatuses', [Task::STATUS_COMPLETED, Task::STATUS_DELETED])
+            ->setParameter('today', new \DateTimeImmutable('today'))
             ->orderBy('t.dueDate', 'ASC')
             ->getQuery()
             ->getResult();
@@ -205,15 +150,9 @@ class TaskRepository extends ServiceEntityRepository
      */
     public function findDueTodayByUser(User $user): array
     {
-        $today = new \DateTimeImmutable('today');
-
-        return $this->createQueryBuilder('t')
-            ->where('t.user = :user')
+        return $this->createActiveTasksQueryBuilder($user)
             ->andWhere('t.dueDate = :today')
-            ->andWhere('t.status NOT IN (:excludedStatuses)')
-            ->setParameter('user', $user)
-            ->setParameter('today', $today)
-            ->setParameter('excludedStatuses', [Task::STATUS_COMPLETED, Task::STATUS_DELETED])
+            ->setParameter('today', new \DateTimeImmutable('today'))
             ->orderBy('t.dueTime', 'ASC')
             ->addOrderBy('t.position', 'ASC')
             ->getQuery()
@@ -230,15 +169,11 @@ class TaskRepository extends ServiceEntityRepository
         \DateTimeImmutable $startDate,
         \DateTimeImmutable $endDate
     ): array {
-        return $this->createQueryBuilder('t')
-            ->where('t.user = :user')
+        return $this->createActiveTasksQueryBuilder($user)
             ->andWhere('t.dueDate >= :startDate')
             ->andWhere('t.dueDate <= :endDate')
-            ->andWhere('t.status NOT IN (:excludedStatuses)')
-            ->setParameter('user', $user)
             ->setParameter('startDate', $startDate)
             ->setParameter('endDate', $endDate)
-            ->setParameter('excludedStatuses', [Task::STATUS_COMPLETED, Task::STATUS_DELETED])
             ->orderBy('t.dueDate', 'ASC')
             ->addOrderBy('t.dueTime', 'ASC')
             ->getQuery()
@@ -250,7 +185,7 @@ class TaskRepository extends ServiceEntityRepository
     // =========================================================================
 
     /**
-     * Find tasks by project
+     * Find tasks by project (excludes deleted)
      *
      * @return Task[]
      */
@@ -258,16 +193,16 @@ class TaskRepository extends ServiceEntityRepository
     {
         return $this->createQueryBuilder('t')
             ->where('t.project = :project')
-            ->andWhere('t.status NOT IN (:excludedStatuses)')
+            ->andWhere('t.status != :deleted')
             ->setParameter('project', $project)
-            ->setParameter('excludedStatuses', [Task::STATUS_DELETED])
+            ->setParameter('deleted', Task::STATUS_DELETED)
             ->orderBy('t.position', 'ASC')
             ->getQuery()
             ->getResult();
     }
 
     /**
-     * Find next action for a project (first task with next_action status)
+     * Find next action for a project
      */
     public function findNextActionByProject(object $project): ?Task
     {
@@ -283,28 +218,7 @@ class TaskRepository extends ServiceEntityRepository
     }
 
     // =========================================================================
-    // Actionable Tasks Queries
-    // =========================================================================
-
-    /**
-     * Find all actionable tasks for a user (next_action + waiting_for)
-     *
-     * @return Task[]
-     */
-    public function findActionableByUser(User $user): array
-    {
-        return $this->createQueryBuilder('t')
-            ->where('t.user = :user')
-            ->andWhere('t.status IN (:statuses)')
-            ->setParameter('user', $user)
-            ->setParameter('statuses', [Task::STATUS_NEXT_ACTION, Task::STATUS_WAITING_FOR])
-            ->orderBy('t.position', 'ASC')
-            ->getQuery()
-            ->getResult();
-    }
-
-    // =========================================================================
-    // Sync Queries
+    // Sync & Statistics
     // =========================================================================
 
     /**
@@ -314,19 +228,13 @@ class TaskRepository extends ServiceEntityRepository
      */
     public function findModifiedSince(User $user, \DateTimeImmutable $since): array
     {
-        return $this->createQueryBuilder('t')
-            ->where('t.user = :user')
+        return $this->createUserQueryBuilder($user)
             ->andWhere('t.updatedAt > :since')
-            ->setParameter('user', $user)
             ->setParameter('since', $since)
             ->orderBy('t.updatedAt', 'ASC')
             ->getQuery()
             ->getResult();
     }
-
-    // =========================================================================
-    // Statistics Queries
-    // =========================================================================
 
     /**
      * Count tasks by status for a user
@@ -335,10 +243,8 @@ class TaskRepository extends ServiceEntityRepository
      */
     public function countByStatusForUser(User $user): array
     {
-        $results = $this->createQueryBuilder('t')
+        $results = $this->createUserQueryBuilder($user)
             ->select('t.status, COUNT(t.id) as count')
-            ->where('t.user = :user')
-            ->setParameter('user', $user)
             ->groupBy('t.status')
             ->getQuery()
             ->getResult();
@@ -359,13 +265,11 @@ class TaskRepository extends ServiceEntityRepository
         \DateTimeImmutable $startDate,
         \DateTimeImmutable $endDate
     ): int {
-        return (int) $this->createQueryBuilder('t')
+        return (int) $this->createUserQueryBuilder($user)
             ->select('COUNT(t.id)')
-            ->where('t.user = :user')
             ->andWhere('t.status = :status')
             ->andWhere('t.completedAt >= :startDate')
             ->andWhere('t.completedAt <= :endDate')
-            ->setParameter('user', $user)
             ->setParameter('status', Task::STATUS_COMPLETED)
             ->setParameter('startDate', $startDate)
             ->setParameter('endDate', $endDate)
@@ -373,24 +277,36 @@ class TaskRepository extends ServiceEntityRepository
             ->getSingleScalarResult();
     }
 
-    // =========================================================================
-    // Position Management
-    // =========================================================================
-
     /**
      * Get the maximum position for a user's tasks in a given status
      */
     public function getMaxPositionByUserAndStatus(User $user, string $status): int
     {
-        $result = $this->createQueryBuilder('t')
+        $result = $this->createUserQueryBuilder($user)
             ->select('MAX(t.position)')
-            ->where('t.user = :user')
             ->andWhere('t.status = :status')
-            ->setParameter('user', $user)
             ->setParameter('status', $status)
             ->getQuery()
             ->getSingleScalarResult();
 
         return $result !== null ? (int) $result : 0;
+    }
+
+    // =========================================================================
+    // Private Query Builder Helpers
+    // =========================================================================
+
+    private function createUserQueryBuilder(User $user): QueryBuilder
+    {
+        return $this->createQueryBuilder('t')
+            ->where('t.user = :user')
+            ->setParameter('user', $user);
+    }
+
+    private function createActiveTasksQueryBuilder(User $user): QueryBuilder
+    {
+        return $this->createUserQueryBuilder($user)
+            ->andWhere('t.status NOT IN (:excludedStatuses)')
+            ->setParameter('excludedStatuses', self::EXCLUDED_STATUSES);
     }
 }

--- a/api/src/Repository/TaskRepository.php
+++ b/api/src/Repository/TaskRepository.php
@@ -1,0 +1,396 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<Task>
+ */
+class TaskRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Task::class);
+    }
+
+    public function save(Task $task, bool $flush = true): void
+    {
+        $this->getEntityManager()->persist($task);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
+    public function remove(Task $task, bool $flush = true): void
+    {
+        $this->getEntityManager()->remove($task);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
+    public function findById(Uuid $id): ?Task
+    {
+        return $this->find($id);
+    }
+
+    // =========================================================================
+    // Inbox Queries (FR-007)
+    // =========================================================================
+
+    /**
+     * Find all inbox tasks for a user, ordered by position then creation date
+     *
+     * @return Task[]
+     */
+    public function findInboxByUser(User $user): array
+    {
+        return $this->createQueryBuilder('t')
+            ->where('t.user = :user')
+            ->andWhere('t.status = :status')
+            ->setParameter('user', $user)
+            ->setParameter('status', Task::STATUS_INBOX)
+            ->orderBy('t.position', 'ASC')
+            ->addOrderBy('t.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Count inbox tasks for a user
+     */
+    public function countInboxByUser(User $user): int
+    {
+        return (int) $this->createQueryBuilder('t')
+            ->select('COUNT(t.id)')
+            ->where('t.user = :user')
+            ->andWhere('t.status = :status')
+            ->setParameter('user', $user)
+            ->setParameter('status', Task::STATUS_INBOX)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    // =========================================================================
+    // Status-based Queries
+    // =========================================================================
+
+    /**
+     * Find tasks by user and status
+     *
+     * @return Task[]
+     */
+    public function findByUserAndStatus(User $user, string $status): array
+    {
+        return $this->createQueryBuilder('t')
+            ->where('t.user = :user')
+            ->andWhere('t.status = :status')
+            ->setParameter('user', $user)
+            ->setParameter('status', $status)
+            ->orderBy('t.position', 'ASC')
+            ->addOrderBy('t.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Find all next actions for a user
+     *
+     * @return Task[]
+     */
+    public function findNextActionsByUser(User $user): array
+    {
+        return $this->findByUserAndStatus($user, Task::STATUS_NEXT_ACTION);
+    }
+
+    /**
+     * Find all waiting for tasks for a user
+     *
+     * @return Task[]
+     */
+    public function findWaitingForByUser(User $user): array
+    {
+        return $this->findByUserAndStatus($user, Task::STATUS_WAITING_FOR);
+    }
+
+    /**
+     * Find all someday/maybe tasks for a user
+     *
+     * @return Task[]
+     */
+    public function findSomedayMaybeByUser(User $user): array
+    {
+        return $this->findByUserAndStatus($user, Task::STATUS_SOMEDAY_MAYBE);
+    }
+
+    /**
+     * Find all reference items for a user
+     *
+     * @return Task[]
+     */
+    public function findReferenceByUser(User $user): array
+    {
+        return $this->findByUserAndStatus($user, Task::STATUS_REFERENCE);
+    }
+
+    /**
+     * Find all completed tasks for a user
+     *
+     * @return Task[]
+     */
+    public function findCompletedByUser(User $user, ?int $limit = null): array
+    {
+        $qb = $this->createQueryBuilder('t')
+            ->where('t.user = :user')
+            ->andWhere('t.status = :status')
+            ->setParameter('user', $user)
+            ->setParameter('status', Task::STATUS_COMPLETED)
+            ->orderBy('t.completedAt', 'DESC');
+
+        if ($limit !== null) {
+            $qb->setMaxResults($limit);
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * Find all deleted (soft-deleted) tasks for a user
+     *
+     * @return Task[]
+     */
+    public function findDeletedByUser(User $user): array
+    {
+        return $this->findByUserAndStatus($user, Task::STATUS_DELETED);
+    }
+
+    // =========================================================================
+    // Due Date Queries
+    // =========================================================================
+
+    /**
+     * Find overdue tasks for a user (excludes completed/deleted)
+     *
+     * @return Task[]
+     */
+    public function findOverdueByUser(User $user): array
+    {
+        $today = new \DateTimeImmutable('today');
+
+        return $this->createQueryBuilder('t')
+            ->where('t.user = :user')
+            ->andWhere('t.dueDate < :today')
+            ->andWhere('t.status NOT IN (:excludedStatuses)')
+            ->setParameter('user', $user)
+            ->setParameter('today', $today)
+            ->setParameter('excludedStatuses', [Task::STATUS_COMPLETED, Task::STATUS_DELETED])
+            ->orderBy('t.dueDate', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Find tasks due today for a user (excludes completed/deleted)
+     *
+     * @return Task[]
+     */
+    public function findDueTodayByUser(User $user): array
+    {
+        $today = new \DateTimeImmutable('today');
+
+        return $this->createQueryBuilder('t')
+            ->where('t.user = :user')
+            ->andWhere('t.dueDate = :today')
+            ->andWhere('t.status NOT IN (:excludedStatuses)')
+            ->setParameter('user', $user)
+            ->setParameter('today', $today)
+            ->setParameter('excludedStatuses', [Task::STATUS_COMPLETED, Task::STATUS_DELETED])
+            ->orderBy('t.dueTime', 'ASC')
+            ->addOrderBy('t.position', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Find tasks due within a date range for a user
+     *
+     * @return Task[]
+     */
+    public function findDueInRangeByUser(
+        User $user,
+        \DateTimeImmutable $startDate,
+        \DateTimeImmutable $endDate
+    ): array {
+        return $this->createQueryBuilder('t')
+            ->where('t.user = :user')
+            ->andWhere('t.dueDate >= :startDate')
+            ->andWhere('t.dueDate <= :endDate')
+            ->andWhere('t.status NOT IN (:excludedStatuses)')
+            ->setParameter('user', $user)
+            ->setParameter('startDate', $startDate)
+            ->setParameter('endDate', $endDate)
+            ->setParameter('excludedStatuses', [Task::STATUS_COMPLETED, Task::STATUS_DELETED])
+            ->orderBy('t.dueDate', 'ASC')
+            ->addOrderBy('t.dueTime', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    // =========================================================================
+    // Project Queries
+    // =========================================================================
+
+    /**
+     * Find tasks by project
+     *
+     * @return Task[]
+     */
+    public function findByProject(object $project): array
+    {
+        return $this->createQueryBuilder('t')
+            ->where('t.project = :project')
+            ->andWhere('t.status NOT IN (:excludedStatuses)')
+            ->setParameter('project', $project)
+            ->setParameter('excludedStatuses', [Task::STATUS_DELETED])
+            ->orderBy('t.position', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Find next action for a project (first task with next_action status)
+     */
+    public function findNextActionByProject(object $project): ?Task
+    {
+        return $this->createQueryBuilder('t')
+            ->where('t.project = :project')
+            ->andWhere('t.status = :status')
+            ->setParameter('project', $project)
+            ->setParameter('status', Task::STATUS_NEXT_ACTION)
+            ->orderBy('t.position', 'ASC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    // =========================================================================
+    // Actionable Tasks Queries
+    // =========================================================================
+
+    /**
+     * Find all actionable tasks for a user (next_action + waiting_for)
+     *
+     * @return Task[]
+     */
+    public function findActionableByUser(User $user): array
+    {
+        return $this->createQueryBuilder('t')
+            ->where('t.user = :user')
+            ->andWhere('t.status IN (:statuses)')
+            ->setParameter('user', $user)
+            ->setParameter('statuses', [Task::STATUS_NEXT_ACTION, Task::STATUS_WAITING_FOR])
+            ->orderBy('t.position', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    // =========================================================================
+    // Sync Queries
+    // =========================================================================
+
+    /**
+     * Find tasks modified since a given date for sync
+     *
+     * @return Task[]
+     */
+    public function findModifiedSince(User $user, \DateTimeImmutable $since): array
+    {
+        return $this->createQueryBuilder('t')
+            ->where('t.user = :user')
+            ->andWhere('t.updatedAt > :since')
+            ->setParameter('user', $user)
+            ->setParameter('since', $since)
+            ->orderBy('t.updatedAt', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    // =========================================================================
+    // Statistics Queries
+    // =========================================================================
+
+    /**
+     * Count tasks by status for a user
+     *
+     * @return array<string, int>
+     */
+    public function countByStatusForUser(User $user): array
+    {
+        $results = $this->createQueryBuilder('t')
+            ->select('t.status, COUNT(t.id) as count')
+            ->where('t.user = :user')
+            ->setParameter('user', $user)
+            ->groupBy('t.status')
+            ->getQuery()
+            ->getResult();
+
+        $counts = [];
+        foreach ($results as $result) {
+            $counts[$result['status']] = (int) $result['count'];
+        }
+
+        return $counts;
+    }
+
+    /**
+     * Count completed tasks in a date range for a user
+     */
+    public function countCompletedInRange(
+        User $user,
+        \DateTimeImmutable $startDate,
+        \DateTimeImmutable $endDate
+    ): int {
+        return (int) $this->createQueryBuilder('t')
+            ->select('COUNT(t.id)')
+            ->where('t.user = :user')
+            ->andWhere('t.status = :status')
+            ->andWhere('t.completedAt >= :startDate')
+            ->andWhere('t.completedAt <= :endDate')
+            ->setParameter('user', $user)
+            ->setParameter('status', Task::STATUS_COMPLETED)
+            ->setParameter('startDate', $startDate)
+            ->setParameter('endDate', $endDate)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    // =========================================================================
+    // Position Management
+    // =========================================================================
+
+    /**
+     * Get the maximum position for a user's tasks in a given status
+     */
+    public function getMaxPositionByUserAndStatus(User $user, string $status): int
+    {
+        $result = $this->createQueryBuilder('t')
+            ->select('MAX(t.position)')
+            ->where('t.user = :user')
+            ->andWhere('t.status = :status')
+            ->setParameter('user', $user)
+            ->setParameter('status', $status)
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return $result !== null ? (int) $result : 0;
+    }
+}

--- a/api/tests/Functional/Task/InboxTest.php
+++ b/api/tests/Functional/Task/InboxTest.php
@@ -1,0 +1,547 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Task;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Functional tests for Task capture and inbox endpoints (FR-007, FR-008)
+ */
+class InboxTest extends WebTestCase
+{
+    private $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+    }
+
+    // =========================================================================
+    // Quick Capture Tests (FR-007)
+    // =========================================================================
+
+    public function testCreateTaskSuccess(): void
+    {
+        $tokens = $this->authenticateUser();
+
+        $this->client->request('POST', '/api/v1/tasks', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'title' => 'Buy groceries',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertArrayHasKey('message', $response);
+        $this->assertArrayHasKey('task', $response);
+        $this->assertEquals('Buy groceries', $response['task']['title']);
+        $this->assertEquals('inbox', $response['task']['status']);
+        $this->assertArrayHasKey('id', $response['task']);
+        $this->assertArrayHasKey('created_at', $response['task']);
+    }
+
+    public function testCreateTaskWithNotes(): void
+    {
+        $tokens = $this->authenticateUser();
+
+        $this->client->request('POST', '/api/v1/tasks', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'title' => 'Call the dentist',
+            'notes' => 'Ask about the appointment next week',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals('Call the dentist', $response['task']['title']);
+        $this->assertEquals('Ask about the appointment next week', $response['task']['notes']);
+    }
+
+    public function testCreateTaskMissingTitle(): void
+    {
+        $tokens = $this->authenticateUser();
+
+        $this->client->request('POST', '/api/v1/tasks', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'notes' => 'Some notes without title',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('MISSING_TITLE', $response['code']);
+    }
+
+    public function testCreateTaskEmptyTitle(): void
+    {
+        $tokens = $this->authenticateUser();
+
+        $this->client->request('POST', '/api/v1/tasks', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'title' => '   ',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('MISSING_TITLE', $response['code']);
+    }
+
+    public function testCreateTaskUnauthenticated(): void
+    {
+        $this->client->request('POST', '/api/v1/tasks', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'title' => 'Test task',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    // =========================================================================
+    // Inbox List Tests (FR-008)
+    // =========================================================================
+
+    public function testGetInboxEmpty(): void
+    {
+        $tokens = $this->authenticateUser('inbox-empty@example.com');
+
+        $this->client->request('GET', '/api/v1/tasks/inbox', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertArrayHasKey('tasks', $response);
+        $this->assertArrayHasKey('count', $response);
+        $this->assertArrayHasKey('has_overflow', $response);
+        $this->assertIsArray($response['tasks']);
+        $this->assertEquals(0, $response['count']);
+        $this->assertFalse($response['has_overflow']);
+    }
+
+    public function testGetInboxWithTasks(): void
+    {
+        $tokens = $this->authenticateUser('inbox-tasks@example.com');
+
+        // Create some tasks
+        $this->createTask($tokens['access_token'], 'Task 1');
+        $this->createTask($tokens['access_token'], 'Task 2');
+        $this->createTask($tokens['access_token'], 'Task 3');
+
+        $this->client->request('GET', '/api/v1/tasks/inbox', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals(3, $response['count']);
+        $this->assertCount(3, $response['tasks']);
+        $this->assertFalse($response['has_overflow']);
+    }
+
+    public function testGetInboxCount(): void
+    {
+        $tokens = $this->authenticateUser('inbox-count@example.com');
+
+        // Create some tasks
+        $this->createTask($tokens['access_token'], 'Task A');
+        $this->createTask($tokens['access_token'], 'Task B');
+
+        $this->client->request('GET', '/api/v1/tasks/inbox/count', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertArrayHasKey('count', $response);
+        $this->assertEquals(2, $response['count']);
+    }
+
+    public function testGetInboxUnauthenticated(): void
+    {
+        $this->client->request('GET', '/api/v1/tasks/inbox');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    // =========================================================================
+    // Task CRUD Tests
+    // =========================================================================
+
+    public function testGetTaskSuccess(): void
+    {
+        $tokens = $this->authenticateUser('get-task@example.com');
+        $taskId = $this->createTask($tokens['access_token'], 'Test task to get');
+
+        $this->client->request('GET', '/api/v1/tasks/' . $taskId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertArrayHasKey('task', $response);
+        $this->assertEquals($taskId, $response['task']['id']);
+        $this->assertEquals('Test task to get', $response['task']['title']);
+    }
+
+    public function testGetTaskNotFound(): void
+    {
+        $tokens = $this->authenticateUser('get-not-found@example.com');
+
+        $this->client->request('GET', '/api/v1/tasks/00000000-0000-0000-0000-000000000000', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testGetTaskInvalidId(): void
+    {
+        $tokens = $this->authenticateUser('get-invalid@example.com');
+
+        // Invalid UUID format doesn't match the route requirements, returns 404
+        $this->client->request('GET', '/api/v1/tasks/invalid-uuid', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testUpdateTaskSuccess(): void
+    {
+        $tokens = $this->authenticateUser('update-task@example.com');
+        $taskId = $this->createTask($tokens['access_token'], 'Original title');
+
+        $this->client->request('PATCH', '/api/v1/tasks/' . $taskId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'title' => 'Updated title',
+            'notes' => 'New notes',
+            'energy_level' => 'high',
+            'time_estimate' => 30,
+        ]));
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals('Updated title', $response['task']['title']);
+        $this->assertEquals('New notes', $response['task']['notes']);
+        $this->assertEquals('high', $response['task']['energy_level']);
+        $this->assertEquals(30, $response['task']['time_estimate']);
+    }
+
+    public function testUpdateTaskInvalidStatus(): void
+    {
+        $tokens = $this->authenticateUser('update-invalid-status@example.com');
+        $taskId = $this->createTask($tokens['access_token'], 'Test task');
+
+        $this->client->request('PATCH', '/api/v1/tasks/' . $taskId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'status' => 'invalid_status',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('INVALID_STATUS', $response['code']);
+    }
+
+    public function testDeleteTaskSuccess(): void
+    {
+        $tokens = $this->authenticateUser('delete-task@example.com');
+        $taskId = $this->createTask($tokens['access_token'], 'Task to delete');
+
+        $this->client->request('DELETE', '/api/v1/tasks/' . $taskId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        // Verify task is soft-deleted
+        $this->client->request('GET', '/api/v1/tasks/' . $taskId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('deleted', $response['task']['status']);
+    }
+
+    // =========================================================================
+    // Quick Actions Tests
+    // =========================================================================
+
+    public function testCompleteTaskSuccess(): void
+    {
+        $tokens = $this->authenticateUser('complete-task@example.com');
+        $taskId = $this->createTask($tokens['access_token'], 'Task to complete');
+
+        $this->client->request('POST', '/api/v1/tasks/' . $taskId . '/complete', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals('completed', $response['task']['status']);
+        $this->assertNotNull($response['task']['completed_at']);
+    }
+
+    public function testRestoreDeletedTask(): void
+    {
+        $tokens = $this->authenticateUser('restore-task@example.com');
+        $taskId = $this->createTask($tokens['access_token'], 'Task to restore');
+
+        // Delete the task
+        $this->client->request('DELETE', '/api/v1/tasks/' . $taskId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        // Restore the task
+        $this->client->request('POST', '/api/v1/tasks/' . $taskId . '/restore', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals('inbox', $response['task']['status']);
+    }
+
+    public function testRestoreNonDeletedTask(): void
+    {
+        $tokens = $this->authenticateUser('restore-non-deleted@example.com');
+        $taskId = $this->createTask($tokens['access_token'], 'Active task');
+
+        $this->client->request('POST', '/api/v1/tasks/' . $taskId . '/restore', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('NOT_DELETED', $response['code']);
+    }
+
+    // =========================================================================
+    // Task List Tests
+    // =========================================================================
+
+    public function testGetAllTasks(): void
+    {
+        $tokens = $this->authenticateUser('all-tasks@example.com');
+
+        $this->createTask($tokens['access_token'], 'Task 1');
+        $taskId2 = $this->createTask($tokens['access_token'], 'Task 2');
+
+        // Complete one task
+        $this->client->request('POST', '/api/v1/tasks/' . $taskId2 . '/complete', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->client->request('GET', '/api/v1/tasks', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals(2, $response['count']);
+    }
+
+    public function testGetTasksByStatus(): void
+    {
+        $tokens = $this->authenticateUser('tasks-by-status@example.com');
+
+        $this->createTask($tokens['access_token'], 'Inbox task');
+        $taskId = $this->createTask($tokens['access_token'], 'Task to complete');
+
+        // Complete one task
+        $this->client->request('POST', '/api/v1/tasks/' . $taskId . '/complete', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        // Get only completed tasks
+        $this->client->request('GET', '/api/v1/tasks?status=completed', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals(1, $response['count']);
+        $this->assertEquals('completed', $response['tasks'][0]['status']);
+    }
+
+    public function testGetTasksInvalidStatus(): void
+    {
+        $tokens = $this->authenticateUser('invalid-filter@example.com');
+
+        $this->client->request('GET', '/api/v1/tasks?status=invalid', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('INVALID_STATUS', $response['code']);
+    }
+
+    // =========================================================================
+    // Statistics Tests
+    // =========================================================================
+
+    public function testGetTaskStats(): void
+    {
+        $tokens = $this->authenticateUser('task-stats@example.com');
+
+        // Create various tasks
+        $this->createTask($tokens['access_token'], 'Inbox 1');
+        $this->createTask($tokens['access_token'], 'Inbox 2');
+        $taskId = $this->createTask($tokens['access_token'], 'To complete');
+
+        // Complete one
+        $this->client->request('POST', '/api/v1/tasks/' . $taskId . '/complete', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->client->request('GET', '/api/v1/tasks/stats', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertArrayHasKey('by_status', $response);
+        $this->assertArrayHasKey('inbox_count', $response);
+        $this->assertArrayHasKey('overdue_count', $response);
+        $this->assertArrayHasKey('due_today_count', $response);
+        $this->assertEquals(2, $response['inbox_count']);
+    }
+
+    // =========================================================================
+    // User Isolation Tests
+    // =========================================================================
+
+    public function testUserCannotAccessOtherUsersTasks(): void
+    {
+        // User 1 creates a task
+        $tokens1 = $this->authenticateUser('user1-isolation@example.com');
+        $taskId = $this->createTask($tokens1['access_token'], 'User 1 task');
+
+        // User 2 tries to access it
+        $tokens2 = $this->authenticateUser('user2-isolation@example.com');
+
+        $this->client->request('GET', '/api/v1/tasks/' . $taskId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens2['access_token'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testUserInboxIsIsolated(): void
+    {
+        // User 1 creates tasks
+        $tokens1 = $this->authenticateUser('user1-inbox@example.com');
+        $this->createTask($tokens1['access_token'], 'User 1 task A');
+        $this->createTask($tokens1['access_token'], 'User 1 task B');
+
+        // User 2 creates tasks
+        $tokens2 = $this->authenticateUser('user2-inbox@example.com');
+        $this->createTask($tokens2['access_token'], 'User 2 task');
+
+        // User 2 should only see their own tasks
+        $this->client->request('GET', '/api/v1/tasks/inbox', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens2['access_token'],
+        ]);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals(1, $response['count']);
+        $this->assertEquals('User 2 task', $response['tasks'][0]['title']);
+    }
+
+    // =========================================================================
+    // Helper Methods
+    // =========================================================================
+
+    private function authenticateUser(string $email = 'test@example.com'): array
+    {
+        $password = 'Password123!';
+
+        // Register user
+        $this->client->request('POST', '/api/v1/auth/register', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'email' => $email,
+            'password' => $password,
+        ]));
+
+        // Verify user
+        $container = static::getContainer();
+        $userRepository = $container->get('App\Repository\UserRepository');
+        $user = $userRepository->findByEmail($email);
+
+        if ($user && $user->getVerificationToken()) {
+            $this->client->request('POST', '/api/v1/auth/verify-email', [], [], [
+                'CONTENT_TYPE' => 'application/json',
+            ], json_encode([
+                'token' => $user->getVerificationToken(),
+            ]));
+        }
+
+        // Login
+        $this->client->request('POST', '/api/v1/auth/login', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'email' => $email,
+            'password' => $password,
+        ]));
+
+        return json_decode($this->client->getResponse()->getContent(), true);
+    }
+
+    private function createTask(string $accessToken, string $title): string
+    {
+        $this->client->request('POST', '/api/v1/tasks', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $accessToken,
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'title' => $title,
+        ]));
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        return $response['task']['id'];
+    }
+}

--- a/api/tests/Unit/Entity/ProjectTest.php
+++ b/api/tests/Unit/Entity/ProjectTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\Project;
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+class ProjectTest extends TestCase
+{
+    private function createUser(): User
+    {
+        $user = new User();
+        $user->setEmail('test@example.com');
+        return $user;
+    }
+
+    public function testProjectCreation(): void
+    {
+        $project = new Project();
+
+        $this->assertInstanceOf(Uuid::class, $project->getId());
+        $this->assertInstanceOf(\DateTimeImmutable::class, $project->getCreatedAt());
+        $this->assertInstanceOf(\DateTimeImmutable::class, $project->getUpdatedAt());
+    }
+
+    public function testNameGetterSetter(): void
+    {
+        $project = new Project();
+        $name = 'My Project';
+
+        $project->setName($name);
+
+        $this->assertEquals($name, $project->getName());
+    }
+
+    public function testUserGetterSetter(): void
+    {
+        $project = new Project();
+        $user = $this->createUser();
+
+        $project->setUser($user);
+
+        $this->assertSame($user, $project->getUser());
+    }
+
+    public function testOnPreUpdate(): void
+    {
+        $project = new Project();
+        $originalUpdatedAt = $project->getUpdatedAt();
+
+        usleep(1000);
+
+        $project->onPreUpdate();
+
+        $this->assertNotEquals($originalUpdatedAt, $project->getUpdatedAt());
+        $this->assertGreaterThan($originalUpdatedAt, $project->getUpdatedAt());
+    }
+
+    public function testFluentInterface(): void
+    {
+        $project = new Project();
+        $user = $this->createUser();
+
+        $result = $project
+            ->setName('Test Project')
+            ->setUser($user);
+
+        $this->assertSame($project, $result);
+    }
+}

--- a/api/tests/Unit/Entity/TaskTest.php
+++ b/api/tests/Unit/Entity/TaskTest.php
@@ -1,0 +1,545 @@
+<?php
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\Task;
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+class TaskTest extends TestCase
+{
+    private function createUser(): User
+    {
+        $user = new User();
+        $user->setEmail('test@example.com');
+        return $user;
+    }
+
+    public function testTaskCreation(): void
+    {
+        $task = new Task();
+
+        $this->assertInstanceOf(Uuid::class, $task->getId());
+        $this->assertInstanceOf(\DateTimeImmutable::class, $task->getCreatedAt());
+        $this->assertInstanceOf(\DateTimeImmutable::class, $task->getUpdatedAt());
+        $this->assertEquals(Task::STATUS_INBOX, $task->getStatus());
+        $this->assertEquals(0, $task->getPosition());
+        $this->assertEquals(1, $task->getVersion());
+        $this->assertNull($task->getNotes());
+        $this->assertNull($task->getEnergyLevel());
+        $this->assertNull($task->getTimeEstimate());
+        $this->assertNull($task->getDueDate());
+        $this->assertNull($task->getDueTime());
+        $this->assertNull($task->getCompletedAt());
+        $this->assertNull($task->getDeletedAt());
+        $this->assertNull($task->getProject());
+    }
+
+    public function testTitleGetterSetter(): void
+    {
+        $task = new Task();
+        $title = 'Buy groceries';
+
+        $task->setTitle($title);
+
+        $this->assertEquals($title, $task->getTitle());
+    }
+
+    public function testUserGetterSetter(): void
+    {
+        $task = new Task();
+        $user = $this->createUser();
+
+        $task->setUser($user);
+
+        $this->assertSame($user, $task->getUser());
+    }
+
+    public function testNotesGetterSetter(): void
+    {
+        $task = new Task();
+        $notes = 'Remember to check for discounts';
+
+        $task->setNotes($notes);
+
+        $this->assertEquals($notes, $task->getNotes());
+
+        $task->setNotes(null);
+        $this->assertNull($task->getNotes());
+    }
+
+    // =========================================================================
+    // Status Tests
+    // =========================================================================
+
+    public function testStatusGetterSetter(): void
+    {
+        $task = new Task();
+
+        foreach (Task::STATUSES as $status) {
+            $task->setStatus($status);
+            $this->assertEquals($status, $task->getStatus());
+        }
+    }
+
+    public function testIsInbox(): void
+    {
+        $task = new Task();
+        $this->assertTrue($task->isInbox());
+
+        $task->setStatus(Task::STATUS_NEXT_ACTION);
+        $this->assertFalse($task->isInbox());
+    }
+
+    public function testIsCompleted(): void
+    {
+        $task = new Task();
+        $this->assertFalse($task->isCompleted());
+
+        $task->setStatus(Task::STATUS_COMPLETED);
+        $this->assertTrue($task->isCompleted());
+    }
+
+    public function testIsDeleted(): void
+    {
+        $task = new Task();
+        $this->assertFalse($task->isDeleted());
+
+        $task->setStatus(Task::STATUS_DELETED);
+        $this->assertTrue($task->isDeleted());
+    }
+
+    public function testIsActionable(): void
+    {
+        $task = new Task();
+
+        $this->assertFalse($task->isActionable());
+
+        $task->setStatus(Task::STATUS_NEXT_ACTION);
+        $this->assertTrue($task->isActionable());
+
+        $task->setStatus(Task::STATUS_WAITING_FOR);
+        $this->assertTrue($task->isActionable());
+
+        $task->setStatus(Task::STATUS_SOMEDAY_MAYBE);
+        $this->assertFalse($task->isActionable());
+
+        $task->setStatus(Task::STATUS_REFERENCE);
+        $this->assertFalse($task->isActionable());
+    }
+
+    public function testSetStatusToCompletedAutoSetsCompletedAt(): void
+    {
+        $task = new Task();
+        $this->assertNull($task->getCompletedAt());
+
+        $beforeTime = new \DateTimeImmutable();
+        $task->setStatus(Task::STATUS_COMPLETED);
+        $afterTime = new \DateTimeImmutable();
+
+        $this->assertNotNull($task->getCompletedAt());
+        $this->assertGreaterThanOrEqual($beforeTime, $task->getCompletedAt());
+        $this->assertLessThanOrEqual($afterTime, $task->getCompletedAt());
+    }
+
+    public function testSetStatusToDeletedAutoSetsDeletedAt(): void
+    {
+        $task = new Task();
+        $this->assertNull($task->getDeletedAt());
+
+        $beforeTime = new \DateTimeImmutable();
+        $task->setStatus(Task::STATUS_DELETED);
+        $afterTime = new \DateTimeImmutable();
+
+        $this->assertNotNull($task->getDeletedAt());
+        $this->assertGreaterThanOrEqual($beforeTime, $task->getDeletedAt());
+        $this->assertLessThanOrEqual($afterTime, $task->getDeletedAt());
+    }
+
+    public function testMarkAsCompleted(): void
+    {
+        $task = new Task();
+
+        $beforeTime = new \DateTimeImmutable();
+        $task->markAsCompleted();
+        $afterTime = new \DateTimeImmutable();
+
+        $this->assertEquals(Task::STATUS_COMPLETED, $task->getStatus());
+        $this->assertNotNull($task->getCompletedAt());
+        $this->assertGreaterThanOrEqual($beforeTime, $task->getCompletedAt());
+        $this->assertLessThanOrEqual($afterTime, $task->getCompletedAt());
+    }
+
+    public function testMarkAsDeleted(): void
+    {
+        $task = new Task();
+
+        $beforeTime = new \DateTimeImmutable();
+        $task->markAsDeleted();
+        $afterTime = new \DateTimeImmutable();
+
+        $this->assertEquals(Task::STATUS_DELETED, $task->getStatus());
+        $this->assertNotNull($task->getDeletedAt());
+        $this->assertGreaterThanOrEqual($beforeTime, $task->getDeletedAt());
+        $this->assertLessThanOrEqual($afterTime, $task->getDeletedAt());
+    }
+
+    public function testRestore(): void
+    {
+        $task = new Task();
+        $task->markAsDeleted();
+
+        $this->assertEquals(Task::STATUS_DELETED, $task->getStatus());
+        $this->assertNotNull($task->getDeletedAt());
+
+        $task->restore();
+
+        $this->assertEquals(Task::STATUS_INBOX, $task->getStatus());
+        $this->assertNull($task->getDeletedAt());
+    }
+
+    public function testRestoreDoesNothingIfNotDeleted(): void
+    {
+        $task = new Task();
+        $task->setStatus(Task::STATUS_NEXT_ACTION);
+
+        $task->restore();
+
+        $this->assertEquals(Task::STATUS_NEXT_ACTION, $task->getStatus());
+    }
+
+    // =========================================================================
+    // Energy Level Tests
+    // =========================================================================
+
+    public function testEnergyLevelGetterSetter(): void
+    {
+        $task = new Task();
+
+        foreach (Task::ENERGY_LEVELS as $level) {
+            $task->setEnergyLevel($level);
+            $this->assertEquals($level, $task->getEnergyLevel());
+        }
+
+        $task->setEnergyLevel(null);
+        $this->assertNull($task->getEnergyLevel());
+    }
+
+    // =========================================================================
+    // Time Estimate Tests
+    // =========================================================================
+
+    public function testTimeEstimateGetterSetter(): void
+    {
+        $task = new Task();
+
+        $task->setTimeEstimate(30);
+        $this->assertEquals(30, $task->getTimeEstimate());
+
+        $task->setTimeEstimate(null);
+        $this->assertNull($task->getTimeEstimate());
+    }
+
+    // =========================================================================
+    // Due Date Tests
+    // =========================================================================
+
+    public function testDueDateGetterSetter(): void
+    {
+        $task = new Task();
+        $dueDate = new \DateTimeImmutable('2025-12-31');
+
+        $task->setDueDate($dueDate);
+
+        $this->assertEquals($dueDate, $task->getDueDate());
+
+        $task->setDueDate(null);
+        $this->assertNull($task->getDueDate());
+    }
+
+    public function testDueTimeGetterSetter(): void
+    {
+        $task = new Task();
+        $dueTime = new \DateTimeImmutable('14:30:00');
+
+        $task->setDueTime($dueTime);
+
+        $this->assertEquals($dueTime, $task->getDueTime());
+
+        $task->setDueTime(null);
+        $this->assertNull($task->getDueTime());
+    }
+
+    public function testIsOverdueWhenNoDueDate(): void
+    {
+        $task = new Task();
+        $this->assertFalse($task->isOverdue());
+    }
+
+    public function testIsOverdueWhenCompleted(): void
+    {
+        $task = new Task();
+        $task->setDueDate(new \DateTimeImmutable('-1 day'));
+        $task->setStatus(Task::STATUS_COMPLETED);
+
+        $this->assertFalse($task->isOverdue());
+    }
+
+    public function testIsOverdueWhenDeleted(): void
+    {
+        $task = new Task();
+        $task->setDueDate(new \DateTimeImmutable('-1 day'));
+        $task->setStatus(Task::STATUS_DELETED);
+
+        $this->assertFalse($task->isOverdue());
+    }
+
+    public function testIsOverdueWhenPastDue(): void
+    {
+        $task = new Task();
+        $task->setTitle('Test task');
+        $task->setDueDate(new \DateTimeImmutable('-1 day'));
+
+        $this->assertTrue($task->isOverdue());
+    }
+
+    public function testIsOverdueWhenFutureDue(): void
+    {
+        $task = new Task();
+        $task->setTitle('Test task');
+        $task->setDueDate(new \DateTimeImmutable('+1 day'));
+
+        $this->assertFalse($task->isOverdue());
+    }
+
+    public function testIsDueTodayWhenNoDueDate(): void
+    {
+        $task = new Task();
+        $this->assertFalse($task->isDueToday());
+    }
+
+    public function testIsDueTodayWhenToday(): void
+    {
+        $task = new Task();
+        $task->setTitle('Test task');
+        $task->setDueDate(new \DateTimeImmutable('today'));
+
+        $this->assertTrue($task->isDueToday());
+    }
+
+    public function testIsDueTodayWhenTomorrow(): void
+    {
+        $task = new Task();
+        $task->setTitle('Test task');
+        $task->setDueDate(new \DateTimeImmutable('tomorrow'));
+
+        $this->assertFalse($task->isDueToday());
+    }
+
+    public function testIsDueSoonWhenNoDueDate(): void
+    {
+        $task = new Task();
+        $this->assertFalse($task->isDueSoon());
+    }
+
+    public function testIsDueSoonWithinDefaultRange(): void
+    {
+        $task = new Task();
+        $task->setTitle('Test task');
+        $task->setDueDate(new \DateTimeImmutable('+3 days'));
+
+        $this->assertTrue($task->isDueSoon());
+    }
+
+    public function testIsDueSoonOutsideDefaultRange(): void
+    {
+        $task = new Task();
+        $task->setTitle('Test task');
+        $task->setDueDate(new \DateTimeImmutable('+10 days'));
+
+        $this->assertFalse($task->isDueSoon());
+    }
+
+    public function testIsDueSoonWithCustomRange(): void
+    {
+        $task = new Task();
+        $task->setTitle('Test task');
+        $task->setDueDate(new \DateTimeImmutable('+10 days'));
+
+        $this->assertFalse($task->isDueSoon(7));
+        $this->assertTrue($task->isDueSoon(14));
+    }
+
+    public function testIsDueSoonWhenPastDue(): void
+    {
+        $task = new Task();
+        $task->setTitle('Test task');
+        $task->setDueDate(new \DateTimeImmutable('-1 day'));
+
+        $this->assertFalse($task->isDueSoon());
+    }
+
+    // =========================================================================
+    // Position Tests
+    // =========================================================================
+
+    public function testPositionGetterSetter(): void
+    {
+        $task = new Task();
+
+        $task->setPosition(5);
+        $this->assertEquals(5, $task->getPosition());
+
+        $task->setPosition(0);
+        $this->assertEquals(0, $task->getPosition());
+    }
+
+    // =========================================================================
+    // CompletedAt and DeletedAt Manual Setters
+    // =========================================================================
+
+    public function testCompletedAtGetterSetter(): void
+    {
+        $task = new Task();
+        $completedAt = new \DateTimeImmutable('2025-01-15 10:00:00');
+
+        $task->setCompletedAt($completedAt);
+
+        $this->assertEquals($completedAt, $task->getCompletedAt());
+    }
+
+    public function testDeletedAtGetterSetter(): void
+    {
+        $task = new Task();
+        $deletedAt = new \DateTimeImmutable('2025-01-15 10:00:00');
+
+        $task->setDeletedAt($deletedAt);
+
+        $this->assertEquals($deletedAt, $task->getDeletedAt());
+    }
+
+    // =========================================================================
+    // Lifecycle Callback Tests
+    // =========================================================================
+
+    public function testOnPreUpdate(): void
+    {
+        $task = new Task();
+        $originalUpdatedAt = $task->getUpdatedAt();
+
+        usleep(1000);
+
+        $task->onPreUpdate();
+
+        $this->assertNotEquals($originalUpdatedAt, $task->getUpdatedAt());
+        $this->assertGreaterThan($originalUpdatedAt, $task->getUpdatedAt());
+    }
+
+    // =========================================================================
+    // toArray Tests
+    // =========================================================================
+
+    public function testToArray(): void
+    {
+        $task = new Task();
+        $user = $this->createUser();
+        $task->setUser($user);
+        $task->setTitle('Test task');
+        $task->setNotes('Some notes');
+        $task->setStatus(Task::STATUS_NEXT_ACTION);
+        $task->setEnergyLevel(Task::ENERGY_HIGH);
+        $task->setTimeEstimate(45);
+        $task->setDueDate(new \DateTimeImmutable('2025-12-31'));
+        $task->setPosition(3);
+
+        $array = $task->toArray();
+
+        $this->assertIsArray($array);
+        $this->assertArrayHasKey('id', $array);
+        $this->assertArrayHasKey('title', $array);
+        $this->assertArrayHasKey('notes', $array);
+        $this->assertArrayHasKey('status', $array);
+        $this->assertArrayHasKey('energy_level', $array);
+        $this->assertArrayHasKey('time_estimate', $array);
+        $this->assertArrayHasKey('due_date', $array);
+        $this->assertArrayHasKey('position', $array);
+        $this->assertArrayHasKey('version', $array);
+        $this->assertArrayHasKey('created_at', $array);
+        $this->assertArrayHasKey('updated_at', $array);
+        $this->assertArrayHasKey('completed_at', $array);
+        $this->assertArrayHasKey('is_overdue', $array);
+        $this->assertArrayHasKey('is_due_today', $array);
+
+        $this->assertEquals('Test task', $array['title']);
+        $this->assertEquals('Some notes', $array['notes']);
+        $this->assertEquals(Task::STATUS_NEXT_ACTION, $array['status']);
+        $this->assertEquals(Task::ENERGY_HIGH, $array['energy_level']);
+        $this->assertEquals(45, $array['time_estimate']);
+        $this->assertEquals('2025-12-31', $array['due_date']);
+        $this->assertEquals(3, $array['position']);
+    }
+
+    public function testToArrayWithMinimalData(): void
+    {
+        $task = new Task();
+        $user = $this->createUser();
+        $task->setUser($user);
+        $task->setTitle('Minimal task');
+
+        $array = $task->toArray();
+
+        $this->assertEquals('Minimal task', $array['title']);
+        $this->assertNull($array['notes']);
+        $this->assertNull($array['energy_level']);
+        $this->assertNull($array['time_estimate']);
+        $this->assertNull($array['due_date']);
+        $this->assertNull($array['due_time']);
+        $this->assertNull($array['completed_at']);
+        $this->assertNull($array['project_id']);
+    }
+
+    // =========================================================================
+    // Constants Tests
+    // =========================================================================
+
+    public function testStatusConstants(): void
+    {
+        $this->assertEquals('inbox', Task::STATUS_INBOX);
+        $this->assertEquals('clarified', Task::STATUS_CLARIFIED);
+        $this->assertEquals('next_action', Task::STATUS_NEXT_ACTION);
+        $this->assertEquals('waiting_for', Task::STATUS_WAITING_FOR);
+        $this->assertEquals('someday_maybe', Task::STATUS_SOMEDAY_MAYBE);
+        $this->assertEquals('reference', Task::STATUS_REFERENCE);
+        $this->assertEquals('completed', Task::STATUS_COMPLETED);
+        $this->assertEquals('deleted', Task::STATUS_DELETED);
+    }
+
+    public function testEnergyLevelConstants(): void
+    {
+        $this->assertEquals('low', Task::ENERGY_LOW);
+        $this->assertEquals('medium', Task::ENERGY_MEDIUM);
+        $this->assertEquals('high', Task::ENERGY_HIGH);
+    }
+
+    public function testStatusesArray(): void
+    {
+        $this->assertCount(8, Task::STATUSES);
+        $this->assertContains(Task::STATUS_INBOX, Task::STATUSES);
+        $this->assertContains(Task::STATUS_CLARIFIED, Task::STATUSES);
+        $this->assertContains(Task::STATUS_NEXT_ACTION, Task::STATUSES);
+        $this->assertContains(Task::STATUS_WAITING_FOR, Task::STATUSES);
+        $this->assertContains(Task::STATUS_SOMEDAY_MAYBE, Task::STATUSES);
+        $this->assertContains(Task::STATUS_REFERENCE, Task::STATUSES);
+        $this->assertContains(Task::STATUS_COMPLETED, Task::STATUSES);
+        $this->assertContains(Task::STATUS_DELETED, Task::STATUSES);
+    }
+
+    public function testEnergyLevelsArray(): void
+    {
+        $this->assertCount(3, Task::ENERGY_LEVELS);
+        $this->assertContains(Task::ENERGY_LOW, Task::ENERGY_LEVELS);
+        $this->assertContains(Task::ENERGY_MEDIUM, Task::ENERGY_LEVELS);
+        $this->assertContains(Task::ENERGY_HIGH, Task::ENERGY_LEVELS);
+    }
+}

--- a/specs/001-gtd-todo-app/tasks.md
+++ b/specs/001-gtd-todo-app/tasks.md
@@ -206,8 +206,8 @@ Per Constitution XVI, all features MUST be tracked as GitHub issues BEFORE imple
 
 - [X] [P2-001] [Story-2] Create Task Doctrine entity with all GTD statuses `api/src/Entity/Task.php`
 - [X] [P2-002] [Story-2] Write unit tests for Task entity `api/tests/Unit/Entity/TaskTest.php`
-- [ ] [P2-003] [Story-2] Create Task repository with inbox queries `api/src/Repository/TaskRepository.php`
-- [ ] [P2-004] [Story-2] Create database migration for tasks table `api/migrations/Version004CreateTasksTable.php`
+- [X] [P2-003] [Story-2] Create Task repository with inbox queries `api/src/Repository/TaskRepository.php`
+- [X] [P2-004] [Story-2] Create database migration for tasks table `api/migrations/Version004CreateTasksTable.php`
 
 ### Phase 2.2: Backend - Capture Endpoint
 

--- a/specs/001-gtd-todo-app/tasks.md
+++ b/specs/001-gtd-todo-app/tasks.md
@@ -211,9 +211,9 @@ Per Constitution XVI, all features MUST be tracked as GitHub issues BEFORE imple
 
 ### Phase 2.2: Backend - Capture Endpoint
 
-- [ ] [P2-005] [Story-2] Create TaskController with POST /api/tasks endpoint `api/src/Controller/TaskController.php`
-- [ ] [P2-006] [Story-2] Create GET /api/tasks/inbox endpoint `api/src/Controller/TaskController.php`
-- [ ] [P2-007] [Story-2] Write functional tests for capture/inbox endpoints `api/tests/Functional/Task/InboxTest.php`
+- [X] [P2-005] [Story-2] Create TaskController with POST /api/tasks endpoint `api/src/Controller/TaskController.php`
+- [X] [P2-006] [Story-2] Create GET /api/tasks/inbox endpoint `api/src/Controller/TaskController.php`
+- [X] [P2-007] [Story-2] Write functional tests for capture/inbox endpoints `api/tests/Functional/Task/InboxTest.php`
 
 ### Phase 2.3: Frontend - Inbox Module
 

--- a/specs/001-gtd-todo-app/tasks.md
+++ b/specs/001-gtd-todo-app/tasks.md
@@ -204,8 +204,8 @@ Per Constitution XVI, all features MUST be tracked as GitHub issues BEFORE imple
 
 ### Phase 2.1: Backend - Task Entity
 
-- [ ] [P2-001] [Story-2] Create Task Doctrine entity with all GTD statuses `api/src/Entity/Task.php`
-- [ ] [P2-002] [Story-2] Write unit tests for Task entity `api/tests/Unit/Entity/TaskTest.php`
+- [X] [P2-001] [Story-2] Create Task Doctrine entity with all GTD statuses `api/src/Entity/Task.php`
+- [X] [P2-002] [Story-2] Write unit tests for Task entity `api/tests/Unit/Entity/TaskTest.php`
 - [ ] [P2-003] [Story-2] Create Task repository with inbox queries `api/src/Repository/TaskRepository.php`
 - [ ] [P2-004] [Story-2] Create database migration for tasks table `api/migrations/Version004CreateTasksTable.php`
 


### PR DESCRIPTION
## Summary

This PR implements the backend portion of P2 (Capture Ideas and Tasks), completing tasks P2-001 through P2-007.

### Changes

- **Task Entity** (P2-001, P2-002): Full GTD workflow entity with 8 statuses, energy levels, time estimates, due dates, and position ordering
- **TaskRepository** (P2-003): Comprehensive query methods for inbox, status filtering, due dates, projects, and sync support
- **Database Migration** (P2-004): Creates tasks table with proper indexes and constraints
- **TaskController** (P2-005, P2-006): Complete REST API with 10 endpoints
- **Functional Tests** (P2-007): 24 tests covering all endpoints
- **Project Entity Stub**: Minimal entity to satisfy Task→Project relation (full implementation in P5)

### API Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | /api/v1/tasks | Quick capture to inbox |
| GET | /api/v1/tasks/inbox | List inbox tasks |
| GET | /api/v1/tasks/inbox/count | Get inbox count |
| GET | /api/v1/tasks/{id} | Get single task |
| PATCH | /api/v1/tasks/{id} | Update task |
| DELETE | /api/v1/tasks/{id} | Soft delete task |
| POST | /api/v1/tasks/{id}/complete | Mark as completed |
| POST | /api/v1/tasks/{id}/restore | Restore deleted task |
| GET | /api/v1/tasks | List all tasks (with filters) |
| GET | /api/v1/tasks/stats | Task statistics |

### Functional Requirements Addressed

- **FR-007**: Capture in less than 3 interactions ✅
- **FR-008**: Auto-timestamp captured items ✅
- **FR-009**: Sync support (API ready, client pending) ⚠️

### Test Results

- **42 unit tests** for Task entity (150 assertions)
- **24 functional tests** for endpoints (68 assertions)

## Test plan

- [ ] Run `php bin/phpunit tests/Unit/Entity/TaskTest.php` - all 42 tests pass
- [ ] Run `APP_ENV=test php bin/phpunit tests/Functional/Task/InboxTest.php` - all 24 tests pass
- [ ] Verify migrations apply cleanly on fresh database
- [ ] Test capture endpoint manually via curl/Postman

🤖 Generated with [Claude Code](https://claude.com/claude-code)