### PR TITLE
fix(config): configure MailHog for local development emails

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -19,9 +19,17 @@ CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 ###< nelmio/cors-bundle ###
 
 ###> Resend Email API ###
-RESEND_API_KEY=re_changeme
+# Leave empty for local development (uses SMTP/MailHog via MAILER_DSN)
+# Set actual API key in Render for dev/prod environments
+RESEND_API_KEY=
 FROM_EMAIL=noreply@gtd-app.com
+MAILER_FROM_ADDRESS=noreply@gtd-app.com
 ###< Resend Email API ###
+
+###> symfony/mailer ###
+# Local development: uses MailHog via Docker
+MAILER_DSN=smtp://gtd_mailhog:1025
+###< symfony/mailer ###
 
 ###> App Configuration ###
 APP_URL=http://localhost:8000


### PR DESCRIPTION
## Summary
- Empty `RESEND_API_KEY` by default so local dev uses SMTP/MailHog instead of Resend API
- Add missing `MAILER_FROM_ADDRESS` env var required by `mailer.yaml`
- Add `MAILER_DSN` pointing to MailHog for local SMTP

## Test plan
- [ ] Run `docker-compose up` and trigger a password reset or registration
- [ ] Verify email appears in MailHog at http://localhost:8025

🤖 Generated with [Claude Code](https://claude.com/claude-code)