### PR TITLE
feat(nav): add Contexts link to main navigation

### DIFF
--- a/docs/implementation/phase-4-3.md
+++ b/docs/implementation/phase-4-3.md
@@ -123,3 +123,17 @@
 - Consider optimistic updates for better UX
 
 **Conclusion:** Code is production-ready for Phase 4.3 scope
+
+## Iteration 1 - 2025-12-03
+
+### Requested Changes
+- Add Contexts link to main navigation bar
+
+### Files Modified
+| File | Change |
+|------|--------|
+| `web/src/components/Navigation.jsx` | Added Contexts link after Clarify |
+| `web/src/tests/unit/components/Navigation.test.jsx` | Added 3 tests for nav links |
+
+### New Tasks Added
+- [X] [P4-013b] Add Contexts link to Navigation component

--- a/specs/001-gtd-todo-app/tasks.md
+++ b/specs/001-gtd-todo-app/tasks.md
@@ -12,7 +12,7 @@ Total tasks: 203
 - P1 User Account Management: 56 tasks (52 complete, 4 remaining) - 93% complete
 - P2 Capture Ideas and Tasks: 14 tasks (14 complete) - 100% complete
 - P3 Clarify and Process: 12 tasks ✅ COMPLETE
-- P4 Organize with Contexts: 18 tasks (8 complete)
+- P4 Organize with Contexts: 19 tasks (14 complete)
 - P5 Project Management: 14 tasks
 - P6 Weekly Review: 12 tasks
 - P7 Calendar and Deadlines: 12 tasks
@@ -275,11 +275,15 @@ Per Constitution XVI, all features MUST be tracked as GitHub issues BEFORE imple
 
 ### Phase 4.3: Frontend - Context Module
 
-- [ ] [P4-009] [Story-4] Create contexts Redux slice `web/src/features/contexts/contextsSlice.ts`
-- [ ] [P4-010] [Story-4] Replace ContextsPage placeholder with full implementation `web/src/pages/ContextsPage.tsx`
-- [ ] [P4-011] [Story-4] Write unit tests for ContextsPage `web/tests/unit/pages/ContextsPage.test.tsx`
-- [ ] [P4-012] [Story-4] Create ContextFilterSidebar component `web/src/components/ContextFilterSidebar.tsx`
-- [ ] [P4-013] [Story-4] Write unit tests for ContextFilterSidebar `web/tests/unit/components/ContextFilterSidebar.test.tsx`
+- [X] [P4-009] [Story-4] Create contexts Redux slice `web/src/features/contexts/contextsSlice.js`
+- [X] [P4-010] [Story-4] Replace ContextsPage placeholder with full implementation `web/src/pages/ContextsPage.jsx`
+- [X] [P4-011] [Story-4] Write unit tests for ContextsPage `web/src/tests/unit/pages/ContextsPage.test.jsx`
+- [X] [P4-012] [Story-4] Create ContextFilterSidebar component `web/src/components/ContextFilterSidebar.jsx`
+- [X] [P4-013] [Story-4] Write unit tests for ContextFilterSidebar `web/src/tests/unit/components/ContextFilterSidebar.test.jsx`
+
+### Phase 4.3 Iteration Tasks (added during testing)
+
+- [X] [P4-013b] [Story-4] Add Contexts link to Navigation component `web/src/components/Navigation.jsx`
 
 ### Phase 4.4: Frontend - GTD List Views (FR-016)
 

--- a/web/src/components/Navigation.jsx
+++ b/web/src/components/Navigation.jsx
@@ -95,6 +95,12 @@ const Navigation = () => {
               >
                 Clarify
               </Link>
+              <Link
+                to="/contexts"
+                className="px-3 py-2 text-sm font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-100 rounded-md transition-colors"
+              >
+                Contexts
+              </Link>
             </div>
           </div>
 

--- a/web/src/tests/e2e/data-persistence.spec.jsx
+++ b/web/src/tests/e2e/data-persistence.spec.jsx
@@ -199,8 +199,6 @@ describe('Data Persistence E2E Tests', () => {
     });
 
     it('should preserve user preferences after logout and login', async () => {
-      const user = userEvent.setup();
-
       // Initial profile with specific preferences
       const originalPreferences = {
         timezone: 'Europe/Paris',
@@ -241,9 +239,11 @@ describe('Data Persistence E2E Tests', () => {
         expect(screen.getByText('user@example.com')).toBeInTheDocument();
       });
 
-      // Verify timezone is loaded
-      const timezoneSelect = screen.getByLabelText(/timezone/i);
-      expect(timezoneSelect).toHaveValue('Europe/Paris');
+      // Wait for profile to be loaded in store and timezone to be updated in UI
+      await waitFor(() => {
+        const timezoneSelect = screen.getByLabelText(/timezone/i);
+        expect(timezoneSelect).toHaveValue('Europe/Paris');
+      });
     });
 
     it('should update preferences and persist them', async () => {

--- a/web/src/tests/unit/components/Navigation.test.jsx
+++ b/web/src/tests/unit/components/Navigation.test.jsx
@@ -211,4 +211,30 @@ describe('Navigation', () => {
     const updatedSvg = button.querySelector('svg');
     expect(updatedSvg.className.baseVal).toContain('rotate-180');
   });
+
+  describe('main navigation links', () => {
+    it('renders Inbox link', () => {
+      const store = createStore({ user: { email: 'test@example.com' } });
+      renderNavigation(store);
+      const inboxLink = screen.getByRole('link', { name: /inbox/i });
+      expect(inboxLink).toBeInTheDocument();
+      expect(inboxLink).toHaveAttribute('href', '/inbox');
+    });
+
+    it('renders Clarify link', () => {
+      const store = createStore({ user: { email: 'test@example.com' } });
+      renderNavigation(store);
+      const clarifyLink = screen.getByRole('link', { name: /clarify/i });
+      expect(clarifyLink).toBeInTheDocument();
+      expect(clarifyLink).toHaveAttribute('href', '/clarify');
+    });
+
+    it('renders Contexts link', () => {
+      const store = createStore({ user: { email: 'test@example.com' } });
+      renderNavigation(store);
+      const contextsLink = screen.getByRole('link', { name: /contexts/i });
+      expect(contextsLink).toBeInTheDocument();
+      expect(contextsLink).toHaveAttribute('href', '/contexts');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds the Contexts link to the main navigation bar, making the Contexts page accessible from the navbar.

### Changes:
- Added "Contexts" link in navbar between Clarify and user menu
- Added 3 unit tests for main navigation links (Inbox, Clarify, Contexts)
- Updated tasks.md to mark P4.3 as complete and add iteration task P4-013b
- Updated implementation doc with iteration 1 notes

## Test Plan

- [x] All 599 tests passing
- [x] Unit tests for Navigation component cover all nav links

### Manual Testing:
- [ ] Verify Contexts link appears in navbar
- [ ] Verify clicking Contexts navigates to /contexts page

🤖 Generated with [Claude Code](https://claude.com/claude-code)