### PR TITLE
feat(web): P4.3 Frontend - Context Module Implementation

### DIFF
--- a/docs/implementation/phase-4-3.md
+++ b/docs/implementation/phase-4-3.md
@@ -1,0 +1,110 @@
+# Implementation: Phase 4.3 - Frontend - Context Module
+
+## Overview
+- Parent: P4 Organize with Contextual Lists (FR-013 to FR-016)
+- User Story: As a user, I want to organize my actions in lists based on context so that I can quickly see what I can do in my current situation.
+- Branch: feat/phase-4-3-frontend-context-module
+
+## Specs Analysis
+
+### Relevant Specs Documents Read
+- `specs/001-gtd-todo-app/data-model.md` - Context entity definition
+- `specs/001-gtd-todo-app/spec.md` - User Story 4, FR-013 to FR-016
+- `specs/001-gtd-todo-app/plan.md` - Technical approach and project structure
+
+### Key Architectural Decisions
+- React 18 with Redux Toolkit for state management (existing pattern)
+- JavaScript (JSX) used throughout (not TypeScript despite tasks.md references)
+- Feature-based module structure under `web/src/features/`
+- API client already has `contextsAPI` methods defined
+- Tailwind CSS for styling (following existing patterns)
+
+### Data Models Involved
+- **Context**: id, user_id, name (starts with @), icon, color, is_default, status (active/archived), position
+- **TaskContext**: Many-to-many join between tasks and contexts
+- Default contexts: @Office, @Home, @Phone, @Errands, @Computer, @Waiting
+
+### Backend API Endpoints (Already Implemented)
+- `GET /api/v1/contexts` - List all contexts for user (including defaults)
+- `GET /api/v1/contexts/defaults` - List only default contexts
+- `GET /api/v1/contexts/{id}` - Get single context
+- `POST /api/v1/contexts` - Create custom context
+- `PATCH /api/v1/contexts/{id}` - Update context (cannot modify defaults)
+- `DELETE /api/v1/contexts/{id}` - Archive context (cannot delete defaults)
+- `POST /api/v1/contexts/{id}/restore` - Restore archived context
+
+## Test Plan
+
+### Unit Tests
+
+#### contexts Redux slice (`web/src/tests/unit/features/contexts/contextsSlice.test.js`)
+1. Initial state verification
+2. `fetchContexts` async thunk - pending, fulfilled, rejected states
+3. `createContext` async thunk - pending, fulfilled, rejected states
+4. `updateContext` async thunk - pending, fulfilled, rejected states
+5. `deleteContext` async thunk - pending, fulfilled, rejected states
+6. Selector tests: `selectAllContexts`, `selectDefaultContexts`, `selectCustomContexts`, `selectContextsLoading`, `selectContextsError`
+7. `clearError` reducer action
+
+#### ContextsPage (`web/src/tests/unit/pages/ContextsPage.test.jsx`)
+1. Renders loading state while fetching
+2. Renders contexts list when loaded
+3. Shows default contexts with appropriate badge
+4. Shows custom contexts that can be edited
+5. Handles empty state (no custom contexts)
+6. Shows error message on fetch failure
+7. Create new context form validation
+8. Edit context modal interactions
+9. Delete context confirmation dialog
+
+#### ContextFilterSidebar (`web/src/tests/unit/components/ContextFilterSidebar.test.jsx`)
+1. Renders all contexts as filter options
+2. Shows active filter state
+3. Handles context selection callback
+4. Shows count of tasks per context
+5. Handles "All" filter option
+6. Responsive behavior (collapsed/expanded)
+
+### Integration Tests
+- Context selection persists across page navigation
+- Creating a context updates the sidebar immediately
+- Deleting a context removes it from sidebar and task associations
+
+### E2E Tests
+- Full context CRUD workflow
+- Context filtering on tasks page (deferred to P4-018)
+
+## Implementation Tasks
+
+| Task ID | Description | File | Status |
+|---------|-------------|------|--------|
+| P4-009 | Create contexts Redux slice | `web/src/features/contexts/contextsSlice.js` | completed |
+| P4-010 | Replace ContextsPage placeholder with full implementation | `web/src/pages/ContextsPage.jsx` | completed |
+| P4-011 | Write unit tests for ContextsPage | `web/src/tests/unit/pages/ContextsPage.test.jsx` | completed |
+| P4-012 | Create ContextFilterSidebar component | `web/src/components/ContextFilterSidebar.jsx` | completed |
+| P4-013 | Write unit tests for ContextFilterSidebar | `web/src/tests/unit/components/ContextFilterSidebar.test.jsx` | completed |
+
+## Side Effects Analysis
+
+### Dependencies Affected
+- `web/src/store/store.js` - Must add contexts reducer
+- `web/src/App.jsx` - Must add `/contexts` route
+- `web/src/components/Navigation.jsx` - May need contexts link
+
+### Potential Side Effects
+1. **Store configuration**: Adding contexts reducer to store requires store.js modification
+2. **Routing**: New route needs to be added - verify no route conflicts
+3. **API client**: `contextsAPI` already defined - no changes needed
+4. **Navigation**: May want to add "Contexts" link to sidebar navigation
+
+### Breaking Changes
+- None expected - this is a new module that doesn't modify existing functionality
+
+## Pre-PR Checklist
+- [ ] All tests written and passing
+- [ ] Code follows clean code principles
+- [ ] No side effects unaddressed
+- [ ] Documentation updated if needed
+
+## Review Notes
+{Will be filled during review cycles}

--- a/docs/implementation/phase-4-3.md
+++ b/docs/implementation/phase-4-3.md
@@ -101,10 +101,25 @@
 - None expected - this is a new module that doesn't modify existing functionality
 
 ## Pre-PR Checklist
-- [ ] All tests written and passing
-- [ ] Code follows clean code principles
-- [ ] No side effects unaddressed
-- [ ] Documentation updated if needed
+- [x] All tests written and passing (596 tests)
+- [x] Code follows clean code principles
+- [x] No side effects unaddressed
+- [x] Documentation updated if needed
 
 ## Review Notes
-{Will be filled during review cycles}
+
+### Review Cycle 1 - 2025-12-03
+**Status:** Passed
+
+**Findings:**
+- False positive XSS alert - code safely renders `{context.name}` without dangerouslySetInnerHTML
+- Modal dialogs have proper `role="dialog"` and `aria-modal="true"` attributes
+- Form validation present with clear user feedback
+- Loading states and error handling implemented correctly
+
+**Suggestions for future iterations (not blocking):**
+- Consider extracting ContextForm, ContextCard as separate components
+- Add useMemo for filtered context lists when search/filter is added
+- Consider optimistic updates for better UX
+
+**Conclusion:** Code is production-ready for Phase 4.3 scope

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -6,6 +6,7 @@ import PasswordResetRequestPage from './pages/PasswordResetRequestPage';
 import PasswordResetConfirmPage from './pages/PasswordResetConfirmPage';
 import InboxPage from './pages/InboxPage';
 import ClarifyPage from './pages/ClarifyPage';
+import ContextsPage from './pages/ContextsPage';
 import AccountSettingsPage from './pages/AccountSettingsPage';
 import AccountDeletionPage from './pages/AccountDeletionPage';
 import ProtectedRoute from './components/ProtectedRoute';
@@ -47,6 +48,16 @@ function App() {
             <ProtectedRoute>
               <AuthenticatedLayout>
                 <ClarifyPage />
+              </AuthenticatedLayout>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/contexts"
+          element={
+            <ProtectedRoute>
+              <AuthenticatedLayout>
+                <ContextsPage />
               </AuthenticatedLayout>
             </ProtectedRoute>
           }

--- a/web/src/components/ContextFilterSidebar.jsx
+++ b/web/src/components/ContextFilterSidebar.jsx
@@ -1,0 +1,154 @@
+import { useState, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
+import {
+  fetchContexts,
+  selectAllContexts,
+  selectContextsLoading,
+} from '../features/contexts/contextsSlice';
+
+const ContextFilterSidebar = ({ selectedContextId, onContextSelect, taskCounts = {} }) => {
+  const dispatch = useDispatch();
+  const contexts = useSelector(selectAllContexts);
+  const isLoading = useSelector(selectContextsLoading);
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  // Fetch contexts on mount if not already loaded
+  useEffect(() => {
+    dispatch(fetchContexts());
+  }, [dispatch]);
+
+  // Calculate total task count
+  const totalTaskCount = Object.values(taskCounts).reduce((sum, count) => sum + count, 0);
+
+  const handleToggle = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  const handleContextClick = (contextId) => {
+    onContextSelect(contextId);
+  };
+
+  const handleAllClick = () => {
+    onContextSelect(null);
+  };
+
+  return (
+    <aside
+      data-testid="context-sidebar"
+      data-expanded={isExpanded}
+      className={`bg-white border-r border-gray-200 transition-all duration-300 ${
+        isExpanded ? 'w-64' : 'w-16'
+      }`}
+    >
+      {/* Header with toggle */}
+      <div className="flex items-center justify-between p-4 border-b border-gray-200">
+        {isExpanded && (
+          <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wider">
+            Contexts
+          </h2>
+        )}
+        <button
+          onClick={handleToggle}
+          className="p-1 text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
+          aria-label="Toggle sidebar"
+        >
+          <svg
+            className={`w-5 h-5 transition-transform ${isExpanded ? '' : 'rotate-180'}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Loading State */}
+      {isLoading && contexts.length === 0 && (
+        <div className="p-4 text-center text-gray-500 text-sm">
+          Loading contexts...
+        </div>
+      )}
+
+      {/* Empty State */}
+      {!isLoading && contexts.length === 0 && (
+        <div className="p-4 text-center text-gray-500 text-sm">
+          No contexts available
+        </div>
+      )}
+
+      {/* Context List */}
+      {contexts.length > 0 && (
+        <nav className="p-2">
+          {/* All Contexts Option */}
+          <button
+            onClick={handleAllClick}
+            className={`w-full flex items-center justify-between px-3 py-2 text-sm font-medium rounded-md transition-colors ${
+              selectedContextId === null
+                ? 'bg-blue-50 text-blue-700'
+                : 'text-gray-700 hover:bg-gray-100'
+            }`}
+            aria-label="All Contexts"
+          >
+            <div className="flex items-center gap-2">
+              <div className="w-3 h-3 rounded-full bg-gray-400" />
+              {isExpanded && <span>All Contexts</span>}
+            </div>
+            {isExpanded && (
+              <span
+                data-testid="all-contexts-count"
+                className="text-xs text-gray-500 bg-gray-100 px-2 py-0.5 rounded-full"
+              >
+                {totalTaskCount}
+              </span>
+            )}
+          </button>
+
+          {/* Context Items */}
+          <div className="mt-2 space-y-1">
+            {contexts.map((context) => {
+              const count = taskCounts[context.id] || 0;
+              const isSelected = selectedContextId === context.id;
+
+              return (
+                <button
+                  key={context.id}
+                  onClick={() => handleContextClick(context.id)}
+                  className={`w-full flex items-center justify-between px-3 py-2 text-sm font-medium rounded-md transition-colors ${
+                    isSelected
+                      ? 'bg-blue-50 text-blue-700'
+                      : 'text-gray-700 hover:bg-gray-100'
+                  }`}
+                  aria-label={context.name}
+                >
+                  <div className="flex items-center gap-2">
+                    <div
+                      data-testid={`filter-color-${context.id}`}
+                      className="w-3 h-3 rounded-full"
+                      style={{ backgroundColor: context.color || '#6B7280' }}
+                    />
+                    {isExpanded && <span>{context.name}</span>}
+                  </div>
+                  {isExpanded && (
+                    <span className="text-xs text-gray-500 bg-gray-100 px-2 py-0.5 rounded-full">
+                      {count}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </nav>
+      )}
+    </aside>
+  );
+};
+
+ContextFilterSidebar.propTypes = {
+  selectedContextId: PropTypes.string,
+  onContextSelect: PropTypes.func.isRequired,
+  taskCounts: PropTypes.objectOf(PropTypes.number),
+};
+
+export default ContextFilterSidebar;

--- a/web/src/features/contexts/contextsSlice.js
+++ b/web/src/features/contexts/contextsSlice.js
@@ -1,0 +1,170 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import { contextsAPI } from '../../services/api';
+
+// Context status constants
+export const CONTEXT_STATUS = {
+  ACTIVE: 'active',
+  ARCHIVED: 'archived',
+};
+
+// Async thunks
+export const fetchContexts = createAsyncThunk(
+  'contexts/fetchAll',
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await contextsAPI.getAll();
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(error.response?.data || { error: 'Failed to fetch contexts' });
+    }
+  }
+);
+
+export const createContext = createAsyncThunk(
+  'contexts/create',
+  async (contextData, { rejectWithValue }) => {
+    try {
+      const response = await contextsAPI.create(contextData);
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(error.response?.data || { error: 'Failed to create context' });
+    }
+  }
+);
+
+export const updateContext = createAsyncThunk(
+  'contexts/update',
+  async ({ id, data }, { rejectWithValue }) => {
+    try {
+      const response = await contextsAPI.update(id, data);
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(error.response?.data || { error: 'Failed to update context' });
+    }
+  }
+);
+
+export const deleteContext = createAsyncThunk(
+  'contexts/delete',
+  async (id, { rejectWithValue }) => {
+    try {
+      await contextsAPI.delete(id);
+      return id;
+    } catch (error) {
+      return rejectWithValue(error.response?.data || { error: 'Failed to delete context' });
+    }
+  }
+);
+
+const initialState = {
+  contexts: [],
+  loading: false,
+  error: null,
+};
+
+const contextsSlice = createSlice({
+  name: 'contexts',
+  initialState,
+  reducers: {
+    clearError: (state) => {
+      state.error = null;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      // Fetch contexts
+      .addCase(fetchContexts.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchContexts.fulfilled, (state, action) => {
+        state.loading = false;
+        state.contexts = action.payload.contexts || [];
+        state.error = null;
+      })
+      .addCase(fetchContexts.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload?.error || 'Failed to fetch contexts';
+      })
+
+      // Create context
+      .addCase(createContext.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(createContext.fulfilled, (state, action) => {
+        state.loading = false;
+        const newContext = action.payload.context;
+        if (newContext) {
+          state.contexts.push(newContext);
+        }
+        state.error = null;
+      })
+      .addCase(createContext.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload?.error || 'Failed to create context';
+      })
+
+      // Update context
+      .addCase(updateContext.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(updateContext.fulfilled, (state, action) => {
+        state.loading = false;
+        const updatedContext = action.payload.context;
+        if (updatedContext) {
+          const index = state.contexts.findIndex((c) => c.id === updatedContext.id);
+          if (index !== -1) {
+            state.contexts[index] = updatedContext;
+          }
+        }
+        state.error = null;
+      })
+      .addCase(updateContext.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload?.error || 'Failed to update context';
+      })
+
+      // Delete context
+      .addCase(deleteContext.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(deleteContext.fulfilled, (state, action) => {
+        state.loading = false;
+        const deletedId = action.payload;
+        state.contexts = state.contexts.filter((c) => c.id !== deletedId);
+        state.error = null;
+      })
+      .addCase(deleteContext.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload?.error || 'Failed to delete context';
+      });
+  },
+});
+
+export const { clearError } = contextsSlice.actions;
+
+// Selectors
+export const selectAllContexts = (state) =>
+  state.contexts.contexts.filter((c) => c.status === CONTEXT_STATUS.ACTIVE);
+
+export const selectDefaultContexts = (state) =>
+  state.contexts.contexts.filter(
+    (c) => c.is_default === true && c.status === CONTEXT_STATUS.ACTIVE
+  );
+
+export const selectCustomContexts = (state) =>
+  state.contexts.contexts.filter(
+    (c) => c.is_default === false && c.status === CONTEXT_STATUS.ACTIVE
+  );
+
+export const selectContextsLoading = (state) => state.contexts.loading;
+
+export const selectContextsError = (state) => state.contexts.error;
+
+export const selectContextById = (state, id) =>
+  state.contexts.contexts.find((c) => c.id === id);
+
+export default contextsSlice.reducer;

--- a/web/src/pages/ContextsPage.jsx
+++ b/web/src/pages/ContextsPage.jsx
@@ -1,0 +1,425 @@
+import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  fetchContexts,
+  createContext,
+  updateContext,
+  deleteContext,
+  selectAllContexts,
+  selectDefaultContexts,
+  selectCustomContexts,
+  selectContextsLoading,
+  selectContextsError,
+  clearError,
+} from '../features/contexts/contextsSlice';
+import Spinner from '../components/Spinner';
+
+// Preset colors for context color picker
+const PRESET_COLORS = [
+  '#4A90D9', // Blue
+  '#50C878', // Green
+  '#FF6B6B', // Red
+  '#9B59B6', // Purple
+  '#F39C12', // Orange
+  '#1ABC9C', // Teal
+  '#E91E63', // Pink
+  '#607D8B', // Gray Blue
+];
+
+const ContextsPage = () => {
+  const dispatch = useDispatch();
+  const allContexts = useSelector(selectAllContexts);
+  const defaultContexts = useSelector(selectDefaultContexts);
+  const customContexts = useSelector(selectCustomContexts);
+  const isLoading = useSelector(selectContextsLoading);
+  const error = useSelector(selectContextsError);
+
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [selectedContext, setSelectedContext] = useState(null);
+  const [formData, setFormData] = useState({ name: '', color: PRESET_COLORS[0] });
+  const [formError, setFormError] = useState('');
+
+  // Fetch contexts on mount
+  useEffect(() => {
+    dispatch(fetchContexts());
+  }, [dispatch]);
+
+  // Clear error after 5 seconds
+  useEffect(() => {
+    if (error) {
+      const timer = setTimeout(() => {
+        dispatch(clearError());
+      }, 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [error, dispatch]);
+
+  const handleOpenCreateModal = () => {
+    setFormData({ name: '', color: PRESET_COLORS[0] });
+    setFormError('');
+    setIsCreateModalOpen(true);
+  };
+
+  const handleOpenEditModal = (context) => {
+    setSelectedContext(context);
+    setFormData({ name: context.name, color: context.color || PRESET_COLORS[0] });
+    setFormError('');
+    setIsEditModalOpen(true);
+  };
+
+  const handleOpenDeleteDialog = (context) => {
+    setSelectedContext(context);
+    setIsDeleteDialogOpen(true);
+  };
+
+  const handleCloseModals = () => {
+    setIsCreateModalOpen(false);
+    setIsEditModalOpen(false);
+    setIsDeleteDialogOpen(false);
+    setSelectedContext(null);
+    setFormData({ name: '', color: PRESET_COLORS[0] });
+    setFormError('');
+  };
+
+  const validateForm = () => {
+    if (!formData.name.startsWith('@')) {
+      setFormError('Context name must start with @');
+      return false;
+    }
+    if (formData.name.length < 2) {
+      setFormError('Context name must be at least 2 characters');
+      return false;
+    }
+    setFormError('');
+    return true;
+  };
+
+  const handleCreateContext = async () => {
+    if (!validateForm()) return;
+
+    try {
+      await dispatch(createContext({ name: formData.name, color: formData.color })).unwrap();
+      handleCloseModals();
+    } catch (err) {
+      setFormError(err.error || 'Failed to create context');
+    }
+  };
+
+  const handleUpdateContext = async () => {
+    if (!validateForm()) return;
+
+    try {
+      await dispatch(
+        updateContext({ id: selectedContext.id, data: { name: formData.name, color: formData.color } })
+      ).unwrap();
+      handleCloseModals();
+    } catch (err) {
+      setFormError(err.error || 'Failed to update context');
+    }
+  };
+
+  const handleDeleteContext = async () => {
+    try {
+      await dispatch(deleteContext(selectedContext.id)).unwrap();
+      handleCloseModals();
+    } catch (err) {
+      console.error('Failed to delete context:', err);
+    }
+  };
+
+  const contextCount = allContexts.length;
+
+  return (
+    <div className="max-w-4xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+      {/* Header */}
+      <div className="mb-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Contexts</h1>
+            <p className="mt-1 text-sm text-gray-500">
+              Organize your actions by situation
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+              {contextCount} {contextCount === 1 ? 'context' : 'contexts'}
+            </span>
+            <button
+              onClick={handleOpenCreateModal}
+              className="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              <svg className="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+              </svg>
+              New Context
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Error Message */}
+      {error && (
+        <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg" role="alert">
+          <div className="flex">
+            <svg className="h-5 w-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <div className="ml-3">
+              <p className="text-sm text-red-700">{error}</p>
+            </div>
+            <button
+              onClick={() => dispatch(clearError())}
+              className="ml-auto pl-3 text-red-500 hover:text-red-700"
+            >
+              <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Loading State */}
+      {isLoading && allContexts.length === 0 && (
+        <div className="flex justify-center items-center py-12">
+          <Spinner size="lg" className="text-blue-500" />
+          <span className="ml-2 text-gray-500">Loading contexts...</span>
+        </div>
+      )}
+
+      {/* Empty State */}
+      {!isLoading && allContexts.length === 0 && (
+        <div className="text-center py-12">
+          <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+          <h3 className="mt-2 text-sm font-medium text-gray-900">No contexts yet</h3>
+          <p className="mt-1 text-sm text-gray-500">
+            Create contexts to organize your tasks by situation (e.g., @Office, @Home).
+          </p>
+        </div>
+      )}
+
+      {/* Contexts List */}
+      {allContexts.length > 0 && (
+        <div className="space-y-6">
+          {/* Default Contexts Section */}
+          {defaultContexts.length > 0 && (
+            <div>
+              <h2 className="text-lg font-medium text-gray-900 mb-3">Default Contexts</h2>
+              <div className="bg-white shadow rounded-lg divide-y divide-gray-200">
+                {defaultContexts.map((context) => (
+                  <div key={context.id} className="p-4 flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                      <div
+                        data-testid={`context-color-${context.id}`}
+                        className="w-4 h-4 rounded-full"
+                        style={{ backgroundColor: context.color || '#6B7280' }}
+                      />
+                      <span className="text-sm font-medium text-gray-900">{context.name}</span>
+                      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
+                        Default
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Custom Contexts Section */}
+          {customContexts.length > 0 && (
+            <div>
+              <h2 className="text-lg font-medium text-gray-900 mb-3">Custom Contexts</h2>
+              <div className="bg-white shadow rounded-lg divide-y divide-gray-200">
+                {customContexts.map((context) => (
+                  <div key={context.id} className="p-4 flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                      <div
+                        data-testid={`context-color-${context.id}`}
+                        className="w-4 h-4 rounded-full"
+                        style={{ backgroundColor: context.color || '#6B7280' }}
+                      />
+                      <span className="text-sm font-medium text-gray-900">{context.name}</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => handleOpenEditModal(context)}
+                        className="p-1 text-gray-400 hover:text-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded"
+                        aria-label={`Edit "${context.name}"`}
+                        title="Edit context"
+                      >
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                        </svg>
+                      </button>
+                      <button
+                        onClick={() => handleOpenDeleteDialog(context)}
+                        className="p-1 text-gray-400 hover:text-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 rounded"
+                        aria-label={`Delete "${context.name}"`}
+                        title="Delete context"
+                      >
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Create/Edit Modal */}
+      {(isCreateModalOpen || isEditModalOpen) && (
+        <div className="fixed inset-0 z-50 overflow-y-auto">
+          <div className="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+            {/* Backdrop */}
+            <div
+              className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+              onClick={handleCloseModals}
+              aria-hidden="true"
+            />
+
+            {/* Modal */}
+            <div
+              role="dialog"
+              aria-modal="true"
+              className="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6"
+            >
+              <div>
+                <h3 className="text-lg font-medium text-gray-900 mb-4">
+                  {isCreateModalOpen ? 'Create New Context' : 'Edit Context'}
+                </h3>
+
+                <div className="space-y-4">
+                  {/* Name Input */}
+                  <div>
+                    <label htmlFor="context-name" className="block text-sm font-medium text-gray-700">
+                      Name
+                    </label>
+                    <input
+                      type="text"
+                      id="context-name"
+                      value={formData.name}
+                      onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                      placeholder="@ContextName"
+                      className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                    />
+                  </div>
+
+                  {/* Color Picker */}
+                  <div>
+                    <label htmlFor="context-color" className="block text-sm font-medium text-gray-700">
+                      Color
+                    </label>
+                    <div id="context-color" className="mt-2 flex flex-wrap gap-2">
+                      {PRESET_COLORS.map((color) => (
+                        <button
+                          key={color}
+                          type="button"
+                          data-testid={`color-option-${color}`}
+                          onClick={() => setFormData({ ...formData, color })}
+                          className={`w-8 h-8 rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 ${
+                            formData.color === color ? 'ring-2 ring-offset-2 ring-blue-500' : ''
+                          }`}
+                          style={{ backgroundColor: color }}
+                          aria-label={`Select color ${color}`}
+                        />
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* Form Error */}
+                  {formError && (
+                    <p className="text-sm text-red-600">{formError}</p>
+                  )}
+                </div>
+
+                {/* Modal Actions */}
+                <div className="mt-5 sm:mt-6 flex gap-3 justify-end">
+                  <button
+                    type="button"
+                    onClick={handleCloseModals}
+                    className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={isCreateModalOpen ? handleCreateContext : handleUpdateContext}
+                    className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                  >
+                    {isCreateModalOpen ? 'Create' : 'Save'}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Confirmation Dialog */}
+      {isDeleteDialogOpen && selectedContext && (
+        <div className="fixed inset-0 z-50 overflow-y-auto">
+          <div className="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+            {/* Backdrop */}
+            <div
+              className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+              onClick={handleCloseModals}
+              aria-hidden="true"
+            />
+
+            {/* Dialog */}
+            <div
+              role="dialog"
+              aria-modal="true"
+              className="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6"
+            >
+              <div>
+                <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100">
+                  <svg className="h-6 w-6 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                  </svg>
+                </div>
+                <div className="mt-3 text-center sm:mt-5">
+                  <h3 className="text-lg font-medium text-gray-900">Delete Context</h3>
+                  <div className="mt-2">
+                    <p className="text-sm text-gray-500">
+                      Are you sure you want to delete <strong>{selectedContext.name}</strong>? This action cannot be undone. Any tasks associated with this context will be unlinked.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Dialog Actions */}
+              <div className="mt-5 sm:mt-6 flex gap-3 justify-center">
+                <button
+                  type="button"
+                  onClick={handleCloseModals}
+                  className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={handleDeleteContext}
+                  className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+                >
+                  Confirm
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ContextsPage;

--- a/web/src/store/store.js
+++ b/web/src/store/store.js
@@ -3,6 +3,7 @@ import authReducer from '../features/auth/authSlice';
 import accountReducer from '../features/account/accountSlice';
 import inboxReducer from '../features/inbox/inboxSlice';
 import tasksReducer from '../features/tasks/tasksSlice';
+import contextsReducer from '../features/contexts/contextsSlice';
 
 export const store = configureStore({
   reducer: {
@@ -10,6 +11,7 @@ export const store = configureStore({
     account: accountReducer,
     inbox: inboxReducer,
     tasks: tasksReducer,
+    contexts: contextsReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({

--- a/web/src/tests/unit/components/ContextFilterSidebar.test.jsx
+++ b/web/src/tests/unit/components/ContextFilterSidebar.test.jsx
@@ -1,0 +1,344 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import contextsReducer from '../../../features/contexts/contextsSlice';
+import ContextFilterSidebar from '../../../components/ContextFilterSidebar';
+
+// Mock the API module
+vi.mock('../../../services/api', () => ({
+  contextsAPI: {
+    getAll: vi.fn(),
+  },
+}));
+
+import { contextsAPI } from '../../../services/api';
+
+describe('ContextFilterSidebar', () => {
+  const mockContextOffice = {
+    id: 'ctx-1',
+    name: '@Office',
+    color: '#4A90D9',
+    is_default: true,
+    status: 'active',
+    position: 0,
+  };
+
+  const mockContextHome = {
+    id: 'ctx-2',
+    name: '@Home',
+    color: '#50C878',
+    is_default: true,
+    status: 'active',
+    position: 1,
+  };
+
+  const mockContextCustom = {
+    id: 'ctx-3',
+    name: '@Meeting',
+    color: '#9B59B6',
+    is_default: false,
+    status: 'active',
+    position: 2,
+  };
+
+  const mockTaskCounts = {
+    'ctx-1': 5,
+    'ctx-2': 3,
+    'ctx-3': 2,
+  };
+
+  const createStore = (contextsState = {}) => {
+    return configureStore({
+      reducer: {
+        contexts: contextsReducer,
+      },
+      preloadedState: {
+        contexts: {
+          contexts: [],
+          loading: false,
+          error: null,
+          ...contextsState,
+        },
+      },
+    });
+  };
+
+  const defaultProps = {
+    selectedContextId: null,
+    onContextSelect: vi.fn(),
+    taskCounts: {},
+  };
+
+  const renderComponent = (store, props = {}) => {
+    return render(
+      <Provider store={store}>
+        <ContextFilterSidebar {...defaultProps} {...props} />
+      </Provider>
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    contextsAPI.getAll.mockResolvedValue({
+      data: { contexts: [], count: 0 },
+    });
+  });
+
+  describe('rendering', () => {
+    it('renders all contexts as filter options', () => {
+      const store = createStore({
+        contexts: [mockContextOffice, mockContextHome, mockContextCustom],
+      });
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [mockContextOffice, mockContextHome, mockContextCustom], count: 3 },
+      });
+      renderComponent(store);
+
+      expect(screen.getByText('@Office')).toBeInTheDocument();
+      expect(screen.getByText('@Home')).toBeInTheDocument();
+      expect(screen.getByText('@Meeting')).toBeInTheDocument();
+    });
+
+    it('renders "All" filter option', () => {
+      const store = createStore({
+        contexts: [mockContextOffice],
+      });
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [mockContextOffice], count: 1 },
+      });
+      renderComponent(store);
+
+      expect(screen.getByText('All Contexts')).toBeInTheDocument();
+    });
+
+    it('displays context colors as visual indicators', () => {
+      const store = createStore({
+        contexts: [mockContextOffice],
+      });
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [mockContextOffice], count: 1 },
+      });
+      renderComponent(store);
+
+      const colorIndicator = screen.getByTestId(`filter-color-${mockContextOffice.id}`);
+      expect(colorIndicator).toHaveStyle({ backgroundColor: mockContextOffice.color });
+    });
+  });
+
+  describe('active filter state', () => {
+    it('highlights selected context', () => {
+      const store = createStore({
+        contexts: [mockContextOffice, mockContextHome],
+      });
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [mockContextOffice, mockContextHome], count: 2 },
+      });
+      renderComponent(store, { selectedContextId: mockContextOffice.id });
+
+      const selectedItem = screen.getByRole('button', { name: /@Office/i });
+      expect(selectedItem).toHaveClass('bg-blue-50');
+    });
+
+    it('highlights "All" when no context selected', () => {
+      const store = createStore({
+        contexts: [mockContextOffice],
+      });
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [mockContextOffice], count: 1 },
+      });
+      renderComponent(store, { selectedContextId: null });
+
+      const allButton = screen.getByRole('button', { name: /all contexts/i });
+      expect(allButton).toHaveClass('bg-blue-50');
+    });
+  });
+
+  describe('context selection', () => {
+    it('calls onContextSelect when context is clicked', async () => {
+      const user = userEvent.setup();
+      const onContextSelect = vi.fn();
+      const store = createStore({
+        contexts: [mockContextOffice],
+      });
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [mockContextOffice], count: 1 },
+      });
+      renderComponent(store, { onContextSelect });
+
+      await user.click(screen.getByRole('button', { name: /@Office/i }));
+
+      expect(onContextSelect).toHaveBeenCalledWith(mockContextOffice.id);
+    });
+
+    it('calls onContextSelect with null when "All" is clicked', async () => {
+      const user = userEvent.setup();
+      const onContextSelect = vi.fn();
+      const store = createStore({
+        contexts: [mockContextOffice],
+      });
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [mockContextOffice], count: 1 },
+      });
+      renderComponent(store, { selectedContextId: mockContextOffice.id, onContextSelect });
+
+      await user.click(screen.getByRole('button', { name: /all contexts/i }));
+
+      expect(onContextSelect).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('task counts', () => {
+    it('displays task count for each context', () => {
+      const store = createStore({
+        contexts: [mockContextOffice, mockContextHome],
+      });
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [mockContextOffice, mockContextHome], count: 2 },
+      });
+      renderComponent(store, { taskCounts: mockTaskCounts });
+
+      expect(screen.getByText('5')).toBeInTheDocument();
+      expect(screen.getByText('3')).toBeInTheDocument();
+    });
+
+    it('displays total task count for "All" option', async () => {
+      const store = createStore({
+        contexts: [mockContextOffice, mockContextHome],
+      });
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [mockContextOffice, mockContextHome], count: 2 },
+      });
+      // Only pass task counts for the contexts we're displaying
+      const filteredTaskCounts = {
+        'ctx-1': 5,
+        'ctx-2': 3,
+      };
+      renderComponent(store, { taskCounts: filteredTaskCounts });
+
+      // Wait for contexts to be available
+      await waitFor(() => {
+        expect(screen.getByText('@Office')).toBeInTheDocument();
+      });
+
+      // Total should be 5 + 3 = 8
+      expect(screen.getByTestId('all-contexts-count')).toHaveTextContent('8');
+    });
+
+    it('shows zero when no tasks for a context', () => {
+      const store = createStore({
+        contexts: [mockContextOffice],
+      });
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [mockContextOffice], count: 1 },
+      });
+      renderComponent(store, { taskCounts: {} });
+
+      // When no task counts provided, should show 0
+      const contextButton = screen.getByRole('button', { name: /@Office/i });
+      expect(contextButton).toHaveTextContent('0');
+    });
+  });
+
+  describe('responsive behavior', () => {
+    it('renders toggle button', () => {
+      const store = createStore({
+        contexts: [mockContextOffice],
+      });
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [mockContextOffice], count: 1 },
+      });
+      renderComponent(store);
+
+      expect(screen.getByRole('button', { name: /toggle/i })).toBeInTheDocument();
+    });
+
+    it('starts expanded by default', () => {
+      const store = createStore({
+        contexts: [mockContextOffice],
+      });
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [mockContextOffice], count: 1 },
+      });
+      renderComponent(store);
+
+      expect(screen.getByTestId('context-sidebar')).toHaveAttribute('data-expanded', 'true');
+    });
+
+    it('collapses when toggle button is clicked', async () => {
+      const user = userEvent.setup();
+      const store = createStore({
+        contexts: [mockContextOffice],
+      });
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [mockContextOffice], count: 1 },
+      });
+      renderComponent(store);
+
+      const toggleButton = screen.getByRole('button', { name: /toggle/i });
+
+      // Click to collapse (starts expanded)
+      await user.click(toggleButton);
+      await waitFor(() => {
+        expect(screen.getByTestId('context-sidebar')).toHaveAttribute('data-expanded', 'false');
+      });
+    });
+
+    it('expands when toggle button is clicked after collapsing', async () => {
+      const user = userEvent.setup();
+      const store = createStore({
+        contexts: [mockContextOffice],
+      });
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [mockContextOffice], count: 1 },
+      });
+      renderComponent(store);
+
+      const toggleButton = screen.getByRole('button', { name: /toggle/i });
+
+      // Click to collapse
+      await user.click(toggleButton);
+      await waitFor(() => {
+        expect(screen.getByTestId('context-sidebar')).toHaveAttribute('data-expanded', 'false');
+      });
+
+      // Click to expand
+      await user.click(toggleButton);
+      await waitFor(() => {
+        expect(screen.getByTestId('context-sidebar')).toHaveAttribute('data-expanded', 'true');
+      });
+    });
+  });
+
+  describe('empty state', () => {
+    it('shows message when no contexts exist', async () => {
+      // Mock API to return empty contexts
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [], count: 0 },
+      });
+      const store = createStore({
+        contexts: [],
+        loading: false,
+      });
+      renderComponent(store);
+
+      // Wait for fetch to complete and show empty state
+      await waitFor(() => {
+        expect(screen.getByText(/no contexts/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows loading indicator when loading', () => {
+      const store = createStore({
+        contexts: [],
+        loading: true,
+      });
+      renderComponent(store);
+
+      expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/tests/unit/features/contexts/contextsSlice.test.js
+++ b/web/src/tests/unit/features/contexts/contextsSlice.test.js
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { configureStore } from '@reduxjs/toolkit';
+import contextsReducer, {
+  fetchContexts,
+  createContext,
+  updateContext,
+  deleteContext,
+  clearError,
+  selectAllContexts,
+  selectDefaultContexts,
+  selectCustomContexts,
+  selectContextsLoading,
+  selectContextsError,
+  CONTEXT_STATUS,
+} from '../../../../features/contexts/contextsSlice';
+import { contextsAPI } from '../../../../services/api';
+
+// Mock the API
+vi.mock('../../../../services/api', () => ({
+  contextsAPI: {
+    getAll: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+describe('contextsSlice', () => {
+  let store;
+
+  beforeEach(() => {
+    store = configureStore({
+      reducer: { contexts: contextsReducer },
+    });
+    vi.clearAllMocks();
+  });
+
+  describe('initial state', () => {
+    it('should have correct initial state', () => {
+      const state = store.getState().contexts;
+      expect(state.contexts).toEqual([]);
+      expect(state.loading).toBe(false);
+      expect(state.error).toBeNull();
+    });
+  });
+
+  describe('fetchContexts', () => {
+    const mockContexts = [
+      {
+        id: '1',
+        name: '@Office',
+        is_default: true,
+        status: 'active',
+        icon: 'building',
+        color: '#4A90D9',
+        position: 0,
+      },
+      {
+        id: '2',
+        name: '@Home',
+        is_default: true,
+        status: 'active',
+        icon: 'home',
+        color: '#50C878',
+        position: 1,
+      },
+      {
+        id: '3',
+        name: '@Custom',
+        is_default: false,
+        status: 'active',
+        icon: null,
+        color: '#FF6B6B',
+        position: 2,
+        user_id: 'user-1',
+      },
+    ];
+
+    it('should set loading to true when pending', async () => {
+      contextsAPI.getAll.mockImplementation(() => new Promise(() => {}));
+      store.dispatch(fetchContexts());
+      expect(store.getState().contexts.loading).toBe(true);
+      expect(store.getState().contexts.error).toBeNull();
+    });
+
+    it('should update contexts when fulfilled', async () => {
+      contextsAPI.getAll.mockResolvedValue({ data: { contexts: mockContexts, count: 3 } });
+      await store.dispatch(fetchContexts());
+
+      const state = store.getState().contexts;
+      expect(state.loading).toBe(false);
+      expect(state.contexts).toEqual(mockContexts);
+      expect(state.error).toBeNull();
+    });
+
+    it('should set error when rejected', async () => {
+      const errorMessage = 'Failed to fetch contexts';
+      contextsAPI.getAll.mockRejectedValue({
+        response: { data: { error: errorMessage } },
+      });
+
+      await store.dispatch(fetchContexts());
+
+      const state = store.getState().contexts;
+      expect(state.loading).toBe(false);
+      expect(state.error).toBe(errorMessage);
+    });
+
+    it('should handle network error gracefully', async () => {
+      contextsAPI.getAll.mockRejectedValue(new Error('Network error'));
+
+      await store.dispatch(fetchContexts());
+
+      const state = store.getState().contexts;
+      expect(state.loading).toBe(false);
+      expect(state.error).toBe('Failed to fetch contexts');
+    });
+  });
+
+  describe('createContext', () => {
+    const newContext = {
+      name: '@Meeting',
+      icon: 'calendar',
+      color: '#9B59B6',
+    };
+
+    const createdContext = {
+      id: 'new-id',
+      name: '@Meeting',
+      is_default: false,
+      status: 'active',
+      icon: 'calendar',
+      color: '#9B59B6',
+      position: 3,
+      user_id: 'user-1',
+    };
+
+    it('should set loading to true when pending', async () => {
+      contextsAPI.create.mockImplementation(() => new Promise(() => {}));
+      store.dispatch(createContext(newContext));
+      expect(store.getState().contexts.loading).toBe(true);
+    });
+
+    it('should add new context when fulfilled', async () => {
+      contextsAPI.create.mockResolvedValue({
+        data: { context: createdContext, message: 'Context created successfully' },
+      });
+
+      await store.dispatch(createContext(newContext));
+
+      const state = store.getState().contexts;
+      expect(state.loading).toBe(false);
+      expect(state.contexts).toContainEqual(createdContext);
+      expect(state.error).toBeNull();
+    });
+
+    it('should set error when creation fails', async () => {
+      contextsAPI.create.mockRejectedValue({
+        response: { data: { error: 'A context with this name already exists', code: 'DUPLICATE_NAME' } },
+      });
+
+      await store.dispatch(createContext(newContext));
+
+      const state = store.getState().contexts;
+      expect(state.loading).toBe(false);
+      expect(state.error).toBe('A context with this name already exists');
+    });
+  });
+
+  describe('updateContext', () => {
+    const existingContexts = [
+      { id: '1', name: '@Office', is_default: true, status: 'active' },
+      { id: '2', name: '@Custom', is_default: false, status: 'active', color: '#FF0000' },
+    ];
+
+    const updatedContext = {
+      id: '2',
+      name: '@Updated',
+      is_default: false,
+      status: 'active',
+      color: '#00FF00',
+    };
+
+    beforeEach(async () => {
+      contextsAPI.getAll.mockResolvedValue({ data: { contexts: existingContexts } });
+      await store.dispatch(fetchContexts());
+    });
+
+    it('should update context in state when fulfilled', async () => {
+      contextsAPI.update.mockResolvedValue({
+        data: { context: updatedContext, message: 'Context updated successfully' },
+      });
+
+      await store.dispatch(updateContext({ id: '2', data: { name: '@Updated', color: '#00FF00' } }));
+
+      const state = store.getState().contexts;
+      const updated = state.contexts.find((c) => c.id === '2');
+      expect(updated.name).toBe('@Updated');
+      expect(updated.color).toBe('#00FF00');
+    });
+
+    it('should set error when update fails', async () => {
+      contextsAPI.update.mockRejectedValue({
+        response: { data: { error: 'Cannot modify default contexts', code: 'CANNOT_MODIFY_DEFAULT' } },
+      });
+
+      await store.dispatch(updateContext({ id: '1', data: { name: '@NewName' } }));
+
+      const state = store.getState().contexts;
+      expect(state.error).toBe('Cannot modify default contexts');
+    });
+  });
+
+  describe('deleteContext', () => {
+    const existingContexts = [
+      { id: '1', name: '@Office', is_default: true, status: 'active' },
+      { id: '2', name: '@Custom', is_default: false, status: 'active' },
+    ];
+
+    beforeEach(async () => {
+      contextsAPI.getAll.mockResolvedValue({ data: { contexts: existingContexts } });
+      await store.dispatch(fetchContexts());
+    });
+
+    it('should remove context from state when fulfilled', async () => {
+      contextsAPI.delete.mockResolvedValue({ data: { message: 'Context archived successfully' } });
+
+      await store.dispatch(deleteContext('2'));
+
+      const state = store.getState().contexts;
+      expect(state.contexts).not.toContainEqual(expect.objectContaining({ id: '2' }));
+      expect(state.contexts).toHaveLength(1);
+    });
+
+    it('should set error when delete fails', async () => {
+      contextsAPI.delete.mockRejectedValue({
+        response: { data: { error: 'Cannot delete default contexts', code: 'CANNOT_DELETE_DEFAULT' } },
+      });
+
+      await store.dispatch(deleteContext('1'));
+
+      const state = store.getState().contexts;
+      expect(state.error).toBe('Cannot delete default contexts');
+      // Context should still exist
+      expect(state.contexts).toHaveLength(2);
+    });
+  });
+
+  describe('clearError reducer', () => {
+    it('should clear the error state', async () => {
+      contextsAPI.getAll.mockRejectedValue({
+        response: { data: { error: 'Some error' } },
+      });
+      await store.dispatch(fetchContexts());
+      expect(store.getState().contexts.error).toBe('Some error');
+
+      store.dispatch(clearError());
+      expect(store.getState().contexts.error).toBeNull();
+    });
+  });
+
+  describe('selectors', () => {
+    const mockState = {
+      contexts: {
+        contexts: [
+          { id: '1', name: '@Office', is_default: true, status: 'active' },
+          { id: '2', name: '@Home', is_default: true, status: 'active' },
+          { id: '3', name: '@Custom1', is_default: false, status: 'active' },
+          { id: '4', name: '@Custom2', is_default: false, status: 'archived' },
+        ],
+        loading: false,
+        error: null,
+      },
+    };
+
+    it('selectAllContexts returns all active contexts', () => {
+      const result = selectAllContexts(mockState);
+      expect(result).toHaveLength(3);
+      expect(result.every((c) => c.status === 'active')).toBe(true);
+    });
+
+    it('selectDefaultContexts returns only default active contexts', () => {
+      const result = selectDefaultContexts(mockState);
+      expect(result).toHaveLength(2);
+      expect(result.every((c) => c.is_default === true)).toBe(true);
+    });
+
+    it('selectCustomContexts returns only custom active contexts', () => {
+      const result = selectCustomContexts(mockState);
+      expect(result).toHaveLength(1);
+      expect(result.every((c) => c.is_default === false && c.status === 'active')).toBe(true);
+    });
+
+    it('selectContextsLoading returns loading state', () => {
+      expect(selectContextsLoading({ contexts: { loading: true } })).toBe(true);
+      expect(selectContextsLoading({ contexts: { loading: false } })).toBe(false);
+    });
+
+    it('selectContextsError returns error state', () => {
+      expect(selectContextsError({ contexts: { error: 'Error!' } })).toBe('Error!');
+      expect(selectContextsError({ contexts: { error: null } })).toBeNull();
+    });
+  });
+
+  describe('CONTEXT_STATUS constants', () => {
+    it('should export correct status constants', () => {
+      expect(CONTEXT_STATUS.ACTIVE).toBe('active');
+      expect(CONTEXT_STATUS.ARCHIVED).toBe('archived');
+    });
+  });
+});

--- a/web/src/tests/unit/pages/ContextsPage.test.jsx
+++ b/web/src/tests/unit/pages/ContextsPage.test.jsx
@@ -1,0 +1,601 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
+import contextsReducer from '../../../features/contexts/contextsSlice';
+import ContextsPage from '../../../pages/ContextsPage';
+
+// Mock the API module
+vi.mock('../../../services/api', () => ({
+  contextsAPI: {
+    getAll: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+import { contextsAPI } from '../../../services/api';
+
+describe('ContextsPage', () => {
+  const mockDefaultContext = {
+    id: 'ctx-default-1',
+    name: '@Office',
+    icon: 'building',
+    color: '#4A90D9',
+    is_default: true,
+    status: 'active',
+    position: 0,
+  };
+
+  const mockDefaultContext2 = {
+    id: 'ctx-default-2',
+    name: '@Home',
+    icon: 'home',
+    color: '#50C878',
+    is_default: true,
+    status: 'active',
+    position: 1,
+  };
+
+  const mockCustomContext = {
+    id: 'ctx-custom-1',
+    name: '@Meeting',
+    icon: 'calendar',
+    color: '#9B59B6',
+    is_default: false,
+    status: 'active',
+    position: 2,
+    user_id: 'user-1',
+  };
+
+  const mockCustomContext2 = {
+    id: 'ctx-custom-2',
+    name: '@Gym',
+    icon: null,
+    color: '#FF6B6B',
+    is_default: false,
+    status: 'active',
+    position: 3,
+    user_id: 'user-1',
+  };
+
+  const createStore = (contextsState = {}) => {
+    return configureStore({
+      reducer: {
+        contexts: contextsReducer,
+      },
+      preloadedState: {
+        contexts: {
+          contexts: [],
+          loading: false,
+          error: null,
+          ...contextsState,
+        },
+      },
+    });
+  };
+
+  const renderPage = (store) => {
+    return render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <ContextsPage />
+        </MemoryRouter>
+      </Provider>
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    contextsAPI.getAll.mockResolvedValue({
+      data: { contexts: [], count: 0 },
+    });
+    contextsAPI.create.mockResolvedValue({
+      data: { context: mockCustomContext, message: 'Context created successfully' },
+    });
+    contextsAPI.update.mockResolvedValue({
+      data: { context: { ...mockCustomContext, name: '@Updated' }, message: 'Context updated successfully' },
+    });
+    contextsAPI.delete.mockResolvedValue({
+      data: { message: 'Context archived successfully' },
+    });
+  });
+
+  describe('rendering', () => {
+    it('renders page title and description', async () => {
+      const store = createStore();
+      renderPage(store);
+
+      expect(screen.getByRole('heading', { name: /contexts/i })).toBeInTheDocument();
+      expect(screen.getByText(/organize your actions by situation/i)).toBeInTheDocument();
+    });
+
+    it('renders contexts count badge', async () => {
+      const store = createStore({
+        contexts: [mockDefaultContext, mockDefaultContext2, mockCustomContext],
+      });
+      renderPage(store);
+
+      expect(screen.getByText('3 contexts')).toBeInTheDocument();
+    });
+
+    it('renders singular context count', async () => {
+      const store = createStore({
+        contexts: [mockDefaultContext],
+      });
+      renderPage(store);
+
+      expect(screen.getByText('1 context')).toBeInTheDocument();
+    });
+
+    it('renders create new context button', async () => {
+      const store = createStore();
+      renderPage(store);
+
+      expect(screen.getByRole('button', { name: /new context/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows loading spinner when loading with no contexts', async () => {
+      const store = createStore({ loading: true, contexts: [] });
+      renderPage(store);
+
+      expect(screen.getByText(/loading contexts/i)).toBeInTheDocument();
+    });
+
+    it('does not show loading spinner when contexts exist', async () => {
+      const store = createStore({ loading: true, contexts: [mockDefaultContext] });
+      renderPage(store);
+
+      expect(screen.queryByText(/loading contexts/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('empty state', () => {
+    it('shows empty state when no contexts and not loading', async () => {
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [], count: 0 },
+      });
+      const store = createStore({ contexts: [], loading: false });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText(/no contexts yet/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('contexts list', () => {
+    it('renders default contexts section', async () => {
+      const store = createStore({
+        contexts: [mockDefaultContext, mockDefaultContext2],
+      });
+      renderPage(store);
+
+      expect(screen.getByText('Default Contexts')).toBeInTheDocument();
+    });
+
+    it('renders custom contexts section', async () => {
+      const store = createStore({
+        contexts: [mockDefaultContext, mockCustomContext],
+      });
+      renderPage(store);
+
+      expect(screen.getByText('Custom Contexts')).toBeInTheDocument();
+    });
+
+    it('renders context names', async () => {
+      const store = createStore({
+        contexts: [mockDefaultContext, mockCustomContext],
+      });
+      renderPage(store);
+
+      expect(screen.getByText('@Office')).toBeInTheDocument();
+      expect(screen.getByText('@Meeting')).toBeInTheDocument();
+    });
+
+    it('shows default badge for default contexts', async () => {
+      const store = createStore({
+        contexts: [mockDefaultContext],
+      });
+      renderPage(store);
+
+      expect(screen.getByText('Default')).toBeInTheDocument();
+    });
+
+    it('shows edit button only for custom contexts', async () => {
+      const store = createStore({
+        contexts: [mockDefaultContext, mockCustomContext],
+      });
+      renderPage(store);
+
+      // Should have edit button for custom context
+      expect(screen.getByRole('button', { name: /edit "@meeting"/i })).toBeInTheDocument();
+
+      // Should not have edit button for default context
+      expect(screen.queryByRole('button', { name: /edit "@office"/i })).not.toBeInTheDocument();
+    });
+
+    it('shows delete button only for custom contexts', async () => {
+      const store = createStore({
+        contexts: [mockDefaultContext, mockCustomContext],
+      });
+      renderPage(store);
+
+      // Should have delete button for custom context
+      expect(screen.getByRole('button', { name: /delete "@meeting"/i })).toBeInTheDocument();
+
+      // Should not have delete button for default context
+      expect(screen.queryByRole('button', { name: /delete "@office"/i })).not.toBeInTheDocument();
+    });
+
+    it('displays context colors as visual indicators', async () => {
+      const store = createStore({
+        contexts: [mockDefaultContext],
+      });
+      renderPage(store);
+
+      // Look for color indicator element
+      const colorIndicator = screen.getByTestId(`context-color-${mockDefaultContext.id}`);
+      expect(colorIndicator).toHaveStyle({ backgroundColor: mockDefaultContext.color });
+    });
+  });
+
+  describe('error handling', () => {
+    it('displays error message when error exists', async () => {
+      contextsAPI.getAll.mockRejectedValue({
+        response: { data: { error: 'Failed to fetch contexts' } },
+      });
+      const store = createStore();
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Failed to fetch contexts')).toBeInTheDocument();
+    });
+
+    it('allows dismissing error message', async () => {
+      const user = userEvent.setup();
+      contextsAPI.getAll.mockRejectedValue({
+        response: { data: { error: 'Some error' } },
+      });
+      const store = createStore();
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      });
+
+      const alert = screen.getByRole('alert');
+      const closeButton = within(alert).getByRole('button');
+      await user.click(closeButton);
+
+      await waitFor(() => {
+        expect(store.getState().contexts.error).toBeNull();
+      });
+    });
+  });
+
+  describe('data fetching', () => {
+    it('fetches contexts on mount', async () => {
+      const store = createStore();
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(contextsAPI.getAll).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('create context', () => {
+    it('opens create modal when clicking new context button', async () => {
+      const user = userEvent.setup();
+      const store = createStore();
+      renderPage(store);
+
+      await user.click(screen.getByRole('button', { name: /new context/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Create New Context')).toBeInTheDocument();
+    });
+
+    it('shows name input in create modal', async () => {
+      const user = userEvent.setup();
+      const store = createStore();
+      renderPage(store);
+
+      await user.click(screen.getByRole('button', { name: /new context/i }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+      });
+    });
+
+    it('validates that name starts with @', async () => {
+      const user = userEvent.setup();
+      const store = createStore();
+      renderPage(store);
+
+      await user.click(screen.getByRole('button', { name: /new context/i }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+      });
+
+      const input = screen.getByLabelText(/name/i);
+      await user.type(input, 'InvalidName');
+
+      const submitButton = screen.getByRole('button', { name: /create$/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/context name must start with @/i)).toBeInTheDocument();
+      });
+    });
+
+    it('creates context when form is valid', async () => {
+      const user = userEvent.setup();
+      const store = createStore();
+      renderPage(store);
+
+      await user.click(screen.getByRole('button', { name: /new context/i }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+      });
+
+      const input = screen.getByLabelText(/name/i);
+      await user.type(input, '@NewContext');
+
+      const submitButton = screen.getByRole('button', { name: /create$/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(contextsAPI.create).toHaveBeenCalledWith(
+          expect.objectContaining({ name: '@NewContext' })
+        );
+      });
+    });
+
+    it('closes modal after successful creation', async () => {
+      const user = userEvent.setup();
+      const store = createStore();
+      renderPage(store);
+
+      await user.click(screen.getByRole('button', { name: /new context/i }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+      });
+
+      const input = screen.getByLabelText(/name/i);
+      await user.type(input, '@NewContext');
+
+      const submitButton = screen.getByRole('button', { name: /create$/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+    });
+
+    it('closes modal on cancel', async () => {
+      const user = userEvent.setup();
+      const store = createStore();
+      renderPage(store);
+
+      await user.click(screen.getByRole('button', { name: /new context/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      const cancelButton = screen.getByRole('button', { name: /cancel/i });
+      await user.click(cancelButton);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('edit context', () => {
+    it('opens edit modal when clicking edit button', async () => {
+      const user = userEvent.setup();
+      // Mock API to return the context so it stays in state after fetch
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [mockCustomContext], count: 1 },
+      });
+      const store = createStore({
+        contexts: [mockCustomContext],
+      });
+      renderPage(store);
+
+      const editButton = screen.getByRole('button', { name: /edit/i });
+      await user.click(editButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Edit Context')).toBeInTheDocument();
+    });
+
+    it('pre-fills form with context data', async () => {
+      const user = userEvent.setup();
+      // Mock API to return the context so it stays in state after fetch
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [mockCustomContext], count: 1 },
+      });
+      const store = createStore({
+        contexts: [mockCustomContext],
+      });
+      renderPage(store);
+
+      const editButton = screen.getByRole('button', { name: /edit/i });
+      await user.click(editButton);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/name/i)).toHaveValue('@Meeting');
+      });
+    });
+
+    it('updates context when form is submitted', async () => {
+      const user = userEvent.setup();
+      // Mock API to return the context so it stays in state after fetch
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [mockCustomContext], count: 1 },
+      });
+      const store = createStore({
+        contexts: [mockCustomContext],
+      });
+      renderPage(store);
+
+      const editButton = screen.getByRole('button', { name: /edit/i });
+      await user.click(editButton);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+      });
+
+      const input = screen.getByLabelText(/name/i);
+      await user.clear(input);
+      await user.type(input, '@Updated');
+
+      const submitButton = screen.getByRole('button', { name: /save/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(contextsAPI.update).toHaveBeenCalledWith(
+          mockCustomContext.id,
+          expect.objectContaining({ name: '@Updated' })
+        );
+      });
+    });
+  });
+
+  describe('delete context', () => {
+    it('shows confirmation dialog when clicking delete', async () => {
+      const user = userEvent.setup();
+      // Mock API to return the context so it stays in state after fetch
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [mockCustomContext], count: 1 },
+      });
+      const store = createStore({
+        contexts: [mockCustomContext],
+      });
+      renderPage(store);
+
+      const deleteButton = screen.getByRole('button', { name: /delete/i });
+      await user.click(deleteButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/are you sure/i)).toBeInTheDocument();
+      });
+    });
+
+    it('deletes context when confirmed', async () => {
+      const user = userEvent.setup();
+      // Mock API to return the context so it stays in state after fetch
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [mockCustomContext], count: 1 },
+      });
+      const store = createStore({
+        contexts: [mockCustomContext],
+      });
+      renderPage(store);
+
+      const deleteButton = screen.getByRole('button', { name: /delete/i });
+      await user.click(deleteButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/are you sure/i)).toBeInTheDocument();
+      });
+
+      const confirmButton = screen.getByRole('button', { name: /confirm/i });
+      await user.click(confirmButton);
+
+      await waitFor(() => {
+        expect(contextsAPI.delete).toHaveBeenCalledWith(mockCustomContext.id);
+      });
+    });
+
+    it('cancels delete when clicking cancel', async () => {
+      const user = userEvent.setup();
+      // Mock API to return the context so it stays in state after fetch
+      contextsAPI.getAll.mockResolvedValue({
+        data: { contexts: [mockCustomContext], count: 1 },
+      });
+      const store = createStore({
+        contexts: [mockCustomContext],
+      });
+      renderPage(store);
+
+      const deleteButton = screen.getByRole('button', { name: /delete/i });
+      await user.click(deleteButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/are you sure/i)).toBeInTheDocument();
+      });
+
+      const cancelButton = screen.getByRole('button', { name: /cancel/i });
+      await user.click(cancelButton);
+
+      await waitFor(() => {
+        expect(screen.queryByText(/are you sure/i)).not.toBeInTheDocument();
+      });
+      expect(contextsAPI.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('color picker', () => {
+    it('shows color picker in create modal', async () => {
+      const user = userEvent.setup();
+      const store = createStore();
+      renderPage(store);
+
+      await user.click(screen.getByRole('button', { name: /new context/i }));
+
+      await waitFor(() => {
+        // Check for Color label text
+        expect(screen.getByText('Color')).toBeInTheDocument();
+        // And verify color options exist
+        expect(screen.getByTestId('color-option-#4A90D9')).toBeInTheDocument();
+      });
+    });
+
+    it('allows selecting a color', async () => {
+      const user = userEvent.setup();
+      const store = createStore();
+      renderPage(store);
+
+      await user.click(screen.getByRole('button', { name: /new context/i }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+      });
+
+      const input = screen.getByLabelText(/name/i);
+      await user.type(input, '@NewContext');
+
+      // Select a color (assuming preset colors exist)
+      const colorOption = screen.getByTestId('color-option-#FF6B6B');
+      await user.click(colorOption);
+
+      const submitButton = screen.getByRole('button', { name: /create$/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(contextsAPI.create).toHaveBeenCalledWith(
+          expect.objectContaining({ color: '#FF6B6B' })
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the frontend Context Module for Phase 4.3, providing users with a full CRUD interface for managing GTD contexts.

### Key Changes:
- **ContextsPage** (`web/src/pages/ContextsPage.jsx`): Full context management page with create/edit/delete functionality
- **ContextFilterSidebar** (`web/src/components/ContextFilterSidebar.jsx`): Collapsible sidebar for filtering tasks by context (ready for Phase 4.4 integration)
- **contexts Redux slice** (`web/src/features/contexts/contextsSlice.js`): State management with async thunks for API calls
- **Store integration**: Added contexts reducer to Redux store
- **Routing**: Added `/contexts` route to App.jsx

### Features:
- Display default contexts (read-only) and custom contexts (editable)
- Create, edit, and delete custom contexts
- Color picker with preset colors for context customization
- Form validation (context names must start with @)
- Loading states and error handling
- Accessible modals with proper ARIA attributes
- Responsive sidebar with collapse/expand functionality

## Test Plan

- [x] All 596 tests passing
- [x] 31 unit tests for ContextsPage component
- [x] 16 unit tests for ContextFilterSidebar component
- [x] 19 unit tests for contexts Redux slice
- [x] Build successful

### Manual Testing Checklist:
- [ ] View default contexts on /contexts page
- [ ] Create a new custom context
- [ ] Edit a custom context
- [ ] Delete a custom context

> Note: ContextFilterSidebar will be integrated into GTD list pages (NextActionsPage, etc.) in Phase 4.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Iteration Changes (2025-12-03)

### Added Contexts link to Navigation
- Added "Contexts" link in main navbar between Clarify and user menu
- Added 3 unit tests for main navigation links (Inbox, Clarify, Contexts)
- All 599 tests passing

### Additional Manual Tests
- [ ] Verify Contexts link appears in navbar
- [ ] Verify clicking Contexts navigates to /contexts page
