### PR TITLE
feat(api): P4.2 Backend - Context CRUD Endpoints

### DIFF
--- a/api/src/Command/SeedContextsCommand.php
+++ b/api/src/Command/SeedContextsCommand.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\Context;
+use App\Repository\ContextRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:seed:contexts',
+    description: 'Seed default GTD contexts (@Office, @Home, @Phone, etc.)'
+)]
+class SeedContextsCommand extends Command
+{
+    private const DEFAULT_CONTEXTS = [
+        ['name' => '@Office', 'icon' => 'briefcase', 'color' => '#3498db'],
+        ['name' => '@Home', 'icon' => 'home', 'color' => '#27ae60'],
+        ['name' => '@Phone', 'icon' => 'phone', 'color' => '#9b59b6'],
+        ['name' => '@Errands', 'icon' => 'shopping-cart', 'color' => '#e74c3c'],
+        ['name' => '@Computer', 'icon' => 'laptop', 'color' => '#f39c12'],
+        ['name' => '@Waiting', 'icon' => 'clock', 'color' => '#95a5a6'],
+    ];
+
+    public function __construct(
+        private readonly ContextRepository $contextRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force re-creation of existing default contexts');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $force = $input->getOption('force');
+
+        $io->title('Seeding Default GTD Contexts');
+
+        $existingDefaults = $this->contextRepository->findDefaults();
+        $existingNames = array_map(static fn(Context $c) => $c->getName(), $existingDefaults);
+
+        $created = 0;
+        $skipped = 0;
+
+        foreach (self::DEFAULT_CONTEXTS as $position => $contextData) {
+            $name = $contextData['name'];
+
+            if (in_array($name, $existingNames, true) && !$force) {
+                $io->text(sprintf('  [SKIP] %s already exists', $name));
+                $skipped++;
+                continue;
+            }
+
+            // Remove existing if force mode
+            if ($force) {
+                $existing = $this->findExistingDefault($existingDefaults, $name);
+                if ($existing !== null) {
+                    $this->contextRepository->remove($existing, false);
+                    $io->text(sprintf('  [REMOVE] Removed existing %s', $name));
+                }
+            }
+
+            $context = Context::createDefault(
+                $contextData['name'],
+                $contextData['icon'],
+                $contextData['color']
+            );
+            $context->setPosition($position);
+
+            $this->contextRepository->save($context, false);
+            $io->text(sprintf('  [CREATE] %s', $name));
+            $created++;
+        }
+
+        // Flush all changes at once
+        $this->contextRepository->save($context ?? $existingDefaults[0], true);
+
+        $io->newLine();
+        $io->success(sprintf(
+            'Seed complete: %d created, %d skipped',
+            $created,
+            $skipped
+        ));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param Context[] $contexts
+     */
+    private function findExistingDefault(array $contexts, string $name): ?Context
+    {
+        foreach ($contexts as $context) {
+            if ($context->getName() === $name) {
+                return $context;
+            }
+        }
+
+        return null;
+    }
+}

--- a/api/src/Controller/ContextController.php
+++ b/api/src/Controller/ContextController.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\Context;
+use App\Entity\User;
+use App\Repository\ContextRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[Route('/api/v1')]
+class ContextController extends AbstractController
+{
+    private const UUID_PATTERN = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+
+    public function __construct(
+        private readonly ContextRepository $contextRepository,
+        private readonly ValidatorInterface $validator,
+    ) {
+    }
+
+    #[Route('/contexts', name: 'api_contexts_list', methods: ['GET'])]
+    public function list(): JsonResponse
+    {
+        $user = $this->getAuthenticatedUser();
+        if ($user instanceof JsonResponse) {
+            return $user;
+        }
+
+        $contexts = $this->contextRepository->findAllForUser($user);
+
+        return $this->contextListResponse($contexts);
+    }
+
+    #[Route('/contexts/defaults', name: 'api_contexts_defaults', methods: ['GET'])]
+    public function defaults(): JsonResponse
+    {
+        $user = $this->getAuthenticatedUser();
+        if ($user instanceof JsonResponse) {
+            return $user;
+        }
+
+        $contexts = $this->contextRepository->findDefaults();
+
+        return $this->contextListResponse($contexts);
+    }
+
+    #[Route('/contexts/{id}', name: 'api_contexts_get', methods: ['GET'], requirements: ['id' => self::UUID_PATTERN])]
+    public function get(string $id): JsonResponse
+    {
+        $result = $this->getAuthenticatedUserAndContext($id);
+        if ($result instanceof JsonResponse) {
+            return $result;
+        }
+
+        return $this->json(['context' => $result['context']->toArray()]);
+    }
+
+    #[Route('/contexts', name: 'api_contexts_create', methods: ['POST'])]
+    public function create(Request $request): JsonResponse
+    {
+        $user = $this->getAuthenticatedUser();
+        if ($user instanceof JsonResponse) {
+            return $user;
+        }
+
+        $data = json_decode($request->getContent(), true) ?? [];
+
+        if (!isset($data['name']) || trim($data['name']) === '') {
+            return $this->errorResponse('Name is required', 'MISSING_NAME', Response::HTTP_BAD_REQUEST);
+        }
+
+        $name = trim($data['name']);
+
+        // Check for duplicate name
+        if (!$this->contextRepository->isNameAvailable($name, $user)) {
+            return $this->errorResponse(
+                'A context with this name already exists',
+                'DUPLICATE_NAME',
+                Response::HTTP_CONFLICT
+            );
+        }
+
+        $context = new Context();
+        $context->setUser($user);
+        $context->setName($name);
+
+        if (isset($data['icon'])) {
+            $context->setIcon($data['icon']);
+        }
+
+        if (isset($data['color'])) {
+            $context->setColor($data['color']);
+        }
+
+        $maxPosition = $this->contextRepository->getMaxPositionByUser($user);
+        $context->setPosition($maxPosition + 1);
+
+        return $this->saveContextWithValidation($context, 'Context created successfully', Response::HTTP_CREATED);
+    }
+
+    #[Route('/contexts/{id}', name: 'api_contexts_update', methods: ['PATCH'], requirements: ['id' => self::UUID_PATTERN])]
+    public function update(string $id, Request $request): JsonResponse
+    {
+        $result = $this->getAuthenticatedUserAndContext($id);
+        if ($result instanceof JsonResponse) {
+            return $result;
+        }
+
+        $context = $result['context'];
+        $user = $result['user'];
+
+        // Cannot modify default contexts
+        if ($context->isDefault()) {
+            return $this->errorResponse(
+                'Cannot modify default contexts',
+                'CANNOT_MODIFY_DEFAULT',
+                Response::HTTP_FORBIDDEN
+            );
+        }
+
+        $data = json_decode($request->getContent(), true) ?? [];
+
+        // Update name if provided
+        if (isset($data['name'])) {
+            $newName = trim($data['name']);
+            if ($newName === '') {
+                return $this->errorResponse('Name cannot be empty', 'INVALID_NAME', Response::HTTP_BAD_REQUEST);
+            }
+
+            // Check for duplicate (excluding current context)
+            if (!$this->contextRepository->isNameAvailable($newName, $user, $context->getId())) {
+                return $this->errorResponse(
+                    'A context with this name already exists',
+                    'DUPLICATE_NAME',
+                    Response::HTTP_CONFLICT
+                );
+            }
+
+            $context->setName($newName);
+        }
+
+        // Update icon if provided
+        if (array_key_exists('icon', $data)) {
+            $context->setIcon($data['icon']);
+        }
+
+        // Update color if provided
+        if (array_key_exists('color', $data)) {
+            $context->setColor($data['color']);
+        }
+
+        // Update position if provided
+        if (isset($data['position']) && is_int($data['position'])) {
+            $context->setPosition($data['position']);
+        }
+
+        return $this->saveContextWithValidation($context, 'Context updated successfully');
+    }
+
+    #[Route('/contexts/{id}', name: 'api_contexts_delete', methods: ['DELETE'], requirements: ['id' => self::UUID_PATTERN])]
+    public function delete(string $id): JsonResponse
+    {
+        $result = $this->getAuthenticatedUserAndContext($id);
+        if ($result instanceof JsonResponse) {
+            return $result;
+        }
+
+        $context = $result['context'];
+
+        // Cannot delete default contexts
+        if ($context->isDefault()) {
+            return $this->errorResponse(
+                'Cannot delete default contexts',
+                'CANNOT_DELETE_DEFAULT',
+                Response::HTTP_FORBIDDEN
+            );
+        }
+
+        $context->archive();
+        $this->contextRepository->save($context);
+
+        return $this->json(['message' => 'Context archived successfully']);
+    }
+
+    #[Route('/contexts/{id}/restore', name: 'api_contexts_restore', methods: ['POST'], requirements: ['id' => self::UUID_PATTERN])]
+    public function restore(string $id): JsonResponse
+    {
+        $result = $this->getAuthenticatedUserAndContext($id);
+        if ($result instanceof JsonResponse) {
+            return $result;
+        }
+
+        $context = $result['context'];
+
+        if (!$context->isArchived()) {
+            return $this->errorResponse('Context is not archived', 'NOT_ARCHIVED', Response::HTTP_BAD_REQUEST);
+        }
+
+        $context->activate();
+        $this->contextRepository->save($context);
+
+        return $this->json([
+            'message' => 'Context restored',
+            'context' => $context->toArray(),
+        ]);
+    }
+
+    private function getAuthenticatedUser(): User|JsonResponse
+    {
+        $user = $this->getUser();
+
+        return $user instanceof User
+            ? $user
+            : $this->errorResponse('Not authenticated', 'NOT_AUTHENTICATED', Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * @return array{user: User, context: Context}|JsonResponse
+     */
+    private function getAuthenticatedUserAndContext(string $id): array|JsonResponse
+    {
+        $user = $this->getAuthenticatedUser();
+        if ($user instanceof JsonResponse) {
+            return $user;
+        }
+
+        if (!Uuid::isValid($id)) {
+            return $this->errorResponse('Invalid context ID', 'INVALID_ID', Response::HTTP_BAD_REQUEST);
+        }
+
+        $context = $this->contextRepository->findById(Uuid::fromString($id));
+
+        if ($context === null) {
+            return $this->errorResponse('Context not found', 'NOT_FOUND', Response::HTTP_NOT_FOUND);
+        }
+
+        // Allow access to default contexts (user is null) or user's own contexts
+        $contextUser = $context->getUser();
+        $isAccessible = $context->isDefault() || ($contextUser !== null && $contextUser->getId()->toRfc4122() === $user->getId()->toRfc4122());
+
+        return $isAccessible
+            ? ['user' => $user, 'context' => $context]
+            : $this->errorResponse('Context not found', 'NOT_FOUND', Response::HTTP_NOT_FOUND);
+    }
+
+    private function errorResponse(string $message, string $code, int $status): JsonResponse
+    {
+        return $this->json(['error' => $message, 'code' => $code], $status);
+    }
+
+    /**
+     * @param Context[] $contexts
+     */
+    private function contextListResponse(array $contexts): JsonResponse
+    {
+        return $this->json([
+            'contexts' => array_map(static fn(Context $context) => $context->toArray(), $contexts),
+            'count' => count($contexts),
+        ]);
+    }
+
+    private function saveContextWithValidation(Context $context, string $message, int $status = Response::HTTP_OK): JsonResponse
+    {
+        $errors = $this->validator->validate($context);
+
+        if (count($errors) > 0) {
+            $errorMessages = [];
+            foreach ($errors as $error) {
+                $errorMessages[$error->getPropertyPath()] = $error->getMessage();
+            }
+
+            return $this->json([
+                'error' => 'Validation failed',
+                'code' => 'VALIDATION_ERROR',
+                'details' => $errorMessages,
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $this->contextRepository->save($context);
+
+        return $this->json([
+            'message' => $message,
+            'context' => $context->toArray(),
+        ], $status);
+    }
+}

--- a/api/tests/Functional/Context/ContextTest.php
+++ b/api/tests/Functional/Context/ContextTest.php
@@ -583,6 +583,145 @@ class ContextTest extends WebTestCase
     }
 
     // =========================================================================
+    // Additional Coverage Tests
+    // =========================================================================
+
+    public function testUpdateContextWithEmptyNameFails(): void
+    {
+        $tokens = $this->authenticateUser('update-empty-name@example.com');
+        $contextId = $this->createContext($tokens['access_token'], '@EmptyUpdate');
+
+        $this->client->request('PATCH', '/api/v1/contexts/' . $contextId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'name' => '   ',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('INVALID_NAME', $response['code']);
+    }
+
+    public function testUpdateContextPosition(): void
+    {
+        $tokens = $this->authenticateUser('update-position@example.com');
+        $contextId = $this->createContext($tokens['access_token'], '@PosUpdate');
+
+        $this->client->request('PATCH', '/api/v1/contexts/' . $contextId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'position' => 99,
+        ]));
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals(99, $response['context']['position']);
+    }
+
+    public function testUpdateContextClearIcon(): void
+    {
+        $tokens = $this->authenticateUser('update-clear-icon@example.com');
+
+        // Create context with icon
+        $this->client->request('POST', '/api/v1/contexts', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'name' => '@IconCtx',
+            'icon' => 'star',
+        ]));
+
+        $createResponse = json_decode($this->client->getResponse()->getContent(), true);
+        $contextId = $createResponse['context']['id'];
+
+        // Clear the icon
+        $this->client->request('PATCH', '/api/v1/contexts/' . $contextId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'icon' => null,
+        ]));
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertNull($response['context']['icon']);
+    }
+
+    public function testUpdateContextClearColor(): void
+    {
+        $tokens = $this->authenticateUser('update-clear-color@example.com');
+
+        // Create context with color
+        $this->client->request('POST', '/api/v1/contexts', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'name' => '@ColorCtx',
+            'color' => '#FF0000',
+        ]));
+
+        $createResponse = json_decode($this->client->getResponse()->getContent(), true);
+        $contextId = $createResponse['context']['id'];
+
+        // Clear the color
+        $this->client->request('PATCH', '/api/v1/contexts/' . $contextId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'color' => null,
+        ]));
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertNull($response['context']['color']);
+    }
+
+    public function testGetContextRequiresAuthentication(): void
+    {
+        $this->client->request('GET', '/api/v1/contexts/00000000-0000-0000-0000-000000000001');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function testUpdateContextRequiresAuthentication(): void
+    {
+        $this->client->request('PATCH', '/api/v1/contexts/00000000-0000-0000-0000-000000000001', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'name' => '@Test',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function testDeleteContextRequiresAuthentication(): void
+    {
+        $this->client->request('DELETE', '/api/v1/contexts/00000000-0000-0000-0000-000000000001');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function testRestoreContextRequiresAuthentication(): void
+    {
+        $this->client->request('POST', '/api/v1/contexts/00000000-0000-0000-0000-000000000001/restore');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function testDefaultsEndpointRequiresAuthentication(): void
+    {
+        $this->client->request('GET', '/api/v1/contexts/defaults');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    // =========================================================================
     // Helper Methods
     // =========================================================================
 

--- a/api/tests/Functional/Context/ContextTest.php
+++ b/api/tests/Functional/Context/ContextTest.php
@@ -1,0 +1,646 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Context;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Functional tests for Context CRUD endpoints (FR-013, FR-014, FR-015)
+ */
+class ContextTest extends WebTestCase
+{
+    private $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+
+        // Seed default contexts if they don't exist
+        $this->seedDefaultContexts();
+    }
+
+    private function seedDefaultContexts(): void
+    {
+        $container = static::getContainer();
+        $contextRepository = $container->get('App\Repository\ContextRepository');
+
+        $existingDefaults = $contextRepository->findDefaults();
+        if (count($existingDefaults) >= 6) {
+            return; // Already seeded
+        }
+
+        $defaultContexts = [
+            ['name' => '@Office', 'icon' => 'briefcase', 'color' => '#3498db'],
+            ['name' => '@Home', 'icon' => 'home', 'color' => '#27ae60'],
+            ['name' => '@Phone', 'icon' => 'phone', 'color' => '#9b59b6'],
+            ['name' => '@Errands', 'icon' => 'shopping-cart', 'color' => '#e74c3c'],
+            ['name' => '@Computer', 'icon' => 'laptop', 'color' => '#f39c12'],
+            ['name' => '@Waiting', 'icon' => 'clock', 'color' => '#95a5a6'],
+        ];
+
+        $existingNames = array_map(fn($c) => $c->getName(), $existingDefaults);
+
+        foreach ($defaultContexts as $position => $data) {
+            if (in_array($data['name'], $existingNames, true)) {
+                continue;
+            }
+
+            $context = \App\Entity\Context::createDefault(
+                $data['name'],
+                $data['icon'],
+                $data['color']
+            );
+            $context->setPosition($position);
+            $contextRepository->save($context, false);
+        }
+
+        // Flush all at once
+        $em = $container->get('doctrine.orm.entity_manager');
+        $em->flush();
+    }
+
+    // =========================================================================
+    // List Contexts Tests (FR-013, FR-015)
+    // =========================================================================
+
+    public function testListContextsReturnsDefaultsAndCustom(): void
+    {
+        $tokens = $this->authenticateUser('list-contexts@example.com');
+
+        // Create a custom context
+        $this->createContext($tokens['access_token'], '@MyCustom');
+
+        $this->client->request('GET', '/api/v1/contexts', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertArrayHasKey('contexts', $response);
+        $this->assertArrayHasKey('count', $response);
+        $this->assertIsArray($response['contexts']);
+
+        // Should have defaults + our custom context
+        $names = array_column($response['contexts'], 'name');
+        $this->assertContains('@Office', $names);
+        $this->assertContains('@Home', $names);
+        $this->assertContains('@MyCustom', $names);
+    }
+
+    public function testListContextsRequiresAuthentication(): void
+    {
+        $this->client->request('GET', '/api/v1/contexts');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function testListContextsOnlyShowsActiveContexts(): void
+    {
+        $tokens = $this->authenticateUser('list-active@example.com');
+
+        // Create and archive a context
+        $contextId = $this->createContext($tokens['access_token'], '@ToArchive');
+        $this->client->request('DELETE', '/api/v1/contexts/' . $contextId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        // List should not include archived
+        $this->client->request('GET', '/api/v1/contexts', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $names = array_column($response['contexts'], 'name');
+
+        $this->assertNotContains('@ToArchive', $names);
+    }
+
+    public function testListDefaultContextsOnly(): void
+    {
+        $tokens = $this->authenticateUser('list-defaults@example.com');
+
+        // Create a custom context
+        $this->createContext($tokens['access_token'], '@Custom');
+
+        $this->client->request('GET', '/api/v1/contexts/defaults', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        // Should only have defaults, no custom
+        foreach ($response['contexts'] as $context) {
+            $this->assertTrue($context['is_default']);
+        }
+    }
+
+    // =========================================================================
+    // Get Single Context Tests
+    // =========================================================================
+
+    public function testGetContextById(): void
+    {
+        $tokens = $this->authenticateUser('get-context@example.com');
+        $contextId = $this->createContext($tokens['access_token'], '@TestGet');
+
+        $this->client->request('GET', '/api/v1/contexts/' . $contextId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertArrayHasKey('context', $response);
+        $this->assertEquals($contextId, $response['context']['id']);
+        $this->assertEquals('@TestGet', $response['context']['name']);
+    }
+
+    public function testGetContextNotFoundReturns404(): void
+    {
+        $tokens = $this->authenticateUser('get-notfound@example.com');
+
+        $this->client->request('GET', '/api/v1/contexts/00000000-0000-0000-0000-000000000000', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testCannotGetOtherUserContext(): void
+    {
+        // User 1 creates a context
+        $tokens1 = $this->authenticateUser('user1-context@example.com');
+        $contextId = $this->createContext($tokens1['access_token'], '@User1Context');
+
+        // User 2 tries to access it
+        $tokens2 = $this->authenticateUser('user2-context@example.com');
+
+        $this->client->request('GET', '/api/v1/contexts/' . $contextId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens2['access_token'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testCanGetDefaultContext(): void
+    {
+        $tokens = $this->authenticateUser('get-default@example.com');
+
+        // Get list to find a default context ID
+        $this->client->request('GET', '/api/v1/contexts/defaults', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $defaultId = $response['contexts'][0]['id'];
+
+        // Should be able to get it
+        $this->client->request('GET', '/api/v1/contexts/' . $defaultId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    // =========================================================================
+    // Create Context Tests (FR-014)
+    // =========================================================================
+
+    public function testCreateContextWithValidData(): void
+    {
+        $tokens = $this->authenticateUser('create-context@example.com');
+
+        $this->client->request('POST', '/api/v1/contexts', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'name' => '@NewContext',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertArrayHasKey('message', $response);
+        $this->assertArrayHasKey('context', $response);
+        $this->assertEquals('@NewContext', $response['context']['name']);
+        $this->assertFalse($response['context']['is_default']);
+        $this->assertEquals('active', $response['context']['status']);
+    }
+
+    public function testCreateContextRequiresName(): void
+    {
+        $tokens = $this->authenticateUser('create-no-name@example.com');
+
+        $this->client->request('POST', '/api/v1/contexts', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('MISSING_NAME', $response['code']);
+    }
+
+    public function testCreateContextNameMustStartWithAt(): void
+    {
+        $tokens = $this->authenticateUser('create-no-at@example.com');
+
+        $this->client->request('POST', '/api/v1/contexts', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'name' => 'NoAtSymbol',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('VALIDATION_ERROR', $response['code']);
+    }
+
+    public function testCreateContextDuplicateNameFails(): void
+    {
+        $tokens = $this->authenticateUser('create-dup@example.com');
+
+        // Create first context
+        $this->createContext($tokens['access_token'], '@Duplicate');
+
+        // Try to create another with same name
+        $this->client->request('POST', '/api/v1/contexts', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'name' => '@Duplicate',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('DUPLICATE_NAME', $response['code']);
+    }
+
+    public function testCreateContextCannotUseSameNameAsDefault(): void
+    {
+        $tokens = $this->authenticateUser('create-default-name@example.com');
+
+        $this->client->request('POST', '/api/v1/contexts', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'name' => '@Office',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+    }
+
+    public function testCreateContextWithOptionalFields(): void
+    {
+        $tokens = $this->authenticateUser('create-opts@example.com');
+
+        $this->client->request('POST', '/api/v1/contexts', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'name' => '@WithOptions',
+            'icon' => 'star',
+            'color' => '#FF5733',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals('@WithOptions', $response['context']['name']);
+        $this->assertEquals('star', $response['context']['icon']);
+        $this->assertEquals('#FF5733', $response['context']['color']);
+    }
+
+    public function testCreateContextWithInvalidColor(): void
+    {
+        $tokens = $this->authenticateUser('create-bad-color@example.com');
+
+        $this->client->request('POST', '/api/v1/contexts', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'name' => '@BadColor',
+            'color' => 'not-a-color',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('VALIDATION_ERROR', $response['code']);
+    }
+
+    public function testCreateContextRequiresAuthentication(): void
+    {
+        $this->client->request('POST', '/api/v1/contexts', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'name' => '@Test',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    // =========================================================================
+    // Update Context Tests
+    // =========================================================================
+
+    public function testUpdateContextName(): void
+    {
+        $tokens = $this->authenticateUser('update-name@example.com');
+        $contextId = $this->createContext($tokens['access_token'], '@OldName');
+
+        $this->client->request('PATCH', '/api/v1/contexts/' . $contextId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'name' => '@NewName',
+        ]));
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('@NewName', $response['context']['name']);
+    }
+
+    public function testUpdateContextIcon(): void
+    {
+        $tokens = $this->authenticateUser('update-icon@example.com');
+        $contextId = $this->createContext($tokens['access_token'], '@UpdateIcon');
+
+        $this->client->request('PATCH', '/api/v1/contexts/' . $contextId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'icon' => 'home',
+        ]));
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('home', $response['context']['icon']);
+    }
+
+    public function testUpdateContextColor(): void
+    {
+        $tokens = $this->authenticateUser('update-color@example.com');
+        $contextId = $this->createContext($tokens['access_token'], '@UpdateColor');
+
+        $this->client->request('PATCH', '/api/v1/contexts/' . $contextId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'color' => '#00FF00',
+        ]));
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('#00FF00', $response['context']['color']);
+    }
+
+    public function testCannotUpdateDefaultContext(): void
+    {
+        $tokens = $this->authenticateUser('update-default@example.com');
+
+        // Get a default context ID
+        $this->client->request('GET', '/api/v1/contexts/defaults', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $defaultId = $response['contexts'][0]['id'];
+
+        // Try to update it
+        $this->client->request('PATCH', '/api/v1/contexts/' . $defaultId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'name' => '@Modified',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('CANNOT_MODIFY_DEFAULT', $response['code']);
+    }
+
+    public function testCannotUpdateOtherUserContext(): void
+    {
+        // User 1 creates a context
+        $tokens1 = $this->authenticateUser('update-user1@example.com');
+        $contextId = $this->createContext($tokens1['access_token'], '@User1Ctx');
+
+        // User 2 tries to update it
+        $tokens2 = $this->authenticateUser('update-user2@example.com');
+
+        $this->client->request('PATCH', '/api/v1/contexts/' . $contextId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens2['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'name' => '@Hacked',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testUpdateContextToExistingNameFails(): void
+    {
+        $tokens = $this->authenticateUser('update-dup@example.com');
+
+        $this->createContext($tokens['access_token'], '@First');
+        $secondId = $this->createContext($tokens['access_token'], '@Second');
+
+        // Try to rename Second to First
+        $this->client->request('PATCH', '/api/v1/contexts/' . $secondId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'name' => '@First',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+    }
+
+    // =========================================================================
+    // Delete (Archive) Context Tests
+    // =========================================================================
+
+    public function testDeleteContextArchivesIt(): void
+    {
+        $tokens = $this->authenticateUser('delete-ctx@example.com');
+        $contextId = $this->createContext($tokens['access_token'], '@ToDelete');
+
+        $this->client->request('DELETE', '/api/v1/contexts/' . $contextId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('Context archived successfully', $response['message']);
+
+        // Verify it's archived (still exists but with archived status)
+        $this->client->request('GET', '/api/v1/contexts/' . $contextId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $getResponse = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('archived', $getResponse['context']['status']);
+    }
+
+    public function testCannotDeleteDefaultContext(): void
+    {
+        $tokens = $this->authenticateUser('delete-default@example.com');
+
+        // Get a default context ID
+        $this->client->request('GET', '/api/v1/contexts/defaults', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $defaultId = $response['contexts'][0]['id'];
+
+        // Try to delete it
+        $this->client->request('DELETE', '/api/v1/contexts/' . $defaultId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('CANNOT_DELETE_DEFAULT', $response['code']);
+    }
+
+    public function testCannotDeleteOtherUserContext(): void
+    {
+        // User 1 creates a context
+        $tokens1 = $this->authenticateUser('del-user1@example.com');
+        $contextId = $this->createContext($tokens1['access_token'], '@User1Del');
+
+        // User 2 tries to delete it
+        $tokens2 = $this->authenticateUser('del-user2@example.com');
+
+        $this->client->request('DELETE', '/api/v1/contexts/' . $contextId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens2['access_token'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    // =========================================================================
+    // Restore Context Tests
+    // =========================================================================
+
+    public function testRestoreArchivedContext(): void
+    {
+        $tokens = $this->authenticateUser('restore-ctx@example.com');
+        $contextId = $this->createContext($tokens['access_token'], '@ToRestore');
+
+        // Archive it
+        $this->client->request('DELETE', '/api/v1/contexts/' . $contextId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        // Restore it
+        $this->client->request('POST', '/api/v1/contexts/' . $contextId . '/restore', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('active', $response['context']['status']);
+    }
+
+    public function testRestoreNonArchivedContextFails(): void
+    {
+        $tokens = $this->authenticateUser('restore-active@example.com');
+        $contextId = $this->createContext($tokens['access_token'], '@Active');
+
+        // Try to restore an active context
+        $this->client->request('POST', '/api/v1/contexts/' . $contextId . '/restore', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('NOT_ARCHIVED', $response['code']);
+    }
+
+    // =========================================================================
+    // Helper Methods
+    // =========================================================================
+
+    private function authenticateUser(string $email = 'test@example.com'): array
+    {
+        $password = 'Password123!';
+
+        // Register user
+        $this->client->request('POST', '/api/v1/auth/register', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'email' => $email,
+            'password' => $password,
+        ]));
+
+        // Verify user
+        $container = static::getContainer();
+        $userRepository = $container->get('App\Repository\UserRepository');
+        $user = $userRepository->findByEmail($email);
+
+        if ($user && $user->getVerificationToken()) {
+            $this->client->request('POST', '/api/v1/auth/verify-email', [], [], [
+                'CONTENT_TYPE' => 'application/json',
+            ], json_encode([
+                'token' => $user->getVerificationToken(),
+            ]));
+        }
+
+        // Login
+        $this->client->request('POST', '/api/v1/auth/login', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'email' => $email,
+            'password' => $password,
+        ]));
+
+        return json_decode($this->client->getResponse()->getContent(), true);
+    }
+
+    private function createContext(string $accessToken, string $name): string
+    {
+        $this->client->request('POST', '/api/v1/contexts', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $accessToken,
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'name' => $name,
+        ]));
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        if (!isset($response['context']['id'])) {
+            throw new \RuntimeException(sprintf(
+                'Failed to create context "%s": %s',
+                $name,
+                json_encode($response)
+            ));
+        }
+
+        return $response['context']['id'];
+    }
+}

--- a/api/tests/Unit/Command/SeedContextsCommandTest.php
+++ b/api/tests/Unit/Command/SeedContextsCommandTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Command;
+
+use App\Command\SeedContextsCommand;
+use App\Entity\Context;
+use App\Repository\ContextRepository;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class SeedContextsCommandTest extends TestCase
+{
+    private MockObject&ContextRepository $contextRepository;
+    private SeedContextsCommand $command;
+    private CommandTester $commandTester;
+
+    protected function setUp(): void
+    {
+        $this->contextRepository = $this->createMock(ContextRepository::class);
+        $this->command = new SeedContextsCommand($this->contextRepository);
+
+        $application = new Application();
+        $application->add($this->command);
+
+        $this->commandTester = new CommandTester($this->command);
+    }
+
+    public function testCommandName(): void
+    {
+        $this->assertEquals('app:seed:contexts', $this->command->getName());
+    }
+
+    public function testCommandDescription(): void
+    {
+        $this->assertEquals(
+            'Seed default GTD contexts (@Office, @Home, @Phone, etc.)',
+            $this->command->getDescription()
+        );
+    }
+
+    public function testSeedCreatesAllDefaultContextsWhenNoneExist(): void
+    {
+        $this->contextRepository
+            ->expects($this->once())
+            ->method('findDefaults')
+            ->willReturn([]);
+
+        // 6 contexts saved without flush + 1 final flush = 7 calls
+        $this->contextRepository
+            ->expects($this->exactly(7))
+            ->method('save');
+
+        $exitCode = $this->commandTester->execute([]);
+
+        $this->assertEquals(0, $exitCode);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('[CREATE] @Office', $output);
+        $this->assertStringContainsString('[CREATE] @Home', $output);
+        $this->assertStringContainsString('[CREATE] @Phone', $output);
+        $this->assertStringContainsString('[CREATE] @Errands', $output);
+        $this->assertStringContainsString('[CREATE] @Computer', $output);
+        $this->assertStringContainsString('[CREATE] @Waiting', $output);
+        $this->assertStringContainsString('6 created, 0 skipped', $output);
+    }
+
+    public function testSeedSkipsExistingContexts(): void
+    {
+        $existingContext = $this->createMockContext('@Office');
+
+        $this->contextRepository
+            ->expects($this->once())
+            ->method('findDefaults')
+            ->willReturn([$existingContext]);
+
+        // 5 new contexts + 1 final flush
+        $this->contextRepository
+            ->expects($this->exactly(6))
+            ->method('save');
+
+        $exitCode = $this->commandTester->execute([]);
+
+        $this->assertEquals(0, $exitCode);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('[SKIP] @Office already exists', $output);
+        $this->assertStringContainsString('5 created, 1 skipped', $output);
+    }
+
+    public function testSeedSkipsAllWhenAllExist(): void
+    {
+        $existingContexts = [
+            $this->createMockContext('@Office'),
+            $this->createMockContext('@Home'),
+            $this->createMockContext('@Phone'),
+            $this->createMockContext('@Errands'),
+            $this->createMockContext('@Computer'),
+            $this->createMockContext('@Waiting'),
+        ];
+
+        $this->contextRepository
+            ->expects($this->once())
+            ->method('findDefaults')
+            ->willReturn($existingContexts);
+
+        // Only the final flush save
+        $this->contextRepository
+            ->expects($this->once())
+            ->method('save');
+
+        $exitCode = $this->commandTester->execute([]);
+
+        $this->assertEquals(0, $exitCode);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('0 created, 6 skipped', $output);
+    }
+
+    public function testForceOptionReplacesExistingContexts(): void
+    {
+        $existingContext = $this->createMockContext('@Office');
+
+        $this->contextRepository
+            ->expects($this->once())
+            ->method('findDefaults')
+            ->willReturn([$existingContext]);
+
+        $this->contextRepository
+            ->expects($this->once())
+            ->method('remove')
+            ->with($existingContext, false);
+
+        // 6 creates + 1 flush
+        $this->contextRepository
+            ->expects($this->exactly(7))
+            ->method('save');
+
+        $exitCode = $this->commandTester->execute(['--force' => true]);
+
+        $this->assertEquals(0, $exitCode);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('[REMOVE] Removed existing @Office', $output);
+        $this->assertStringContainsString('[CREATE] @Office', $output);
+        $this->assertStringContainsString('6 created, 0 skipped', $output);
+    }
+
+    public function testForceOptionWithMultipleExisting(): void
+    {
+        $existingContexts = [
+            $this->createMockContext('@Office'),
+            $this->createMockContext('@Home'),
+        ];
+
+        $this->contextRepository
+            ->expects($this->once())
+            ->method('findDefaults')
+            ->willReturn($existingContexts);
+
+        $this->contextRepository
+            ->expects($this->exactly(2))
+            ->method('remove');
+
+        // 6 creates + 1 flush
+        $this->contextRepository
+            ->expects($this->exactly(7))
+            ->method('save');
+
+        $exitCode = $this->commandTester->execute(['--force' => true]);
+
+        $this->assertEquals(0, $exitCode);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('[REMOVE] Removed existing @Office', $output);
+        $this->assertStringContainsString('[REMOVE] Removed existing @Home', $output);
+        $this->assertStringContainsString('6 created, 0 skipped', $output);
+    }
+
+    public function testForceOptionWithNonExisting(): void
+    {
+        $this->contextRepository
+            ->expects($this->once())
+            ->method('findDefaults')
+            ->willReturn([]);
+
+        // Never called because nothing exists
+        $this->contextRepository
+            ->expects($this->never())
+            ->method('remove');
+
+        $exitCode = $this->commandTester->execute(['--force' => true]);
+
+        $this->assertEquals(0, $exitCode);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('6 created, 0 skipped', $output);
+    }
+
+    public function testOutputContainsTitle(): void
+    {
+        $this->contextRepository
+            ->method('findDefaults')
+            ->willReturn([]);
+
+        $this->commandTester->execute([]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('Seeding Default GTD Contexts', $output);
+    }
+
+    public function testOutputContainsSuccessMessage(): void
+    {
+        $this->contextRepository
+            ->method('findDefaults')
+            ->willReturn([]);
+
+        $this->commandTester->execute([]);
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('Seed complete:', $output);
+    }
+
+    private function createMockContext(string $name): Context
+    {
+        $context = $this->createMock(Context::class);
+        $context->method('getName')->willReturn($name);
+
+        return $context;
+    }
+}

--- a/implementation-phase-4-2.md
+++ b/implementation-phase-4-2.md
@@ -1,0 +1,135 @@
+# Implementation: Phase 4.2 - Backend Context Endpoints
+
+## Overview
+- **Parent**: P4: Organize with Contextual Lists (FR-013 to FR-016)
+- **User Story**: As a user, I want to organize my actions in lists based on context so that I can quickly see what I can do in my current situation.
+- **Branch**: feat/phase-4-2-backend-context-endpoints
+
+## Specs Analysis
+
+### Relevant Requirements (from spec.md)
+- **FR-013**: System MUST provide default contexts: @Office, @Home, @Phone, @Errands, @Computer, @Waiting
+- **FR-014**: System MUST allow creation of custom contexts
+- **FR-015**: System MUST allow filtering actions by context
+
+### Data Model (from data-model.md)
+- **Context Entity**: Already implemented in Phase 4.1
+  - Fields: id, user_id (NULL for defaults), name, icon, color, is_default, status, position, created_at, updated_at
+  - Statuses: active, archived
+  - Validation: Name starts with "@", max 50 chars, unique per user
+
+### Existing Code Analysis
+- **ContextRepository**: Already complete with all necessary methods:
+  - `findAllForUser()` - Gets user's contexts + defaults
+  - `findDefaults()` - Gets system defaults only
+  - `findCustomByUser()` - Gets user's custom contexts only
+  - `findByNameForUser()` - Finds context by name
+  - `isNameAvailable()` - Checks name uniqueness
+  - `getMaxPositionByUser()` - For positioning new contexts
+- **TaskController**: Reference pattern for controller structure
+
+### API Endpoints to Implement
+Based on TaskController patterns and REST conventions:
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | /api/v1/contexts | List all contexts for user (defaults + custom) |
+| GET | /api/v1/contexts/defaults | List default contexts only |
+| GET | /api/v1/contexts/{id} | Get single context |
+| POST | /api/v1/contexts | Create custom context |
+| PATCH | /api/v1/contexts/{id} | Update context |
+| DELETE | /api/v1/contexts/{id} | Archive (soft delete) custom context |
+| POST | /api/v1/contexts/{id}/restore | Restore archived context |
+
+## Test Plan
+
+### Unit Tests
+N/A - Entity tests already done in Phase 4.1
+
+### Functional Tests (`api/tests/Functional/Context/ContextTest.php`)
+Following TDD approach - tests first, then implementation:
+
+1. **List Contexts**
+   - `testListContextsReturnsDefaultsAndCustom()`
+   - `testListContextsRequiresAuthentication()`
+   - `testListContextsOnlyShowsActiveContexts()`
+
+2. **Get Single Context**
+   - `testGetContextById()`
+   - `testGetContextNotFoundReturns404()`
+   - `testCannotGetOtherUserContext()`
+
+3. **Create Context**
+   - `testCreateContextWithValidData()`
+   - `testCreateContextRequiresName()`
+   - `testCreateContextNameMustStartWithAt()`
+   - `testCreateContextDuplicateNameFails()`
+   - `testCreateContextWithOptionalFields()`
+
+4. **Update Context**
+   - `testUpdateContextName()`
+   - `testUpdateContextIcon()`
+   - `testUpdateContextColor()`
+   - `testCannotUpdateDefaultContext()`
+   - `testCannotUpdateOtherUserContext()`
+
+5. **Delete Context**
+   - `testDeleteContextArchivesIt()`
+   - `testCannotDeleteDefaultContext()`
+   - `testCannotDeleteOtherUserContext()`
+
+6. **Restore Context**
+   - `testRestoreArchivedContext()`
+   - `testRestoreNonArchivedContextFails()`
+
+7. **Seed Command Tests** (separate test file or within functional)
+   - `testSeedCommandCreatesDefaultContexts()`
+   - `testSeedCommandIsIdempotent()`
+
+## Implementation Tasks
+
+| Task ID | Description | File | Status |
+|---------|-------------|------|--------|
+| P4-006 | Create seed command for default contexts | `api/src/Command/SeedContextsCommand.php` | completed |
+| P4-007 | Create ContextController with CRUD endpoints | `api/src/Controller/ContextController.php` | completed |
+| P4-008 | Write functional tests for context endpoints | `api/tests/Functional/Context/ContextTest.php` | completed |
+
+## Implementation Order (TDD)
+
+1. **P4-008 (Tests First)**: Write functional tests
+2. **P4-006 (Seed Command)**: Create seed command (needed for test fixtures)
+3. **P4-007 (Controller)**: Implement ContextController
+4. Run tests and iterate
+
+## Side Effects Analysis
+
+### Potential Impact
+1. **Task Entity**: May need to add context relationship methods in future (Phase 4.3+)
+2. **Database**: Seed command will insert default contexts - must be idempotent
+3. **Security**: Controller must verify user ownership for custom contexts
+
+### Dependencies
+- Context entity (P4-001) - Done
+- TaskContext entity (P4-003) - Done
+- Migrations (P4-004, P4-005) - Done
+- ContextRepository - Already exists
+
+### Breaking Changes
+- None - this is a new feature
+
+## Pre-PR Checklist
+- [x] All tests written and passing
+- [x] Code follows clean code principles
+- [x] No side effects unaddressed
+- [x] Documentation updated if needed
+- [x] Seed command tested manually
+
+## Review Notes
+
+### Review Cycle 1 (2025-12-03)
+- **Reviewer**: Claude Code
+- **Tests**: 27 context tests passing (428 total tests passing)
+- **Findings**: None - implementation follows existing patterns from TaskController
+- **Security**: Authorization checks implemented correctly via `getAuthenticatedUserAndContext()`
+- **Code Quality**: Clean, follows established patterns
+- **Status**: APPROVED

--- a/specs/001-gtd-todo-app/tasks.md
+++ b/specs/001-gtd-todo-app/tasks.md
@@ -12,7 +12,7 @@ Total tasks: 203
 - P1 User Account Management: 56 tasks (52 complete, 4 remaining) - 93% complete
 - P2 Capture Ideas and Tasks: 14 tasks (14 complete) - 100% complete
 - P3 Clarify and Process: 12 tasks ✅ COMPLETE
-- P4 Organize with Contexts: 18 tasks
+- P4 Organize with Contexts: 18 tasks (8 complete)
 - P5 Project Management: 14 tasks
 - P6 Weekly Review: 12 tasks
 - P7 Calendar and Deadlines: 12 tasks
@@ -259,19 +259,19 @@ Per Constitution XVI, all features MUST be tracked as GitHub issues BEFORE imple
 
 **User Story**: As a user, I want to organize my actions in lists based on context so that I can quickly see what I can do in my current situation.
 
-### Phase 4.1: Backend - Context Entity
+### Phase 4.1: Backend - Context Entity ✅
 
-- [ ] [P4-001] [Story-4] Create Context Doctrine entity `api/src/Entity/Context.php`
-- [ ] [P4-002] [Story-4] Write unit tests for Context entity `api/tests/Unit/Entity/ContextTest.php`
-- [ ] [P4-003] [Story-4] Create TaskContext join entity for M:N relationship `api/src/Entity/TaskContext.php`
-- [ ] [P4-004] [Story-4] Create database migration for contexts table `api/migrations/Version002CreateContextsTable.php`
-- [ ] [P4-005] [Story-4] Create database migration for task_contexts join table `api/migrations/Version005CreateTaskContextsTable.php`
+- [X] [P4-001] [Story-4] Create Context Doctrine entity `api/src/Entity/Context.php`
+- [X] [P4-002] [Story-4] Write unit tests for Context entity `api/tests/Unit/Entity/ContextTest.php`
+- [X] [P4-003] [Story-4] Create TaskContext join entity for M:N relationship `api/src/Entity/TaskContext.php`
+- [X] [P4-004] [Story-4] Create database migration for contexts table `api/migrations/Version002CreateContextsTable.php`
+- [X] [P4-005] [Story-4] Create database migration for task_contexts join table `api/migrations/Version005CreateTaskContextsTable.php`
 
-### Phase 4.2: Backend - Context Endpoints
+### Phase 4.2: Backend - Context Endpoints ✅
 
-- [ ] [P4-006] [Story-4] Create seed command for default contexts `api/src/Command/SeedContextsCommand.php`
-- [ ] [P4-007] [Story-4] Create ContextController with CRUD endpoints `api/src/Controller/ContextController.php`
-- [ ] [P4-008] [Story-4] Write functional tests for context endpoints `api/tests/Functional/Context/ContextTest.php`
+- [X] [P4-006] [Story-4] Create seed command for default contexts `api/src/Command/SeedContextsCommand.php`
+- [X] [P4-007] [Story-4] Create ContextController with CRUD endpoints `api/src/Controller/ContextController.php`
+- [X] [P4-008] [Story-4] Write functional tests for context endpoints `api/tests/Functional/Context/ContextTest.php`
 
 ### Phase 4.3: Frontend - Context Module
 


### PR DESCRIPTION
## Summary

Implement backend API for GTD context management (FR-013, FR-014, FR-015):

- **ContextController** with full CRUD operations:
  - `GET /api/v1/contexts` - List all contexts (defaults + custom)
  - `GET /api/v1/contexts/defaults` - List default contexts only
  - `GET /api/v1/contexts/{id}` - Get single context
  - `POST /api/v1/contexts` - Create custom context
  - `PATCH /api/v1/contexts/{id}` - Update context
  - `DELETE /api/v1/contexts/{id}` - Archive (soft delete)
  - `POST /api/v1/contexts/{id}/restore` - Restore archived

- **SeedContextsCommand** for default GTD contexts:
  - @Office, @Home, @Phone, @Errands, @Computer, @Waiting
  - Idempotent seeding with `--force` option

- **Comprehensive functional tests** (27 tests):
  - Authentication and authorization checks
  - CRUD operations for contexts
  - Cross-user isolation validation
  - Default context protection

## Tasks Completed
- [x] [P4-006] Create seed command for default contexts
- [x] [P4-007] Create ContextController with CRUD endpoints
- [x] [P4-008] Write functional tests for context endpoints

## Test Plan

- [x] Run `php bin/phpunit tests/Functional/Context/ContextTest.php` - 27 tests pass
- [x] Run full test suite - 428 tests pass
- [x] Manual test of seed command `php bin/console app:seed:contexts`
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)