### PR TITLE
feat(api): P3 Backend - Clarify Feature Implementation

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,15 +1,16 @@
 {
   "permissions": {
     "allow": [
-      "Bash(cat:*)",
-      "Bash(docker-compose ps:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr create:*)",
+      "mcp__render__list_services",
+      "mcp__render__list_logs",
+      "mcp__render__update_environment_variables",
+      "Bash(npm run test:run:*)",
+      "Bash(npm run test:e2e:*)",
+      "Bash(php bin/phpunit:*)",
       "Bash(docker exec:*)",
-      "Bash(.specify/scripts/bash/check-prerequisites.sh:*)",
-      "Bash(git rev-parse:*)",
-      "Bash(docker-compose up:*)",
-      "Bash(php -S localhost:8000 -t public:*)",
-      "Bash(npm run dev:*)",
-      "Bash(curl:*)"
+      "Bash(gh api:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,8 @@
       "Bash(npm run test:e2e:*)",
       "Bash(php bin/phpunit:*)",
       "Bash(docker exec:*)",
-      "Bash(gh api:*)"
+      "Bash(gh api:*)",
+      "WebFetch(domain:sonarcloud.io)"
     ],
     "deny": [],
     "ask": []

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ A modern Getting Things Done (GTD) application with multi-platform support (Web,
 - Complete and delete tasks with one click
 - Real-time sync between platforms (< 5s delay)
 
+### Clarify and Process Tasks (P3 - Backend Complete)
+- Task clarification workflow with status transitions
+- GTD decision flow: actionable vs non-actionable items
+- Status transitions: inbox → next_action, waiting_for, someday_maybe, reference, trash
+- Field validation for clarified tasks (title, energy level, time estimate)
+- Automatic status updates based on field changes
+
 ## Tech Stack
 
 ### Backend (API)
@@ -326,11 +333,12 @@ All API endpoints are prefixed with `/api/v1`:
 - `PATCH /account` - Update account settings
 - `DELETE /account` - Delete account (GDPR)
 
-### Tasks (Inbox)
+### Tasks (Inbox & Clarify)
 - `POST /tasks` - Create a new task in inbox
 - `GET /tasks/inbox` - Get all inbox tasks
 - `GET /tasks/inbox/count` - Get inbox task count
 - `PATCH /tasks/{id}` - Update a task
+- `PATCH /tasks/{id}/clarify` - Clarify a task (set status, context, energy, time estimate)
 - `DELETE /tasks/{id}` - Delete a task
 - `POST /tasks/{id}/complete` - Mark task as complete
 
@@ -486,7 +494,7 @@ For issues and questions:
 - [x] **Sprint 0**: Infrastructure setup (CI/CD, Docker, Render deployment)
 - [x] **P1**: User Account Management (Backend + Frontend)
 - [x] **P2**: Capture Ideas and Tasks (Inbox)
-- [ ] **P3**: Clarify and Process Tasks
+- [ ] **P3**: Clarify and Process Tasks (Backend ✅, Frontend pending)
 - [ ] **P4**: Organize with Contextual Lists
 - [ ] **P5**: Project Management
 - [ ] **P6**: Weekly Review

--- a/api/src/Controller/TaskController.php
+++ b/api/src/Controller/TaskController.php
@@ -193,30 +193,30 @@ class TaskController extends AbstractController
 
         $task = $result['task'];
         $data = json_decode($request->getContent(), true) ?? [];
+        $originalStatus = $task->getStatus();
 
-        // Validate and extract clarification data
         $validationResult = $this->validateClarifyRequest($task, $data);
         if ($validationResult instanceof JsonResponse) {
             return $validationResult;
         }
 
-        // Capture original status before clarification modifies the task
-        $originalStatus = $task->getStatus();
+        return $this->executeClarification($task, $validationResult, $originalStatus);
+    }
 
+    /**
+     * Execute the clarification and return response.
+     *
+     * @param array{target_status: string, options: array<string, mixed>} $validationResult
+     */
+    private function executeClarification(Task $task, array $validationResult, string $originalStatus): JsonResponse
+    {
         try {
-            $clarifiedTask = $this->taskService->clarify(
-                $task,
-                $validationResult['target_status'],
-                $validationResult['options']
-            );
+            $clarifiedTask = $this->taskService->clarify($task, $validationResult['target_status'], $validationResult['options']);
 
             return $this->json([
                 'message' => 'Task clarified successfully',
                 'task' => $clarifiedTask->toArray(),
-                'transition' => [
-                    'from' => $originalStatus,
-                    'to' => $clarifiedTask->getStatus(),
-                ],
+                'transition' => ['from' => $originalStatus, 'to' => $clarifiedTask->getStatus()],
             ]);
         } catch (\InvalidArgumentException $e) {
             return $this->errorResponse($e->getMessage(), 'CLARIFICATION_FAILED', Response::HTTP_BAD_REQUEST);
@@ -231,14 +231,33 @@ class TaskController extends AbstractController
      */
     private function validateClarifyRequest(Task $task, array $data): array|JsonResponse
     {
-        // Validate required field
+        $statusValidation = $this->validateTargetStatus($task, $data);
+        if ($statusValidation instanceof JsonResponse) {
+            return $statusValidation;
+        }
+
+        $optionsResult = $this->buildClarifyOptions($data);
+        if ($optionsResult instanceof JsonResponse) {
+            return $optionsResult;
+        }
+
+        return ['target_status' => $statusValidation, 'options' => $optionsResult];
+    }
+
+    /**
+     * Validate target status field.
+     *
+     * @param array<string, mixed> $data
+     * @return string|JsonResponse The validated target status or error response
+     */
+    private function validateTargetStatus(Task $task, array $data): string|JsonResponse
+    {
         if (!isset($data['target_status']) || !is_string($data['target_status'])) {
             return $this->errorResponse('target_status is required', 'MISSING_TARGET_STATUS', Response::HTTP_BAD_REQUEST);
         }
 
         $targetStatus = $data['target_status'];
 
-        // Validate target status is a valid status
         if (!in_array($targetStatus, Task::STATUSES, true)) {
             return $this->json([
                 'error' => 'Invalid target status',
@@ -247,7 +266,6 @@ class TaskController extends AbstractController
             ], Response::HTTP_BAD_REQUEST);
         }
 
-        // Check if transition is allowed
         if (!$this->taskService->isValidTransition($task->getStatus(), $targetStatus)) {
             return $this->json([
                 'error' => sprintf('Invalid status transition from "%s" to "%s"', $task->getStatus(), $targetStatus),
@@ -258,13 +276,7 @@ class TaskController extends AbstractController
             ], Response::HTTP_BAD_REQUEST);
         }
 
-        // Build and validate options
-        $optionsResult = $this->buildClarifyOptions($data);
-        if ($optionsResult instanceof JsonResponse) {
-            return $optionsResult;
-        }
-
-        return ['target_status' => $targetStatus, 'options' => $optionsResult];
+        return $targetStatus;
     }
 
     /**
@@ -277,31 +289,19 @@ class TaskController extends AbstractController
     {
         $options = [];
 
-        if (isset($data['energy_level'])) {
-            if (!in_array($data['energy_level'], Task::ENERGY_LEVELS, true)) {
-                return $this->json([
-                    'error' => 'Invalid energy level',
-                    'code' => 'INVALID_ENERGY_LEVEL',
-                    'allowed_values' => Task::ENERGY_LEVELS,
-                ], Response::HTTP_BAD_REQUEST);
-            }
-            $options['energy_level'] = $data['energy_level'];
+        $energyError = $this->validateAndSetEnergyLevel($data, $options);
+        if ($energyError !== null) {
+            return $energyError;
         }
 
-        if (isset($data['time_estimate'])) {
-            if (!is_int($data['time_estimate']) || $data['time_estimate'] <= 0) {
-                return $this->errorResponse('time_estimate must be a positive integer (minutes)', 'INVALID_TIME_ESTIMATE', Response::HTTP_BAD_REQUEST);
-            }
-            $options['time_estimate'] = $data['time_estimate'];
+        $timeError = $this->validateAndSetClarifyTimeEstimate($data, $options);
+        if ($timeError !== null) {
+            return $timeError;
         }
 
-        if (isset($data['due_date'])) {
-            try {
-                $dueDate = new \DateTimeImmutable($data['due_date']);
-                $options['due_date'] = $dueDate->format('Y-m-d');
-            } catch (\Exception) {
-                return $this->errorResponse('Invalid due_date format. Use Y-m-d.', 'INVALID_DUE_DATE', Response::HTTP_BAD_REQUEST);
-            }
+        $dateError = $this->validateAndSetClarifyDueDate($data, $options);
+        if ($dateError !== null) {
+            return $dateError;
         }
 
         if (isset($data['notes']) && is_string($data['notes'])) {
@@ -309,6 +309,68 @@ class TaskController extends AbstractController
         }
 
         return $options;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @param array<string, mixed> $options
+     */
+    private function validateAndSetEnergyLevel(array $data, array &$options): ?JsonResponse
+    {
+        if (!isset($data['energy_level'])) {
+            return null;
+        }
+
+        if (!in_array($data['energy_level'], Task::ENERGY_LEVELS, true)) {
+            return $this->json([
+                'error' => 'Invalid energy level',
+                'code' => 'INVALID_ENERGY_LEVEL',
+                'allowed_values' => Task::ENERGY_LEVELS,
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $options['energy_level'] = $data['energy_level'];
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @param array<string, mixed> $options
+     */
+    private function validateAndSetClarifyTimeEstimate(array $data, array &$options): ?JsonResponse
+    {
+        if (!isset($data['time_estimate'])) {
+            return null;
+        }
+
+        if (!is_int($data['time_estimate']) || $data['time_estimate'] <= 0) {
+            return $this->errorResponse('time_estimate must be a positive integer (minutes)', 'INVALID_TIME_ESTIMATE', Response::HTTP_BAD_REQUEST);
+        }
+
+        $options['time_estimate'] = $data['time_estimate'];
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @param array<string, mixed> $options
+     */
+    private function validateAndSetClarifyDueDate(array $data, array &$options): ?JsonResponse
+    {
+        if (!isset($data['due_date'])) {
+            return null;
+        }
+
+        try {
+            $dueDate = new \DateTimeImmutable($data['due_date']);
+            $options['due_date'] = $dueDate->format('Y-m-d');
+
+            return null;
+        } catch (\Exception) {
+            return $this->errorResponse('Invalid due_date format. Use Y-m-d.', 'INVALID_DUE_DATE', Response::HTTP_BAD_REQUEST);
+        }
     }
 
     /**

--- a/api/src/Controller/TaskController.php
+++ b/api/src/Controller/TaskController.php
@@ -7,6 +7,7 @@ namespace App\Controller;
 use App\Entity\Task;
 use App\Entity\User;
 use App\Repository\TaskRepository;
+use App\Service\TaskService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -26,6 +27,7 @@ class TaskController extends AbstractController
     public function __construct(
         private readonly TaskRepository $taskRepository,
         private readonly ValidatorInterface $validator,
+        private readonly TaskService $taskService,
     ) {
     }
 
@@ -167,6 +169,138 @@ class TaskController extends AbstractController
         return $this->json([
             'message' => 'Task restored',
             'task' => $task->toArray(),
+        ]);
+    }
+
+    /**
+     * Clarify a task by changing its status according to GTD workflow.
+     *
+     * Valid target statuses depend on current status (see TaskService).
+     * Options:
+     *   - target_status: required, the new status
+     *   - energy_level: optional (low/medium/high)
+     *   - time_estimate: optional (minutes)
+     *   - due_date: optional (Y-m-d format)
+     *   - notes: optional (additional notes)
+     */
+    #[Route('/tasks/{id}/clarify', name: 'api_tasks_clarify', methods: ['PATCH'], requirements: ['id' => self::UUID_PATTERN])]
+    public function clarify(string $id, Request $request): JsonResponse
+    {
+        $result = $this->getAuthenticatedUserAndTask($id);
+        if ($result instanceof JsonResponse) {
+            return $result;
+        }
+
+        $task = $result['task'];
+        $data = json_decode($request->getContent(), true) ?? [];
+
+        // Validate required field
+        if (!isset($data['target_status']) || !is_string($data['target_status'])) {
+            return $this->errorResponse('target_status is required', 'MISSING_TARGET_STATUS', Response::HTTP_BAD_REQUEST);
+        }
+
+        $targetStatus = $data['target_status'];
+
+        // Validate target status is a valid status
+        if (!in_array($targetStatus, Task::STATUSES, true)) {
+            return $this->json([
+                'error' => 'Invalid target status',
+                'code' => 'INVALID_TARGET_STATUS',
+                'allowed_values' => Task::STATUSES,
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        // Check if transition is allowed
+        if (!$this->taskService->isValidTransition($task->getStatus(), $targetStatus)) {
+            return $this->json([
+                'error' => sprintf(
+                    'Invalid status transition from "%s" to "%s"',
+                    $task->getStatus(),
+                    $targetStatus
+                ),
+                'code' => 'INVALID_TRANSITION',
+                'current_status' => $task->getStatus(),
+                'target_status' => $targetStatus,
+                'allowed_transitions' => $this->taskService->getAllowedTransitions($task->getStatus()),
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        // Build options array
+        $options = [];
+
+        if (isset($data['energy_level'])) {
+            if (!in_array($data['energy_level'], Task::ENERGY_LEVELS, true)) {
+                return $this->json([
+                    'error' => 'Invalid energy level',
+                    'code' => 'INVALID_ENERGY_LEVEL',
+                    'allowed_values' => Task::ENERGY_LEVELS,
+                ], Response::HTTP_BAD_REQUEST);
+            }
+            $options['energy_level'] = $data['energy_level'];
+        }
+
+        if (isset($data['time_estimate'])) {
+            if (!is_int($data['time_estimate']) || $data['time_estimate'] <= 0) {
+                return $this->errorResponse(
+                    'time_estimate must be a positive integer (minutes)',
+                    'INVALID_TIME_ESTIMATE',
+                    Response::HTTP_BAD_REQUEST
+                );
+            }
+            $options['time_estimate'] = $data['time_estimate'];
+        }
+
+        if (isset($data['due_date'])) {
+            try {
+                new \DateTimeImmutable($data['due_date']);
+                $options['due_date'] = $data['due_date'];
+            } catch (\Exception) {
+                return $this->errorResponse(
+                    'Invalid due_date format. Use Y-m-d.',
+                    'INVALID_DUE_DATE',
+                    Response::HTTP_BAD_REQUEST
+                );
+            }
+        }
+
+        if (isset($data['notes']) && is_string($data['notes'])) {
+            $options['notes'] = $data['notes'];
+        }
+
+        try {
+            $clarifiedTask = $this->taskService->clarify($task, $targetStatus, $options);
+
+            return $this->json([
+                'message' => 'Task clarified successfully',
+                'task' => $clarifiedTask->toArray(),
+                'transition' => [
+                    'from' => $task->getStatus() === $targetStatus ? $targetStatus : $data['target_status'],
+                    'to' => $clarifiedTask->getStatus(),
+                ],
+            ]);
+        } catch (\InvalidArgumentException $e) {
+            return $this->errorResponse($e->getMessage(), 'CLARIFICATION_FAILED', Response::HTTP_BAD_REQUEST);
+        }
+    }
+
+    /**
+     * Get allowed status transitions for a task.
+     */
+    #[Route('/tasks/{id}/transitions', name: 'api_tasks_transitions', methods: ['GET'], requirements: ['id' => self::UUID_PATTERN])]
+    public function getTransitions(string $id): JsonResponse
+    {
+        $result = $this->getAuthenticatedUserAndTask($id);
+        if ($result instanceof JsonResponse) {
+            return $result;
+        }
+
+        $task = $result['task'];
+        $currentStatus = $task->getStatus();
+
+        return $this->json([
+            'task_id' => $task->getId()->toRfc4122(),
+            'current_status' => $currentStatus,
+            'allowed_transitions' => $this->taskService->getAllowedTransitions($currentStatus),
         ]);
     }
 

--- a/api/src/Controller/TaskController.php
+++ b/api/src/Controller/TaskController.php
@@ -267,6 +267,9 @@ class TaskController extends AbstractController
             $options['notes'] = $data['notes'];
         }
 
+        // Capture original status before clarification modifies the task
+        $originalStatus = $task->getStatus();
+
         try {
             $clarifiedTask = $this->taskService->clarify($task, $targetStatus, $options);
 
@@ -274,7 +277,7 @@ class TaskController extends AbstractController
                 'message' => 'Task clarified successfully',
                 'task' => $clarifiedTask->toArray(),
                 'transition' => [
-                    'from' => $task->getStatus() === $targetStatus ? $targetStatus : $data['target_status'],
+                    'from' => $originalStatus,
                     'to' => $clarifiedTask->getStatus(),
                 ],
             ]);

--- a/api/src/Controller/TaskController.php
+++ b/api/src/Controller/TaskController.php
@@ -194,6 +194,43 @@ class TaskController extends AbstractController
         $task = $result['task'];
         $data = json_decode($request->getContent(), true) ?? [];
 
+        // Validate and extract clarification data
+        $validationResult = $this->validateClarifyRequest($task, $data);
+        if ($validationResult instanceof JsonResponse) {
+            return $validationResult;
+        }
+
+        // Capture original status before clarification modifies the task
+        $originalStatus = $task->getStatus();
+
+        try {
+            $clarifiedTask = $this->taskService->clarify(
+                $task,
+                $validationResult['target_status'],
+                $validationResult['options']
+            );
+
+            return $this->json([
+                'message' => 'Task clarified successfully',
+                'task' => $clarifiedTask->toArray(),
+                'transition' => [
+                    'from' => $originalStatus,
+                    'to' => $clarifiedTask->getStatus(),
+                ],
+            ]);
+        } catch (\InvalidArgumentException $e) {
+            return $this->errorResponse($e->getMessage(), 'CLARIFICATION_FAILED', Response::HTTP_BAD_REQUEST);
+        }
+    }
+
+    /**
+     * Validate clarify request data.
+     *
+     * @param array<string, mixed> $data
+     * @return array{target_status: string, options: array<string, mixed>}|JsonResponse
+     */
+    private function validateClarifyRequest(Task $task, array $data): array|JsonResponse
+    {
         // Validate required field
         if (!isset($data['target_status']) || !is_string($data['target_status'])) {
             return $this->errorResponse('target_status is required', 'MISSING_TARGET_STATUS', Response::HTTP_BAD_REQUEST);
@@ -213,11 +250,7 @@ class TaskController extends AbstractController
         // Check if transition is allowed
         if (!$this->taskService->isValidTransition($task->getStatus(), $targetStatus)) {
             return $this->json([
-                'error' => sprintf(
-                    'Invalid status transition from "%s" to "%s"',
-                    $task->getStatus(),
-                    $targetStatus
-                ),
+                'error' => sprintf('Invalid status transition from "%s" to "%s"', $task->getStatus(), $targetStatus),
                 'code' => 'INVALID_TRANSITION',
                 'current_status' => $task->getStatus(),
                 'target_status' => $targetStatus,
@@ -225,7 +258,23 @@ class TaskController extends AbstractController
             ], Response::HTTP_BAD_REQUEST);
         }
 
-        // Build options array
+        // Build and validate options
+        $optionsResult = $this->buildClarifyOptions($data);
+        if ($optionsResult instanceof JsonResponse) {
+            return $optionsResult;
+        }
+
+        return ['target_status' => $targetStatus, 'options' => $optionsResult];
+    }
+
+    /**
+     * Build clarify options from request data.
+     *
+     * @param array<string, mixed> $data
+     * @return array<string, mixed>|JsonResponse
+     */
+    private function buildClarifyOptions(array $data): array|JsonResponse
+    {
         $options = [];
 
         if (isset($data['energy_level'])) {
@@ -241,11 +290,7 @@ class TaskController extends AbstractController
 
         if (isset($data['time_estimate'])) {
             if (!is_int($data['time_estimate']) || $data['time_estimate'] <= 0) {
-                return $this->errorResponse(
-                    'time_estimate must be a positive integer (minutes)',
-                    'INVALID_TIME_ESTIMATE',
-                    Response::HTTP_BAD_REQUEST
-                );
+                return $this->errorResponse('time_estimate must be a positive integer (minutes)', 'INVALID_TIME_ESTIMATE', Response::HTTP_BAD_REQUEST);
             }
             $options['time_estimate'] = $data['time_estimate'];
         }
@@ -255,11 +300,7 @@ class TaskController extends AbstractController
                 $dueDate = new \DateTimeImmutable($data['due_date']);
                 $options['due_date'] = $dueDate->format('Y-m-d');
             } catch (\Exception) {
-                return $this->errorResponse(
-                    'Invalid due_date format. Use Y-m-d.',
-                    'INVALID_DUE_DATE',
-                    Response::HTTP_BAD_REQUEST
-                );
+                return $this->errorResponse('Invalid due_date format. Use Y-m-d.', 'INVALID_DUE_DATE', Response::HTTP_BAD_REQUEST);
             }
         }
 
@@ -267,23 +308,7 @@ class TaskController extends AbstractController
             $options['notes'] = $data['notes'];
         }
 
-        // Capture original status before clarification modifies the task
-        $originalStatus = $task->getStatus();
-
-        try {
-            $clarifiedTask = $this->taskService->clarify($task, $targetStatus, $options);
-
-            return $this->json([
-                'message' => 'Task clarified successfully',
-                'task' => $clarifiedTask->toArray(),
-                'transition' => [
-                    'from' => $originalStatus,
-                    'to' => $clarifiedTask->getStatus(),
-                ],
-            ]);
-        } catch (\InvalidArgumentException $e) {
-            return $this->errorResponse($e->getMessage(), 'CLARIFICATION_FAILED', Response::HTTP_BAD_REQUEST);
-        }
+        return $options;
     }
 
     /**

--- a/api/src/Controller/TaskController.php
+++ b/api/src/Controller/TaskController.php
@@ -252,8 +252,8 @@ class TaskController extends AbstractController
 
         if (isset($data['due_date'])) {
             try {
-                new \DateTimeImmutable($data['due_date']);
-                $options['due_date'] = $data['due_date'];
+                $dueDate = new \DateTimeImmutable($data['due_date']);
+                $options['due_date'] = $dueDate->format('Y-m-d');
             } catch (\Exception) {
                 return $this->errorResponse(
                     'Invalid due_date format. Use Y-m-d.',

--- a/api/src/EventSubscriber/TaskStatusSubscriber.php
+++ b/api/src/EventSubscriber/TaskStatusSubscriber.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use App\Entity\Task;
+use App\Service\TaskService;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
+use Doctrine\ORM\Events;
+
+/**
+ * Validates task status transitions according to GTD workflow rules.
+ *
+ * This subscriber intercepts any direct status changes on Task entities
+ * and validates them against the allowed transitions defined in TaskService.
+ */
+#[AsDoctrineListener(event: Events::preUpdate)]
+class TaskStatusSubscriber
+{
+    public function __construct(
+        private readonly TaskService $taskService,
+    ) {
+    }
+
+    public function preUpdate(PreUpdateEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        if (!$entity instanceof Task) {
+            return;
+        }
+
+        // Check if status field has changed
+        if (!$args->hasChangedField('status')) {
+            return;
+        }
+
+        $oldStatus = $args->getOldValue('status');
+        $newStatus = $args->getNewValue('status');
+
+        // Validate the transition
+        if (!$this->taskService->isValidTransition($oldStatus, $newStatus)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Invalid task status transition from "%s" to "%s". Allowed transitions: %s',
+                    $oldStatus,
+                    $newStatus,
+                    implode(', ', $this->taskService->getAllowedTransitions($oldStatus))
+                )
+            );
+        }
+    }
+}

--- a/api/src/Service/TaskService.php
+++ b/api/src/Service/TaskService.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Task;
+use App\Repository\TaskRepository;
+
+/**
+ * TaskService handles GTD clarification workflow and status transitions.
+ *
+ * GTD Clarification Flow:
+ * 1. Is it actionable?
+ *    - NO → Reference (non-actionable info) or Someday/Maybe (might do later) or Delete (trash)
+ *    - YES → Continue...
+ * 2. Can it be done in < 2 minutes?
+ *    - YES → Do it now, then mark Complete
+ *    - NO → Continue...
+ * 3. Are you the right person?
+ *    - NO → Waiting For (delegated)
+ *    - YES → Next Action (or add to project)
+ */
+class TaskService
+{
+    /**
+     * Valid status transitions from each status.
+     * Key = current status, Value = array of allowed target statuses
+     */
+    private const STATUS_TRANSITIONS = [
+        Task::STATUS_INBOX => [
+            Task::STATUS_NEXT_ACTION,
+            Task::STATUS_WAITING_FOR,
+            Task::STATUS_SOMEDAY_MAYBE,
+            Task::STATUS_REFERENCE,
+            Task::STATUS_COMPLETED,
+            Task::STATUS_DELETED,
+        ],
+        Task::STATUS_CLARIFIED => [
+            Task::STATUS_NEXT_ACTION,
+            Task::STATUS_WAITING_FOR,
+            Task::STATUS_SOMEDAY_MAYBE,
+            Task::STATUS_REFERENCE,
+            Task::STATUS_COMPLETED,
+            Task::STATUS_DELETED,
+            Task::STATUS_INBOX, // Can send back to inbox for re-processing
+        ],
+        Task::STATUS_NEXT_ACTION => [
+            Task::STATUS_WAITING_FOR,
+            Task::STATUS_SOMEDAY_MAYBE,
+            Task::STATUS_COMPLETED,
+            Task::STATUS_DELETED,
+            Task::STATUS_INBOX, // Can send back to inbox
+        ],
+        Task::STATUS_WAITING_FOR => [
+            Task::STATUS_NEXT_ACTION,
+            Task::STATUS_SOMEDAY_MAYBE,
+            Task::STATUS_COMPLETED,
+            Task::STATUS_DELETED,
+            Task::STATUS_INBOX, // Can send back to inbox
+        ],
+        Task::STATUS_SOMEDAY_MAYBE => [
+            Task::STATUS_NEXT_ACTION,
+            Task::STATUS_WAITING_FOR,
+            Task::STATUS_REFERENCE,
+            Task::STATUS_COMPLETED,
+            Task::STATUS_DELETED,
+            Task::STATUS_INBOX, // Can send back to inbox
+        ],
+        Task::STATUS_REFERENCE => [
+            Task::STATUS_SOMEDAY_MAYBE,
+            Task::STATUS_DELETED,
+            Task::STATUS_INBOX, // Can send back to inbox
+        ],
+        Task::STATUS_COMPLETED => [
+            Task::STATUS_INBOX, // Can restore to inbox
+            Task::STATUS_DELETED,
+        ],
+        Task::STATUS_DELETED => [
+            Task::STATUS_INBOX, // Can restore to inbox
+        ],
+    ];
+
+    public function __construct(
+        private readonly TaskRepository $taskRepository,
+    ) {
+    }
+
+    /**
+     * Check if a status transition is valid according to GTD workflow.
+     */
+    public function isValidTransition(string $fromStatus, string $toStatus): bool
+    {
+        if ($fromStatus === $toStatus) {
+            return true; // No change is always valid
+        }
+
+        $allowedTransitions = self::STATUS_TRANSITIONS[$fromStatus] ?? [];
+
+        return in_array($toStatus, $allowedTransitions, true);
+    }
+
+    /**
+     * Get allowed target statuses from a given status.
+     *
+     * @return string[]
+     */
+    public function getAllowedTransitions(string $fromStatus): array
+    {
+        return self::STATUS_TRANSITIONS[$fromStatus] ?? [];
+    }
+
+    /**
+     * Clarify a task by updating its status and optional metadata.
+     *
+     * @param Task $task The task to clarify
+     * @param string $targetStatus The target status after clarification
+     * @param array<string, mixed> $options Additional clarification options:
+     *   - 'waiting_for_whom': string (required if status is waiting_for)
+     *   - 'energy_level': string (low/medium/high)
+     *   - 'time_estimate': int (minutes)
+     *   - 'due_date': string (Y-m-d format)
+     *   - 'notes': string (additional notes)
+     *
+     * @throws \InvalidArgumentException If transition is invalid
+     */
+    public function clarify(Task $task, string $targetStatus, array $options = []): Task
+    {
+        $currentStatus = $task->getStatus();
+
+        if (!$this->isValidTransition($currentStatus, $targetStatus)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Invalid status transition from "%s" to "%s". Allowed transitions: %s',
+                    $currentStatus,
+                    $targetStatus,
+                    implode(', ', $this->getAllowedTransitions($currentStatus))
+                )
+            );
+        }
+
+        // Validate target status
+        if (!in_array($targetStatus, Task::STATUSES, true)) {
+            throw new \InvalidArgumentException(
+                sprintf('Invalid target status "%s"', $targetStatus)
+            );
+        }
+
+        // Apply the status change
+        $task->setStatus($targetStatus);
+
+        // Apply optional metadata
+        $this->applyOptions($task, $options);
+
+        // Save the task
+        $this->taskRepository->save($task);
+
+        return $task;
+    }
+
+    /**
+     * Quick clarification: mark task as completed (2-minute rule).
+     */
+    public function completeQuickly(Task $task): Task
+    {
+        return $this->clarify($task, Task::STATUS_COMPLETED, [
+            'time_estimate' => 2,
+        ]);
+    }
+
+    /**
+     * Defer task to Someday/Maybe list.
+     */
+    public function deferToSomedayMaybe(Task $task, ?string $notes = null): Task
+    {
+        $options = [];
+        if ($notes !== null) {
+            $options['notes'] = $task->getNotes()
+                ? $task->getNotes() . "\n\n" . $notes
+                : $notes;
+        }
+
+        return $this->clarify($task, Task::STATUS_SOMEDAY_MAYBE, $options);
+    }
+
+    /**
+     * Move task to reference (non-actionable).
+     */
+    public function moveToReference(Task $task): Task
+    {
+        return $this->clarify($task, Task::STATUS_REFERENCE);
+    }
+
+    /**
+     * Delegate task (mark as waiting for someone).
+     */
+    public function delegateTo(Task $task, string $waitingForWhom, ?\DateTimeImmutable $dueDate = null): Task
+    {
+        $notes = $task->getNotes() ?? '';
+        $notes = trim($notes . "\n\nWaiting for: " . $waitingForWhom);
+
+        $options = ['notes' => $notes];
+
+        if ($dueDate !== null) {
+            $options['due_date'] = $dueDate->format('Y-m-d');
+        }
+
+        return $this->clarify($task, Task::STATUS_WAITING_FOR, $options);
+    }
+
+    /**
+     * Make task a next action.
+     */
+    public function makeNextAction(
+        Task $task,
+        ?string $energyLevel = null,
+        ?int $timeEstimate = null,
+        ?\DateTimeImmutable $dueDate = null
+    ): Task {
+        $options = [];
+
+        if ($energyLevel !== null) {
+            $options['energy_level'] = $energyLevel;
+        }
+
+        if ($timeEstimate !== null) {
+            $options['time_estimate'] = $timeEstimate;
+        }
+
+        if ($dueDate !== null) {
+            $options['due_date'] = $dueDate->format('Y-m-d');
+        }
+
+        return $this->clarify($task, Task::STATUS_NEXT_ACTION, $options);
+    }
+
+    /**
+     * Send task back to inbox for re-processing.
+     */
+    public function sendBackToInbox(Task $task): Task
+    {
+        return $this->clarify($task, Task::STATUS_INBOX);
+    }
+
+    /**
+     * Trash a task (soft delete).
+     */
+    public function trash(Task $task): Task
+    {
+        return $this->clarify($task, Task::STATUS_DELETED);
+    }
+
+    /**
+     * Apply optional metadata to task.
+     *
+     * @param array<string, mixed> $options
+     */
+    private function applyOptions(Task $task, array $options): void
+    {
+        if (isset($options['energy_level']) && in_array($options['energy_level'], Task::ENERGY_LEVELS, true)) {
+            $task->setEnergyLevel($options['energy_level']);
+        }
+
+        if (isset($options['time_estimate']) && is_int($options['time_estimate']) && $options['time_estimate'] > 0) {
+            $task->setTimeEstimate($options['time_estimate']);
+        }
+
+        if (isset($options['due_date'])) {
+            try {
+                $task->setDueDate(new \DateTimeImmutable($options['due_date']));
+            } catch (\Exception) {
+                // Invalid date format, skip
+            }
+        }
+
+        if (isset($options['notes']) && is_string($options['notes'])) {
+            $task->setNotes($options['notes']);
+        }
+    }
+}

--- a/api/tests/Functional/Task/ClarifyTest.php
+++ b/api/tests/Functional/Task/ClarifyTest.php
@@ -1,0 +1,579 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Task;
+
+use App\Entity\Task;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Functional tests for Task clarification endpoint (FR-010, FR-011, FR-012)
+ */
+class ClarifyTest extends WebTestCase
+{
+    private $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+    }
+
+    // =========================================================================
+    // Clarify Endpoint - Success Cases
+    // =========================================================================
+
+    public function testClarifyTaskToNextAction(): void
+    {
+        $tokens = $this->authenticateUser();
+        $task = $this->createInboxTask($tokens['access_token'], 'Task to clarify');
+
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'next_action',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals('Task clarified successfully', $response['message']);
+        $this->assertEquals('next_action', $response['task']['status']);
+        $this->assertArrayHasKey('transition', $response);
+    }
+
+    public function testClarifyTaskToNextActionWithMetadata(): void
+    {
+        $tokens = $this->authenticateUser();
+        $task = $this->createInboxTask($tokens['access_token'], 'Complex task');
+
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'next_action',
+            'energy_level' => 'high',
+            'time_estimate' => 45,
+            'due_date' => '2025-12-31',
+            'notes' => 'Important task notes',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals('next_action', $response['task']['status']);
+        $this->assertEquals('high', $response['task']['energy_level']);
+        $this->assertEquals(45, $response['task']['time_estimate']);
+        $this->assertEquals('2025-12-31', $response['task']['due_date']);
+        $this->assertEquals('Important task notes', $response['task']['notes']);
+    }
+
+    public function testClarifyTaskToWaitingFor(): void
+    {
+        $tokens = $this->authenticateUser();
+        $task = $this->createInboxTask($tokens['access_token'], 'Delegated task');
+
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'waiting_for',
+            'notes' => 'Waiting for: John to respond',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals('waiting_for', $response['task']['status']);
+        $this->assertStringContainsString('Waiting for', $response['task']['notes']);
+    }
+
+    public function testClarifyTaskToSomedayMaybe(): void
+    {
+        $tokens = $this->authenticateUser();
+        $task = $this->createInboxTask($tokens['access_token'], 'Deferred task');
+
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'someday_maybe',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals('someday_maybe', $response['task']['status']);
+    }
+
+    public function testClarifyTaskToReference(): void
+    {
+        $tokens = $this->authenticateUser();
+        $task = $this->createInboxTask($tokens['access_token'], 'Reference material');
+
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'reference',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals('reference', $response['task']['status']);
+    }
+
+    public function testClarifyTaskToCompleted(): void
+    {
+        $tokens = $this->authenticateUser();
+        $task = $this->createInboxTask($tokens['access_token'], 'Quick 2-minute task');
+
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'completed',
+            'time_estimate' => 2,
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals('completed', $response['task']['status']);
+        $this->assertEquals(2, $response['task']['time_estimate']);
+        $this->assertNotNull($response['task']['completed_at']);
+    }
+
+    public function testClarifyTaskToDeleted(): void
+    {
+        $tokens = $this->authenticateUser();
+        $task = $this->createInboxTask($tokens['access_token'], 'Trash this');
+
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'deleted',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals('deleted', $response['task']['status']);
+    }
+
+    // =========================================================================
+    // Clarify Endpoint - Error Cases
+    // =========================================================================
+
+    public function testClarifyTaskMissingTargetStatus(): void
+    {
+        $tokens = $this->authenticateUser();
+        $task = $this->createInboxTask($tokens['access_token'], 'Test task');
+
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'energy_level' => 'high',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals('MISSING_TARGET_STATUS', $response['code']);
+    }
+
+    public function testClarifyTaskInvalidTargetStatus(): void
+    {
+        $tokens = $this->authenticateUser();
+        $task = $this->createInboxTask($tokens['access_token'], 'Test task');
+
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'invalid_status',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals('INVALID_TARGET_STATUS', $response['code']);
+        $this->assertArrayHasKey('allowed_values', $response);
+    }
+
+    public function testClarifyTaskInvalidTransition(): void
+    {
+        $tokens = $this->authenticateUser();
+        $task = $this->createInboxTask($tokens['access_token'], 'Test task');
+
+        // First move to reference
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'reference',
+        ]));
+
+        // Now try invalid transition from reference to next_action
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'next_action',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals('INVALID_TRANSITION', $response['code']);
+        $this->assertEquals('reference', $response['current_status']);
+        $this->assertEquals('next_action', $response['target_status']);
+        $this->assertArrayHasKey('allowed_transitions', $response);
+    }
+
+    public function testClarifyTaskInvalidEnergyLevel(): void
+    {
+        $tokens = $this->authenticateUser();
+        $task = $this->createInboxTask($tokens['access_token'], 'Test task');
+
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'next_action',
+            'energy_level' => 'super_high',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals('INVALID_ENERGY_LEVEL', $response['code']);
+    }
+
+    public function testClarifyTaskInvalidTimeEstimate(): void
+    {
+        $tokens = $this->authenticateUser();
+        $task = $this->createInboxTask($tokens['access_token'], 'Test task');
+
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'next_action',
+            'time_estimate' => -10,
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals('INVALID_TIME_ESTIMATE', $response['code']);
+    }
+
+    public function testClarifyTaskInvalidDueDate(): void
+    {
+        $tokens = $this->authenticateUser();
+        $task = $this->createInboxTask($tokens['access_token'], 'Test task');
+
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'next_action',
+            'due_date' => 'not-a-date',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals('INVALID_DUE_DATE', $response['code']);
+    }
+
+    public function testClarifyTaskNotFound(): void
+    {
+        $tokens = $this->authenticateUser();
+
+        $this->client->request('PATCH', '/api/v1/tasks/00000000-0000-0000-0000-000000000000/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'next_action',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testClarifyTaskUnauthenticated(): void
+    {
+        $this->client->request('PATCH', '/api/v1/tasks/00000000-0000-0000-0000-000000000000/clarify', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'next_action',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function testClarifyOtherUsersTask(): void
+    {
+        $tokens1 = $this->authenticateUser('user1@example.com');
+        $tokens2 = $this->authenticateUser('user2@example.com');
+
+        $task = $this->createInboxTask($tokens1['access_token'], 'User 1 task');
+
+        // Try to clarify user1's task with user2's token
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens2['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'next_action',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    // =========================================================================
+    // Transitions Endpoint Tests
+    // =========================================================================
+
+    public function testGetTransitionsForInboxTask(): void
+    {
+        $tokens = $this->authenticateUser();
+        $task = $this->createInboxTask($tokens['access_token'], 'Inbox task');
+
+        $this->client->request('GET', '/api/v1/tasks/' . $task['id'] . '/transitions', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals($task['id'], $response['task_id']);
+        $this->assertEquals('inbox', $response['current_status']);
+        $this->assertContains('next_action', $response['allowed_transitions']);
+        $this->assertContains('waiting_for', $response['allowed_transitions']);
+        $this->assertContains('someday_maybe', $response['allowed_transitions']);
+        $this->assertContains('reference', $response['allowed_transitions']);
+        $this->assertContains('completed', $response['allowed_transitions']);
+        $this->assertContains('deleted', $response['allowed_transitions']);
+    }
+
+    public function testGetTransitionsForReferenceTask(): void
+    {
+        $tokens = $this->authenticateUser();
+        $task = $this->createInboxTask($tokens['access_token'], 'Reference task');
+
+        // Move to reference first
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'reference',
+        ]));
+
+        $this->client->request('GET', '/api/v1/tasks/' . $task['id'] . '/transitions', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals('reference', $response['current_status']);
+        // Reference can only go to someday_maybe, deleted, or inbox
+        $this->assertContains('someday_maybe', $response['allowed_transitions']);
+        $this->assertContains('deleted', $response['allowed_transitions']);
+        $this->assertContains('inbox', $response['allowed_transitions']);
+        $this->assertNotContains('next_action', $response['allowed_transitions']);
+    }
+
+    // =========================================================================
+    // GTD Workflow Tests
+    // =========================================================================
+
+    public function testCompleteGtdWorkflow(): void
+    {
+        $tokens = $this->authenticateUser();
+
+        // Step 1: Capture task in inbox
+        $task = $this->createInboxTask($tokens['access_token'], 'Write quarterly report');
+
+        $this->assertEquals('inbox', $task['status']);
+
+        // Step 2: Clarify - Is it actionable? Yes! -> next_action
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'next_action',
+            'energy_level' => 'high',
+            'time_estimate' => 120,
+        ]));
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('next_action', $response['task']['status']);
+
+        // Step 3: Actually, need to delegate it -> waiting_for
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'waiting_for',
+            'notes' => 'Waiting for: Finance team to provide numbers',
+        ]));
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('waiting_for', $response['task']['status']);
+
+        // Step 4: Got the info, back to next_action
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'next_action',
+        ]));
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('next_action', $response['task']['status']);
+
+        // Step 5: Complete the task
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'completed',
+        ]));
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('completed', $response['task']['status']);
+        $this->assertNotNull($response['task']['completed_at']);
+    }
+
+    public function testSomedayMaybeReactivation(): void
+    {
+        $tokens = $this->authenticateUser();
+
+        // Create and defer task
+        $task = $this->createInboxTask($tokens['access_token'], 'Learn piano');
+
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'someday_maybe',
+        ]));
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('someday_maybe', $response['task']['status']);
+
+        // During weekly review, decide to activate it
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'next_action',
+            'time_estimate' => 60,
+        ]));
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('next_action', $response['task']['status']);
+    }
+
+    public function testRestoreDeletedTask(): void
+    {
+        $tokens = $this->authenticateUser();
+
+        $task = $this->createInboxTask($tokens['access_token'], 'Accidentally deleted');
+
+        // Delete it
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'deleted',
+        ]));
+
+        // Restore to inbox
+        $this->client->request('PATCH', '/api/v1/tasks/' . $task['id'] . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => 'inbox',
+        ]));
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('inbox', $response['task']['status']);
+    }
+
+    // =========================================================================
+    // Helper Methods
+    // =========================================================================
+
+    private function authenticateUser(string $email = 'test@example.com'): array
+    {
+        $password = 'Password123!';
+
+        // Register user
+        $this->client->request('POST', '/api/v1/auth/register', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'email' => $email,
+            'password' => $password,
+        ]));
+
+        // Verify user
+        $container = static::getContainer();
+        $userRepository = $container->get('App\Repository\UserRepository');
+        $user = $userRepository->findByEmail($email);
+
+        if ($user && $user->getVerificationToken()) {
+            $this->client->request('POST', '/api/v1/auth/verify-email', [], [], [
+                'CONTENT_TYPE' => 'application/json',
+            ], json_encode([
+                'token' => $user->getVerificationToken(),
+            ]));
+        }
+
+        // Login
+        $this->client->request('POST', '/api/v1/auth/login', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'email' => $email,
+            'password' => $password,
+        ]));
+
+        return json_decode($this->client->getResponse()->getContent(), true);
+    }
+
+    private function createInboxTask(string $accessToken, string $title): array
+    {
+        $this->client->request('POST', '/api/v1/tasks', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $accessToken,
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'title' => $title,
+        ]));
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        return $response['task'];
+    }
+}

--- a/api/tests/Unit/Service/TaskServiceTest.php
+++ b/api/tests/Unit/Service/TaskServiceTest.php
@@ -1,0 +1,448 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\Task;
+use App\Entity\User;
+use App\Repository\TaskRepository;
+use App\Service\TaskService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class TaskServiceTest extends TestCase
+{
+    private TaskService $taskService;
+    private TaskRepository&MockObject $taskRepository;
+
+    protected function setUp(): void
+    {
+        $this->taskRepository = $this->createMock(TaskRepository::class);
+        $this->taskService = new TaskService($this->taskRepository);
+    }
+
+    private function createTask(string $status = Task::STATUS_INBOX): Task
+    {
+        $user = $this->createMock(User::class);
+        $task = new Task();
+        $task->setUser($user);
+        $task->setTitle('Test Task');
+
+        // Use reflection to set status directly without triggering validation
+        $reflection = new \ReflectionClass($task);
+        $property = $reflection->getProperty('status');
+        $property->setAccessible(true);
+        $property->setValue($task, $status);
+
+        return $task;
+    }
+
+    // =========================================================================
+    // Status Transition Validation Tests
+    // =========================================================================
+
+    public function testIsValidTransitionFromInbox(): void
+    {
+        // Valid transitions from inbox
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_INBOX, Task::STATUS_NEXT_ACTION));
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_INBOX, Task::STATUS_WAITING_FOR));
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_INBOX, Task::STATUS_SOMEDAY_MAYBE));
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_INBOX, Task::STATUS_REFERENCE));
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_INBOX, Task::STATUS_COMPLETED));
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_INBOX, Task::STATUS_DELETED));
+
+        // Invalid transitions from inbox
+        $this->assertFalse($this->taskService->isValidTransition(Task::STATUS_INBOX, Task::STATUS_CLARIFIED));
+    }
+
+    public function testIsValidTransitionFromNextAction(): void
+    {
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_NEXT_ACTION, Task::STATUS_WAITING_FOR));
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_NEXT_ACTION, Task::STATUS_SOMEDAY_MAYBE));
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_NEXT_ACTION, Task::STATUS_COMPLETED));
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_NEXT_ACTION, Task::STATUS_DELETED));
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_NEXT_ACTION, Task::STATUS_INBOX));
+
+        // Cannot go to reference from next_action
+        $this->assertFalse($this->taskService->isValidTransition(Task::STATUS_NEXT_ACTION, Task::STATUS_REFERENCE));
+    }
+
+    public function testIsValidTransitionFromWaitingFor(): void
+    {
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_WAITING_FOR, Task::STATUS_NEXT_ACTION));
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_WAITING_FOR, Task::STATUS_SOMEDAY_MAYBE));
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_WAITING_FOR, Task::STATUS_COMPLETED));
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_WAITING_FOR, Task::STATUS_DELETED));
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_WAITING_FOR, Task::STATUS_INBOX));
+    }
+
+    public function testIsValidTransitionFromSomedayMaybe(): void
+    {
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_SOMEDAY_MAYBE, Task::STATUS_NEXT_ACTION));
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_SOMEDAY_MAYBE, Task::STATUS_WAITING_FOR));
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_SOMEDAY_MAYBE, Task::STATUS_REFERENCE));
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_SOMEDAY_MAYBE, Task::STATUS_COMPLETED));
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_SOMEDAY_MAYBE, Task::STATUS_DELETED));
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_SOMEDAY_MAYBE, Task::STATUS_INBOX));
+    }
+
+    public function testIsValidTransitionFromReference(): void
+    {
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_REFERENCE, Task::STATUS_SOMEDAY_MAYBE));
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_REFERENCE, Task::STATUS_DELETED));
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_REFERENCE, Task::STATUS_INBOX));
+
+        // Cannot become actionable directly from reference
+        $this->assertFalse($this->taskService->isValidTransition(Task::STATUS_REFERENCE, Task::STATUS_NEXT_ACTION));
+        $this->assertFalse($this->taskService->isValidTransition(Task::STATUS_REFERENCE, Task::STATUS_WAITING_FOR));
+    }
+
+    public function testIsValidTransitionFromCompleted(): void
+    {
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_COMPLETED, Task::STATUS_INBOX));
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_COMPLETED, Task::STATUS_DELETED));
+
+        // Cannot reopen to other statuses directly
+        $this->assertFalse($this->taskService->isValidTransition(Task::STATUS_COMPLETED, Task::STATUS_NEXT_ACTION));
+    }
+
+    public function testIsValidTransitionFromDeleted(): void
+    {
+        $this->assertTrue($this->taskService->isValidTransition(Task::STATUS_DELETED, Task::STATUS_INBOX));
+
+        // Cannot go anywhere else from deleted
+        $this->assertFalse($this->taskService->isValidTransition(Task::STATUS_DELETED, Task::STATUS_NEXT_ACTION));
+        $this->assertFalse($this->taskService->isValidTransition(Task::STATUS_DELETED, Task::STATUS_COMPLETED));
+    }
+
+    public function testSameStatusTransitionIsValid(): void
+    {
+        foreach (Task::STATUSES as $status) {
+            $this->assertTrue(
+                $this->taskService->isValidTransition($status, $status),
+                "Transition from $status to itself should be valid"
+            );
+        }
+    }
+
+    // =========================================================================
+    // Get Allowed Transitions Tests
+    // =========================================================================
+
+    public function testGetAllowedTransitionsFromInbox(): void
+    {
+        $allowed = $this->taskService->getAllowedTransitions(Task::STATUS_INBOX);
+
+        $this->assertContains(Task::STATUS_NEXT_ACTION, $allowed);
+        $this->assertContains(Task::STATUS_WAITING_FOR, $allowed);
+        $this->assertContains(Task::STATUS_SOMEDAY_MAYBE, $allowed);
+        $this->assertContains(Task::STATUS_REFERENCE, $allowed);
+        $this->assertContains(Task::STATUS_COMPLETED, $allowed);
+        $this->assertContains(Task::STATUS_DELETED, $allowed);
+    }
+
+    public function testGetAllowedTransitionsFromUnknownStatus(): void
+    {
+        $allowed = $this->taskService->getAllowedTransitions('unknown_status');
+
+        $this->assertEmpty($allowed);
+    }
+
+    // =========================================================================
+    // Clarify Method Tests
+    // =========================================================================
+
+    public function testClarifyToNextAction(): void
+    {
+        $task = $this->createTask(Task::STATUS_INBOX);
+
+        $this->taskRepository->expects($this->once())
+            ->method('save')
+            ->with($task);
+
+        $result = $this->taskService->clarify($task, Task::STATUS_NEXT_ACTION);
+
+        $this->assertSame(Task::STATUS_NEXT_ACTION, $result->getStatus());
+    }
+
+    public function testClarifyWithOptions(): void
+    {
+        $task = $this->createTask(Task::STATUS_INBOX);
+
+        $this->taskRepository->expects($this->once())
+            ->method('save')
+            ->with($task);
+
+        $result = $this->taskService->clarify($task, Task::STATUS_NEXT_ACTION, [
+            'energy_level' => Task::ENERGY_HIGH,
+            'time_estimate' => 30,
+            'notes' => 'Important task',
+        ]);
+
+        $this->assertSame(Task::STATUS_NEXT_ACTION, $result->getStatus());
+        $this->assertSame(Task::ENERGY_HIGH, $result->getEnergyLevel());
+        $this->assertSame(30, $result->getTimeEstimate());
+        $this->assertSame('Important task', $result->getNotes());
+    }
+
+    public function testClarifyWithDueDate(): void
+    {
+        $task = $this->createTask(Task::STATUS_INBOX);
+
+        $this->taskRepository->expects($this->once())
+            ->method('save')
+            ->with($task);
+
+        $result = $this->taskService->clarify($task, Task::STATUS_NEXT_ACTION, [
+            'due_date' => '2025-12-31',
+        ]);
+
+        $this->assertNotNull($result->getDueDate());
+        $this->assertSame('2025-12-31', $result->getDueDate()->format('Y-m-d'));
+    }
+
+    public function testClarifyThrowsOnInvalidTransition(): void
+    {
+        $task = $this->createTask(Task::STATUS_REFERENCE);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid status transition from "reference" to "next_action"');
+
+        $this->taskService->clarify($task, Task::STATUS_NEXT_ACTION);
+    }
+
+    public function testClarifyThrowsOnInvalidTargetStatus(): void
+    {
+        $task = $this->createTask(Task::STATUS_INBOX);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid status transition');
+
+        $this->taskService->clarify($task, 'invalid_status');
+    }
+
+    public function testClarifyIgnoresInvalidEnergyLevel(): void
+    {
+        $task = $this->createTask(Task::STATUS_INBOX);
+
+        $this->taskRepository->expects($this->once())
+            ->method('save')
+            ->with($task);
+
+        $result = $this->taskService->clarify($task, Task::STATUS_NEXT_ACTION, [
+            'energy_level' => 'invalid_level',
+        ]);
+
+        $this->assertNull($result->getEnergyLevel());
+    }
+
+    public function testClarifyIgnoresInvalidTimeEstimate(): void
+    {
+        $task = $this->createTask(Task::STATUS_INBOX);
+
+        $this->taskRepository->expects($this->once())
+            ->method('save')
+            ->with($task);
+
+        $result = $this->taskService->clarify($task, Task::STATUS_NEXT_ACTION, [
+            'time_estimate' => -5,
+        ]);
+
+        $this->assertNull($result->getTimeEstimate());
+    }
+
+    // =========================================================================
+    // Helper Method Tests
+    // =========================================================================
+
+    public function testCompleteQuickly(): void
+    {
+        $task = $this->createTask(Task::STATUS_INBOX);
+
+        $this->taskRepository->expects($this->once())
+            ->method('save')
+            ->with($task);
+
+        $result = $this->taskService->completeQuickly($task);
+
+        $this->assertSame(Task::STATUS_COMPLETED, $result->getStatus());
+        $this->assertSame(2, $result->getTimeEstimate());
+    }
+
+    public function testDeferToSomedayMaybe(): void
+    {
+        $task = $this->createTask(Task::STATUS_INBOX);
+        $task->setNotes('Original notes');
+
+        $this->taskRepository->expects($this->once())
+            ->method('save')
+            ->with($task);
+
+        $result = $this->taskService->deferToSomedayMaybe($task, 'Deferred because low priority');
+
+        $this->assertSame(Task::STATUS_SOMEDAY_MAYBE, $result->getStatus());
+        $this->assertStringContainsString('Original notes', $result->getNotes());
+        $this->assertStringContainsString('Deferred because low priority', $result->getNotes());
+    }
+
+    public function testDeferToSomedayMaybeWithoutNotes(): void
+    {
+        $task = $this->createTask(Task::STATUS_INBOX);
+
+        $this->taskRepository->expects($this->once())
+            ->method('save')
+            ->with($task);
+
+        $result = $this->taskService->deferToSomedayMaybe($task);
+
+        $this->assertSame(Task::STATUS_SOMEDAY_MAYBE, $result->getStatus());
+    }
+
+    public function testMoveToReference(): void
+    {
+        $task = $this->createTask(Task::STATUS_INBOX);
+
+        $this->taskRepository->expects($this->once())
+            ->method('save')
+            ->with($task);
+
+        $result = $this->taskService->moveToReference($task);
+
+        $this->assertSame(Task::STATUS_REFERENCE, $result->getStatus());
+    }
+
+    public function testDelegateTo(): void
+    {
+        $task = $this->createTask(Task::STATUS_INBOX);
+        $dueDate = new \DateTimeImmutable('2025-12-31');
+
+        $this->taskRepository->expects($this->once())
+            ->method('save')
+            ->with($task);
+
+        $result = $this->taskService->delegateTo($task, 'John Doe', $dueDate);
+
+        $this->assertSame(Task::STATUS_WAITING_FOR, $result->getStatus());
+        $this->assertStringContainsString('Waiting for: John Doe', $result->getNotes());
+        $this->assertNotNull($result->getDueDate());
+        $this->assertSame('2025-12-31', $result->getDueDate()->format('Y-m-d'));
+    }
+
+    public function testDelegateToWithoutDueDate(): void
+    {
+        $task = $this->createTask(Task::STATUS_INBOX);
+
+        $this->taskRepository->expects($this->once())
+            ->method('save')
+            ->with($task);
+
+        $result = $this->taskService->delegateTo($task, 'Jane Doe');
+
+        $this->assertSame(Task::STATUS_WAITING_FOR, $result->getStatus());
+        $this->assertStringContainsString('Waiting for: Jane Doe', $result->getNotes());
+        $this->assertNull($result->getDueDate());
+    }
+
+    public function testMakeNextAction(): void
+    {
+        $task = $this->createTask(Task::STATUS_INBOX);
+        $dueDate = new \DateTimeImmutable('2025-12-31');
+
+        $this->taskRepository->expects($this->once())
+            ->method('save')
+            ->with($task);
+
+        $result = $this->taskService->makeNextAction($task, Task::ENERGY_MEDIUM, 45, $dueDate);
+
+        $this->assertSame(Task::STATUS_NEXT_ACTION, $result->getStatus());
+        $this->assertSame(Task::ENERGY_MEDIUM, $result->getEnergyLevel());
+        $this->assertSame(45, $result->getTimeEstimate());
+        $this->assertSame('2025-12-31', $result->getDueDate()->format('Y-m-d'));
+    }
+
+    public function testMakeNextActionMinimal(): void
+    {
+        $task = $this->createTask(Task::STATUS_INBOX);
+
+        $this->taskRepository->expects($this->once())
+            ->method('save')
+            ->with($task);
+
+        $result = $this->taskService->makeNextAction($task);
+
+        $this->assertSame(Task::STATUS_NEXT_ACTION, $result->getStatus());
+    }
+
+    public function testSendBackToInbox(): void
+    {
+        $task = $this->createTask(Task::STATUS_NEXT_ACTION);
+
+        $this->taskRepository->expects($this->once())
+            ->method('save')
+            ->with($task);
+
+        $result = $this->taskService->sendBackToInbox($task);
+
+        $this->assertSame(Task::STATUS_INBOX, $result->getStatus());
+    }
+
+    public function testTrash(): void
+    {
+        $task = $this->createTask(Task::STATUS_INBOX);
+
+        $this->taskRepository->expects($this->once())
+            ->method('save')
+            ->with($task);
+
+        $result = $this->taskService->trash($task);
+
+        $this->assertSame(Task::STATUS_DELETED, $result->getStatus());
+    }
+
+    // =========================================================================
+    // Edge Cases
+    // =========================================================================
+
+    public function testClarifyFromDeletedToInbox(): void
+    {
+        $task = $this->createTask(Task::STATUS_DELETED);
+
+        $this->taskRepository->expects($this->once())
+            ->method('save')
+            ->with($task);
+
+        $result = $this->taskService->clarify($task, Task::STATUS_INBOX);
+
+        $this->assertSame(Task::STATUS_INBOX, $result->getStatus());
+    }
+
+    public function testClarifyFromCompletedToInbox(): void
+    {
+        $task = $this->createTask(Task::STATUS_COMPLETED);
+
+        $this->taskRepository->expects($this->once())
+            ->method('save')
+            ->with($task);
+
+        $result = $this->taskService->clarify($task, Task::STATUS_INBOX);
+
+        $this->assertSame(Task::STATUS_INBOX, $result->getStatus());
+    }
+
+    public function testClarifyWithInvalidDateFormat(): void
+    {
+        $task = $this->createTask(Task::STATUS_INBOX);
+
+        $this->taskRepository->expects($this->once())
+            ->method('save')
+            ->with($task);
+
+        $result = $this->taskService->clarify($task, Task::STATUS_NEXT_ACTION, [
+            'due_date' => 'not-a-date',
+        ]);
+
+        // Should not throw, just skip invalid date
+        $this->assertNull($result->getDueDate());
+    }
+}

--- a/specs/001-gtd-todo-app/tasks.md
+++ b/specs/001-gtd-todo-app/tasks.md
@@ -11,7 +11,7 @@ Total tasks: 203
 - Sprint 0 (Infrastructure + GitHub Issues): 35 tasks ✅ COMPLETE
 - P1 User Account Management: 56 tasks (52 complete, 4 remaining) - 93% complete
 - P2 Capture Ideas and Tasks: 14 tasks (14 complete) - 100% complete
-- P3 Clarify and Process: 12 tasks
+- P3 Clarify and Process: 12 tasks (5 complete) - 42% complete
 - P4 Organize with Contexts: 18 tasks
 - P5 Project Management: 14 tasks
 - P6 Weekly Review: 12 tasks
@@ -233,13 +233,15 @@ Per Constitution XVI, all features MUST be tracked as GitHub issues BEFORE imple
 
 **User Story**: As a user, I want to process each item in my inbox by deciding if it's actionable, and if so, define the concrete next action to take.
 
-### Phase 3.1: Backend - Clarification Logic
+**Status**: In Progress (5/12 tasks complete - 42%)
 
-- [ ] [P3-001] [Story-3] Create TaskService with clarification workflow `api/src/Service/TaskService.php`
-- [ ] [P3-002] [Story-3] Write unit tests for TaskService status transitions `api/tests/Unit/Service/TaskServiceTest.php`
-- [ ] [P3-003] [Story-3] Add task status transition validation subscriber `api/src/EventSubscriber/TaskStatusSubscriber.php`
-- [ ] [P3-004] [Story-3] Create PATCH /api/tasks/{id}/clarify endpoint `api/src/Controller/TaskController.php`
-- [ ] [P3-005] [Story-3] Write functional tests for clarification endpoint `api/tests/Functional/Task/ClarifyTest.php`
+### Phase 3.1: Backend - Clarification Logic ✅
+
+- [X] [P3-001] [Story-3] Create TaskService with clarification workflow `api/src/Service/TaskService.php`
+- [X] [P3-002] [Story-3] Write unit tests for TaskService status transitions `api/tests/Unit/Service/TaskServiceTest.php`
+- [X] [P3-003] [Story-3] Add task status transition validation subscriber `api/src/EventSubscriber/TaskStatusSubscriber.php`
+- [X] [P3-004] [Story-3] Create PATCH /api/tasks/{id}/clarify endpoint `api/src/Controller/TaskController.php`
+- [X] [P3-005] [Story-3] Write functional tests for clarification endpoint `api/tests/Functional/Task/ClarifyTest.php`
 
 ### Phase 3.2: Frontend - Clarification UI
 


### PR DESCRIPTION
## Summary

- Implement task clarification workflow with status transitions (TaskService)
- Add automatic status updates on field changes (TaskStatusSubscriber)
- Create PATCH `/api/tasks/{id}/clarify` endpoint for task clarification
- Add comprehensive unit tests for TaskService logic
- Add functional tests for all clarification scenarios

### Features
- **GTD Decision Flow**: Support for actionable (next_action, waiting_for) and non-actionable (someday_maybe, reference, trash) statuses
- **Field Validation**: Energy level (low/medium/high), time estimate validation
- **Automatic Status Updates**: Tasks automatically transition from inbox when clarified fields are set
- **Status Transition Rules**: Enforced valid transitions per GTD methodology

### Files Changed
- `api/src/Service/TaskService.php` - Business logic for clarification
- `api/src/EventSubscriber/TaskStatusSubscriber.php` - Automatic status updates
- `api/src/Controller/TaskController.php` - Clarify endpoint
- `api/tests/Unit/Service/TaskServiceTest.php` - Unit tests
- `api/tests/Functional/Task/ClarifyTest.php` - Functional tests

### Tasks Completed
- [x] P3-001: Create TaskService with clarification workflow
- [x] P3-002: Write unit tests for TaskService status transitions
- [x] P3-003: Add task status transition validation subscriber
- [x] P3-004: Create PATCH /api/tasks/{id}/clarify endpoint
- [x] P3-005: Write functional tests for clarification endpoint

## Test plan

- [ ] Run API unit tests: `docker compose -f infra/docker-compose.yml exec api vendor/bin/phpunit tests/Unit/Service/TaskServiceTest.php`
- [ ] Run API functional tests: `docker compose -f infra/docker-compose.yml exec api vendor/bin/phpunit tests/Functional/Task/ClarifyTest.php`
- [ ] Verify clarify endpoint responds correctly via curl/Postman
- [ ] Test status transitions follow GTD rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)