### PR TITLE
feat(web): P4.4 Frontend - GTD List Views Implementation

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -8,6 +8,7 @@ import InboxPage from './pages/InboxPage';
 import ClarifyPage from './pages/ClarifyPage';
 import ContextsPage from './pages/ContextsPage';
 import NextActionsPage from './pages/NextActionsPage';
+import WaitingForPage from './pages/WaitingForPage';
 import AccountSettingsPage from './pages/AccountSettingsPage';
 import AccountDeletionPage from './pages/AccountDeletionPage';
 import ProtectedRoute from './components/ProtectedRoute';
@@ -69,6 +70,16 @@ function App() {
             <ProtectedRoute>
               <AuthenticatedLayout>
                 <NextActionsPage />
+              </AuthenticatedLayout>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/waiting-for"
+          element={
+            <ProtectedRoute>
+              <AuthenticatedLayout>
+                <WaitingForPage />
               </AuthenticatedLayout>
             </ProtectedRoute>
           }

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -9,6 +9,7 @@ import ClarifyPage from './pages/ClarifyPage';
 import ContextsPage from './pages/ContextsPage';
 import NextActionsPage from './pages/NextActionsPage';
 import WaitingForPage from './pages/WaitingForPage';
+import SomedayMaybePage from './pages/SomedayMaybePage';
 import AccountSettingsPage from './pages/AccountSettingsPage';
 import AccountDeletionPage from './pages/AccountDeletionPage';
 import ProtectedRoute from './components/ProtectedRoute';
@@ -80,6 +81,16 @@ function App() {
             <ProtectedRoute>
               <AuthenticatedLayout>
                 <WaitingForPage />
+              </AuthenticatedLayout>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/someday-maybe"
+          element={
+            <ProtectedRoute>
+              <AuthenticatedLayout>
+                <SomedayMaybePage />
               </AuthenticatedLayout>
             </ProtectedRoute>
           }

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -7,6 +7,7 @@ import PasswordResetConfirmPage from './pages/PasswordResetConfirmPage';
 import InboxPage from './pages/InboxPage';
 import ClarifyPage from './pages/ClarifyPage';
 import ContextsPage from './pages/ContextsPage';
+import NextActionsPage from './pages/NextActionsPage';
 import AccountSettingsPage from './pages/AccountSettingsPage';
 import AccountDeletionPage from './pages/AccountDeletionPage';
 import ProtectedRoute from './components/ProtectedRoute';
@@ -58,6 +59,16 @@ function App() {
             <ProtectedRoute>
               <AuthenticatedLayout>
                 <ContextsPage />
+              </AuthenticatedLayout>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/next-actions"
+          element={
+            <ProtectedRoute>
+              <AuthenticatedLayout>
+                <NextActionsPage />
               </AuthenticatedLayout>
             </ProtectedRoute>
           }

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -10,6 +10,7 @@ import ContextsPage from './pages/ContextsPage';
 import NextActionsPage from './pages/NextActionsPage';
 import WaitingForPage from './pages/WaitingForPage';
 import SomedayMaybePage from './pages/SomedayMaybePage';
+import ReferencePage from './pages/ReferencePage';
 import AccountSettingsPage from './pages/AccountSettingsPage';
 import AccountDeletionPage from './pages/AccountDeletionPage';
 import ProtectedRoute from './components/ProtectedRoute';
@@ -91,6 +92,16 @@ function App() {
             <ProtectedRoute>
               <AuthenticatedLayout>
                 <SomedayMaybePage />
+              </AuthenticatedLayout>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/reference"
+          element={
+            <ProtectedRoute>
+              <AuthenticatedLayout>
+                <ReferencePage />
               </AuthenticatedLayout>
             </ProtectedRoute>
           }

--- a/web/src/components/DueDateBadge.jsx
+++ b/web/src/components/DueDateBadge.jsx
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+
+/**
+ * Shared due date badge component.
+ * Displays a date with calendar icon in purple styling.
+ */
+const DueDateBadge = ({ date }) => {
+  if (!date) return null;
+
+  return (
+    <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800">
+      <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+      </svg>
+      {new Date(date).toLocaleDateString()}
+    </span>
+  );
+};
+
+DueDateBadge.propTypes = {
+  date: PropTypes.string,
+};
+
+export default DueDateBadge;

--- a/web/src/components/EmptyState.jsx
+++ b/web/src/components/EmptyState.jsx
@@ -1,0 +1,26 @@
+import PropTypes from 'prop-types';
+
+/**
+ * Reusable empty state component with customizable icon, title, and message.
+ */
+const EmptyState = ({ icon, title, message }) => {
+  return (
+    <div className="text-center py-12">
+      {icon && (
+        <div className="mx-auto h-12 w-12 text-gray-400">
+          {icon}
+        </div>
+      )}
+      <h3 className="mt-2 text-sm font-medium text-gray-900">{title}</h3>
+      <p className="mt-1 text-sm text-gray-500">{message}</p>
+    </div>
+  );
+};
+
+EmptyState.propTypes = {
+  icon: PropTypes.node,
+  title: PropTypes.string.isRequired,
+  message: PropTypes.string.isRequired,
+};
+
+export default EmptyState;

--- a/web/src/components/ErrorAlert.jsx
+++ b/web/src/components/ErrorAlert.jsx
@@ -1,0 +1,40 @@
+import PropTypes from 'prop-types';
+
+/**
+ * Reusable error alert component for displaying error messages
+ * with a dismiss button.
+ */
+const ErrorAlert = ({ message, onDismiss }) => {
+  if (!message) return null;
+
+  return (
+    <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg" role="alert">
+      <div className="flex">
+        <svg className="h-5 w-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <div className="ml-3">
+          <p className="text-sm text-red-700">{message}</p>
+        </div>
+        {onDismiss && (
+          <button
+            onClick={onDismiss}
+            className="ml-auto pl-3 text-red-500 hover:text-red-700"
+            aria-label="Dismiss error"
+          >
+            <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+ErrorAlert.propTypes = {
+  message: PropTypes.string,
+  onDismiss: PropTypes.func,
+};
+
+export default ErrorAlert;

--- a/web/src/components/LoadingState.jsx
+++ b/web/src/components/LoadingState.jsx
@@ -1,0 +1,28 @@
+import PropTypes from 'prop-types';
+import Spinner from './Spinner';
+
+/**
+ * Reusable loading state component.
+ */
+const LoadingState = ({ message, color = 'blue' }) => {
+  const colorClasses = {
+    blue: 'text-blue-500',
+    orange: 'text-orange-500',
+    purple: 'text-purple-500',
+    gray: 'text-gray-500',
+  };
+
+  return (
+    <div className="flex justify-center items-center py-12">
+      <Spinner size="lg" className={colorClasses[color]} />
+      <span className="ml-2 text-gray-500">{message}</span>
+    </div>
+  );
+};
+
+LoadingState.propTypes = {
+  message: PropTypes.string.isRequired,
+  color: PropTypes.oneOf(['blue', 'orange', 'purple', 'gray']),
+};
+
+export default LoadingState;

--- a/web/src/components/Navigation.jsx
+++ b/web/src/components/Navigation.jsx
@@ -101,6 +101,12 @@ const Navigation = () => {
               >
                 Contexts
               </Link>
+              <Link
+                to="/next-actions"
+                className="px-3 py-2 text-sm font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-100 rounded-md transition-colors"
+              >
+                Next Actions
+              </Link>
             </div>
           </div>
 

--- a/web/src/components/Navigation.jsx
+++ b/web/src/components/Navigation.jsx
@@ -113,6 +113,12 @@ const Navigation = () => {
               >
                 Waiting For
               </Link>
+              <Link
+                to="/someday-maybe"
+                className="px-3 py-2 text-sm font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-100 rounded-md transition-colors"
+              >
+                Someday
+              </Link>
             </div>
           </div>
 

--- a/web/src/components/Navigation.jsx
+++ b/web/src/components/Navigation.jsx
@@ -119,6 +119,12 @@ const Navigation = () => {
               >
                 Someday
               </Link>
+              <Link
+                to="/reference"
+                className="px-3 py-2 text-sm font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-100 rounded-md transition-colors"
+              >
+                Reference
+              </Link>
             </div>
           </div>
 

--- a/web/src/components/Navigation.jsx
+++ b/web/src/components/Navigation.jsx
@@ -107,6 +107,12 @@ const Navigation = () => {
               >
                 Next Actions
               </Link>
+              <Link
+                to="/waiting-for"
+                className="px-3 py-2 text-sm font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-100 rounded-md transition-colors"
+              >
+                Waiting For
+              </Link>
             </div>
           </div>
 

--- a/web/src/components/PageHeader.jsx
+++ b/web/src/components/PageHeader.jsx
@@ -1,0 +1,51 @@
+import PropTypes from 'prop-types';
+
+/**
+ * Reusable page header component with title, description, count badge,
+ * and refresh button.
+ */
+const PageHeader = ({ title, description, count, countColor = 'blue', onRefresh }) => {
+  const colorClasses = {
+    blue: 'bg-blue-100 text-blue-800',
+    orange: 'bg-orange-100 text-orange-800',
+    purple: 'bg-purple-100 text-purple-800',
+    gray: 'bg-gray-100 text-gray-800',
+  };
+
+  return (
+    <div className="mb-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">{title}</h1>
+          <p className="mt-1 text-sm text-gray-500">{description}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${colorClasses[countColor]}`}>
+            {count}
+          </span>
+          {onRefresh && (
+            <button
+              onClick={onRefresh}
+              className="p-2 text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
+              aria-label="Refresh"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+PageHeader.propTypes = {
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  count: PropTypes.number.isRequired,
+  countColor: PropTypes.oneOf(['blue', 'orange', 'purple', 'gray']),
+  onRefresh: PropTypes.func,
+};
+
+export default PageHeader;

--- a/web/src/components/TaskContextBadges.jsx
+++ b/web/src/components/TaskContextBadges.jsx
@@ -1,0 +1,32 @@
+import PropTypes from 'prop-types';
+
+/**
+ * Reusable component for displaying task context badges.
+ */
+const TaskContextBadges = ({ contexts }) => {
+  if (!contexts || contexts.length === 0) return null;
+
+  return (
+    <>
+      {contexts.map((ctx) => (
+        <span
+          key={ctx.id}
+          className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800"
+        >
+          {ctx.name}
+        </span>
+      ))}
+    </>
+  );
+};
+
+TaskContextBadges.propTypes = {
+  contexts: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+    })
+  ),
+};
+
+export default TaskContextBadges;

--- a/web/src/components/TaskList.jsx
+++ b/web/src/components/TaskList.jsx
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types';
+
+/**
+ * Shared task list container component for GTD pages.
+ * Wraps task items in a styled card with dividers.
+ */
+const TaskList = ({ children }) => {
+  if (!children || (Array.isArray(children) && children.length === 0)) {
+    return null;
+  }
+
+  return (
+    <div className="bg-white shadow rounded-lg divide-y divide-gray-200">
+      {children}
+    </div>
+  );
+};
+
+TaskList.propTypes = {
+  children: PropTypes.node,
+};
+
+export default TaskList;

--- a/web/src/components/TaskListItem.jsx
+++ b/web/src/components/TaskListItem.jsx
@@ -1,0 +1,79 @@
+import PropTypes from 'prop-types';
+import TaskContextBadges from './TaskContextBadges';
+
+/**
+ * Shared task list item component for GTD pages.
+ * Displays a task with complete button, title, notes, metadata badges, and optional actions.
+ */
+const TaskListItem = ({
+  task,
+  onComplete,
+  onAction,
+  actionLabel,
+  actionClassName,
+  metadataBadges,
+  titleBadge,
+}) => {
+  return (
+    <div className="p-4 hover:bg-gray-50 transition-colors">
+      <div className="flex items-start gap-3">
+        {onComplete && (
+          <button
+            onClick={() => onComplete(task.id)}
+            className="mt-0.5 flex-shrink-0 w-5 h-5 rounded-full border-2 border-gray-300 hover:border-green-500 hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"
+            aria-label={`Complete "${task.title}"`}
+            title="Complete task"
+          >
+            <span className="sr-only">Complete</span>
+          </button>
+        )}
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <p className="text-sm font-medium text-gray-900 break-words">
+              {task.title}
+            </p>
+            {titleBadge}
+          </div>
+          {task.notes && (
+            <p className="mt-1 text-sm text-gray-500 break-words line-clamp-2">
+              {task.notes}
+            </p>
+          )}
+
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            {metadataBadges}
+            <TaskContextBadges contexts={task.contexts} />
+          </div>
+        </div>
+
+        {onAction && (
+          <button
+            onClick={() => onAction(task.id)}
+            className={actionClassName || "flex-shrink-0 px-3 py-1.5 text-xs font-medium text-blue-700 bg-blue-50 hover:bg-blue-100 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"}
+            aria-label={actionLabel}
+          >
+            {actionLabel}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+TaskListItem.propTypes = {
+  task: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    notes: PropTypes.string,
+    contexts: PropTypes.array,
+  }).isRequired,
+  onComplete: PropTypes.func,
+  onAction: PropTypes.func,
+  actionLabel: PropTypes.string,
+  actionClassName: PropTypes.string,
+  metadataBadges: PropTypes.node,
+  titleBadge: PropTypes.node,
+};
+
+export default TaskListItem;

--- a/web/src/features/tasks/tasksSlice.js
+++ b/web/src/features/tasks/tasksSlice.js
@@ -105,6 +105,55 @@ export const convertToProject = createAsyncThunk(
   }
 );
 
+// Fetch tasks by GTD status
+export const fetchNextActions = createAsyncThunk(
+  'tasks/fetchNextActions',
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await tasksAPI.getByStatus(TASK_STATUS.NEXT_ACTION);
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(error.response?.data || { message: 'Failed to fetch next actions' });
+    }
+  }
+);
+
+export const fetchWaitingFor = createAsyncThunk(
+  'tasks/fetchWaitingFor',
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await tasksAPI.getByStatus(TASK_STATUS.WAITING_FOR);
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(error.response?.data || { message: 'Failed to fetch waiting for tasks' });
+    }
+  }
+);
+
+export const fetchSomedayMaybe = createAsyncThunk(
+  'tasks/fetchSomedayMaybe',
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await tasksAPI.getByStatus(TASK_STATUS.SOMEDAY_MAYBE);
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(error.response?.data || { message: 'Failed to fetch someday/maybe tasks' });
+    }
+  }
+);
+
+export const fetchReference = createAsyncThunk(
+  'tasks/fetchReference',
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await tasksAPI.getByStatus(TASK_STATUS.REFERENCE);
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(error.response?.data || { message: 'Failed to fetch reference items' });
+    }
+  }
+);
+
 const initialState = {
   // Tasks by status for quick access
   inbox: [],
@@ -283,6 +332,62 @@ const tasksSlice = createSlice({
       .addCase(convertToProject.rejected, (state, action) => {
         state.loading = false;
         state.error = action.payload?.message || 'Failed to convert to project';
+      })
+
+      // Fetch next actions
+      .addCase(fetchNextActions.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchNextActions.fulfilled, (state, action) => {
+        state.loading = false;
+        state.nextActions = action.payload.tasks || [];
+      })
+      .addCase(fetchNextActions.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload?.message || 'Failed to fetch next actions';
+      })
+
+      // Fetch waiting for
+      .addCase(fetchWaitingFor.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchWaitingFor.fulfilled, (state, action) => {
+        state.loading = false;
+        state.waitingFor = action.payload.tasks || [];
+      })
+      .addCase(fetchWaitingFor.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload?.message || 'Failed to fetch waiting for tasks';
+      })
+
+      // Fetch someday/maybe
+      .addCase(fetchSomedayMaybe.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchSomedayMaybe.fulfilled, (state, action) => {
+        state.loading = false;
+        state.somedayMaybe = action.payload.tasks || [];
+      })
+      .addCase(fetchSomedayMaybe.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload?.message || 'Failed to fetch someday/maybe tasks';
+      })
+
+      // Fetch reference
+      .addCase(fetchReference.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchReference.fulfilled, (state, action) => {
+        state.loading = false;
+        state.reference = action.payload.tasks || [];
+      })
+      .addCase(fetchReference.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload?.message || 'Failed to fetch reference items';
       });
   },
 });

--- a/web/src/hooks/useAutoCleanError.js
+++ b/web/src/hooks/useAutoCleanError.js
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { clearError } from '../features/tasks/tasksSlice';
+
+/**
+ * Hook to automatically clear error after a specified delay.
+ * @param {string|null} error - The error message
+ * @param {number} delay - Delay in milliseconds before clearing (default: 5000)
+ */
+const useAutoCleanError = (error, delay = 5000) => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (error) {
+      const timer = setTimeout(() => {
+        dispatch(clearError());
+      }, delay);
+      return () => clearTimeout(timer);
+    }
+  }, [error, delay, dispatch]);
+};
+
+export default useAutoCleanError;

--- a/web/src/pages/NextActionsPage.jsx
+++ b/web/src/pages/NextActionsPage.jsx
@@ -14,7 +14,9 @@ import ErrorAlert from '../components/ErrorAlert';
 import PageHeader from '../components/PageHeader';
 import LoadingState from '../components/LoadingState';
 import EmptyState from '../components/EmptyState';
-import TaskContextBadges from '../components/TaskContextBadges';
+import TaskList from '../components/TaskList';
+import TaskListItem from '../components/TaskListItem';
+import DueDateBadge from '../components/DueDateBadge';
 import useAutoCleanError from '../hooks/useAutoCleanError';
 
 const NextActionsPage = () => {
@@ -95,6 +97,25 @@ const NextActionsPage = () => {
     </svg>
   );
 
+  const renderMetadataBadges = (task) => (
+    <>
+      {task.energy_level && (
+        <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getEnergyBadgeColor(task.energy_level)}`}>
+          {task.energy_level}
+        </span>
+      )}
+      {task.time_estimate && (
+        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800">
+          <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          {formatTimeEstimate(task.time_estimate)}
+        </span>
+      )}
+      <DueDateBadge date={task.due_date} />
+    </>
+  );
+
   return (
     <div className="flex h-[calc(100vh-4rem)]">
       <ContextFilterSidebar
@@ -129,63 +150,16 @@ const NextActionsPage = () => {
             />
           )}
 
-          {filteredTasks.length > 0 && (
-            <div className="bg-white shadow rounded-lg divide-y divide-gray-200">
-              {filteredTasks.map((task) => (
-                <div key={task.id} className="p-4 hover:bg-gray-50 transition-colors">
-                  <div className="flex items-start gap-3">
-                    <button
-                      onClick={() => handleCompleteTask(task.id)}
-                      className="mt-0.5 flex-shrink-0 w-5 h-5 rounded-full border-2 border-gray-300 hover:border-green-500 hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"
-                      aria-label={`Complete "${task.title}"`}
-                      title="Complete task"
-                    >
-                      <span className="sr-only">Complete</span>
-                    </button>
-
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm font-medium text-gray-900 break-words">
-                        {task.title}
-                      </p>
-                      {task.notes && (
-                        <p className="mt-1 text-sm text-gray-500 break-words line-clamp-2">
-                          {task.notes}
-                        </p>
-                      )}
-
-                      <div className="mt-2 flex flex-wrap gap-2">
-                        {task.energy_level && (
-                          <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getEnergyBadgeColor(task.energy_level)}`}>
-                            {task.energy_level}
-                          </span>
-                        )}
-
-                        {task.time_estimate && (
-                          <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800">
-                            <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                            </svg>
-                            {formatTimeEstimate(task.time_estimate)}
-                          </span>
-                        )}
-
-                        {task.due_date && (
-                          <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800">
-                            <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                            </svg>
-                            {new Date(task.due_date).toLocaleDateString()}
-                          </span>
-                        )}
-
-                        <TaskContextBadges contexts={task.contexts} />
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
+          <TaskList>
+            {filteredTasks.map((task) => (
+              <TaskListItem
+                key={task.id}
+                task={task}
+                onComplete={handleCompleteTask}
+                metadataBadges={renderMetadataBadges(task)}
+              />
+            ))}
+          </TaskList>
         </div>
       </div>
     </div>

--- a/web/src/pages/NextActionsPage.jsx
+++ b/web/src/pages/NextActionsPage.jsx
@@ -1,0 +1,262 @@
+import { useEffect, useState, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  fetchNextActions,
+  completeTask,
+  selectNextActions,
+  selectTasksLoading,
+  selectTasksError,
+  clearError,
+} from '../features/tasks/tasksSlice';
+import { selectAllContexts } from '../features/contexts/contextsSlice';
+import ContextFilterSidebar from '../components/ContextFilterSidebar';
+import Spinner from '../components/Spinner';
+
+const NextActionsPage = () => {
+  const dispatch = useDispatch();
+  const tasks = useSelector(selectNextActions);
+  const contexts = useSelector(selectAllContexts);
+  const isLoading = useSelector(selectTasksLoading);
+  const error = useSelector(selectTasksError);
+
+  const [selectedContextId, setSelectedContextId] = useState(null);
+
+  // Fetch next actions on mount
+  useEffect(() => {
+    dispatch(fetchNextActions());
+  }, [dispatch]);
+
+  // Clear error after 5 seconds
+  useEffect(() => {
+    if (error) {
+      const timer = setTimeout(() => {
+        dispatch(clearError());
+      }, 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [error, dispatch]);
+
+  // Filter tasks by selected context
+  const filteredTasks = useMemo(() => {
+    if (!selectedContextId) {
+      return tasks;
+    }
+    return tasks.filter((task) =>
+      task.contexts?.some((ctx) => ctx.id === selectedContextId)
+    );
+  }, [tasks, selectedContextId]);
+
+  // Calculate task counts per context
+  const taskCounts = useMemo(() => {
+    const counts = {};
+    tasks.forEach((task) => {
+      task.contexts?.forEach((ctx) => {
+        counts[ctx.id] = (counts[ctx.id] || 0) + 1;
+      });
+    });
+    return counts;
+  }, [tasks]);
+
+  const handleContextSelect = (contextId) => {
+    setSelectedContextId(contextId);
+  };
+
+  const handleCompleteTask = async (taskId) => {
+    try {
+      await dispatch(completeTask(taskId)).unwrap();
+    } catch (err) {
+      console.error('Failed to complete task:', err);
+    }
+  };
+
+  const handleRefresh = () => {
+    dispatch(fetchNextActions());
+  };
+
+  const formatTimeEstimate = (minutes) => {
+    if (!minutes) return null;
+    if (minutes < 60) return `${minutes} min`;
+    const hours = Math.floor(minutes / 60);
+    const remainingMinutes = minutes % 60;
+    if (remainingMinutes === 0) return `${hours}h`;
+    return `${hours}h ${remainingMinutes}m`;
+  };
+
+  const getEnergyBadgeColor = (level) => {
+    switch (level) {
+      case 'high':
+        return 'bg-red-100 text-red-800';
+      case 'medium':
+        return 'bg-yellow-100 text-yellow-800';
+      case 'low':
+        return 'bg-green-100 text-green-800';
+      default:
+        return 'bg-gray-100 text-gray-800';
+    }
+  };
+
+  return (
+    <div className="flex h-[calc(100vh-4rem)]">
+      {/* Context Filter Sidebar */}
+      <ContextFilterSidebar
+        selectedContextId={selectedContextId}
+        onContextSelect={handleContextSelect}
+        taskCounts={taskCounts}
+      />
+
+      {/* Main Content */}
+      <div className="flex-1 overflow-auto">
+        <div className="max-w-4xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+          {/* Header */}
+          <div className="mb-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <h1 className="text-2xl font-bold text-gray-900">Next Actions</h1>
+                <p className="mt-1 text-sm text-gray-500">
+                  Tasks you can do right now
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                  {filteredTasks.length}
+                </span>
+                <button
+                  onClick={handleRefresh}
+                  className="p-2 text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
+                  aria-label="Refresh"
+                >
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* Error Message */}
+          {error && (
+            <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg" role="alert">
+              <div className="flex">
+                <svg className="h-5 w-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <div className="ml-3">
+                  <p className="text-sm text-red-700">{error}</p>
+                </div>
+                <button
+                  onClick={() => dispatch(clearError())}
+                  className="ml-auto pl-3 text-red-500 hover:text-red-700"
+                >
+                  <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Loading State */}
+          {isLoading && tasks.length === 0 && (
+            <div className="flex justify-center items-center py-12">
+              <Spinner size="lg" className="text-blue-500" />
+              <span className="ml-2 text-gray-500">Loading next actions...</span>
+            </div>
+          )}
+
+          {/* Empty State */}
+          {!isLoading && filteredTasks.length === 0 && (
+            <div className="text-center py-12">
+              <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+              </svg>
+              <h3 className="mt-2 text-sm font-medium text-gray-900">No Next Actions</h3>
+              <p className="mt-1 text-sm text-gray-500">
+                {selectedContextId
+                  ? 'No tasks in this context. Select "All" to see all tasks.'
+                  : 'Process your inbox to create next actions.'}
+              </p>
+            </div>
+          )}
+
+          {/* Task List */}
+          {filteredTasks.length > 0 && (
+            <div className="bg-white shadow rounded-lg divide-y divide-gray-200">
+              {filteredTasks.map((task) => (
+                <div
+                  key={task.id}
+                  className="p-4 hover:bg-gray-50 transition-colors"
+                >
+                  <div className="flex items-start gap-3">
+                    {/* Complete Button */}
+                    <button
+                      onClick={() => handleCompleteTask(task.id)}
+                      className="mt-0.5 flex-shrink-0 w-5 h-5 rounded-full border-2 border-gray-300 hover:border-green-500 hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"
+                      aria-label={`Complete "${task.title}"`}
+                      title="Complete task"
+                    >
+                      <span className="sr-only">Complete</span>
+                    </button>
+
+                    {/* Task Content */}
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-gray-900 break-words">
+                        {task.title}
+                      </p>
+                      {task.notes && (
+                        <p className="mt-1 text-sm text-gray-500 break-words line-clamp-2">
+                          {task.notes}
+                        </p>
+                      )}
+
+                      {/* Task metadata */}
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {/* Energy Level */}
+                        {task.energy_level && (
+                          <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getEnergyBadgeColor(task.energy_level)}`}>
+                            {task.energy_level}
+                          </span>
+                        )}
+
+                        {/* Time Estimate */}
+                        {task.time_estimate && (
+                          <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800">
+                            <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                            </svg>
+                            {formatTimeEstimate(task.time_estimate)}
+                          </span>
+                        )}
+
+                        {/* Due Date */}
+                        {task.due_date && (
+                          <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800">
+                            <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                            </svg>
+                            {new Date(task.due_date).toLocaleDateString()}
+                          </span>
+                        )}
+
+                        {/* Contexts */}
+                        {task.contexts?.map((ctx) => (
+                          <span
+                            key={ctx.id}
+                            className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800"
+                          >
+                            {ctx.name}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NextActionsPage;

--- a/web/src/pages/NextActionsPage.jsx
+++ b/web/src/pages/NextActionsPage.jsx
@@ -10,7 +10,12 @@ import {
 } from '../features/tasks/tasksSlice';
 import { selectAllContexts } from '../features/contexts/contextsSlice';
 import ContextFilterSidebar from '../components/ContextFilterSidebar';
-import Spinner from '../components/Spinner';
+import ErrorAlert from '../components/ErrorAlert';
+import PageHeader from '../components/PageHeader';
+import LoadingState from '../components/LoadingState';
+import EmptyState from '../components/EmptyState';
+import TaskContextBadges from '../components/TaskContextBadges';
+import useAutoCleanError from '../hooks/useAutoCleanError';
 
 const NextActionsPage = () => {
   const dispatch = useDispatch();
@@ -21,22 +26,12 @@ const NextActionsPage = () => {
 
   const [selectedContextId, setSelectedContextId] = useState(null);
 
-  // Fetch next actions on mount
   useEffect(() => {
     dispatch(fetchNextActions());
   }, [dispatch]);
 
-  // Clear error after 5 seconds
-  useEffect(() => {
-    if (error) {
-      const timer = setTimeout(() => {
-        dispatch(clearError());
-      }, 5000);
-      return () => clearTimeout(timer);
-    }
-  }, [error, dispatch]);
+  useAutoCleanError(error);
 
-  // Filter tasks by selected context
   const filteredTasks = useMemo(() => {
     if (!selectedContextId) {
       return tasks;
@@ -46,7 +41,6 @@ const NextActionsPage = () => {
     );
   }, [tasks, selectedContextId]);
 
-  // Calculate task counts per context
   const taskCounts = useMemo(() => {
     const counts = {};
     tasks.forEach((task) => {
@@ -95,99 +89,51 @@ const NextActionsPage = () => {
     }
   };
 
+  const emptyIcon = (
+    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+    </svg>
+  );
+
   return (
     <div className="flex h-[calc(100vh-4rem)]">
-      {/* Context Filter Sidebar */}
       <ContextFilterSidebar
         selectedContextId={selectedContextId}
         onContextSelect={handleContextSelect}
         taskCounts={taskCounts}
       />
 
-      {/* Main Content */}
       <div className="flex-1 overflow-auto">
         <div className="max-w-4xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-          {/* Header */}
-          <div className="mb-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <h1 className="text-2xl font-bold text-gray-900">Next Actions</h1>
-                <p className="mt-1 text-sm text-gray-500">
-                  Tasks you can do right now
-                </p>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                  {filteredTasks.length}
-                </span>
-                <button
-                  onClick={handleRefresh}
-                  className="p-2 text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
-                  aria-label="Refresh"
-                >
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                  </svg>
-                </button>
-              </div>
-            </div>
-          </div>
+          <PageHeader
+            title="Next Actions"
+            description="Tasks you can do right now"
+            count={filteredTasks.length}
+            countColor="blue"
+            onRefresh={handleRefresh}
+          />
 
-          {/* Error Message */}
-          {error && (
-            <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg" role="alert">
-              <div className="flex">
-                <svg className="h-5 w-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-                <div className="ml-3">
-                  <p className="text-sm text-red-700">{error}</p>
-                </div>
-                <button
-                  onClick={() => dispatch(clearError())}
-                  className="ml-auto pl-3 text-red-500 hover:text-red-700"
-                >
-                  <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                </button>
-              </div>
-            </div>
-          )}
+          <ErrorAlert message={error} onDismiss={() => dispatch(clearError())} />
 
-          {/* Loading State */}
           {isLoading && tasks.length === 0 && (
-            <div className="flex justify-center items-center py-12">
-              <Spinner size="lg" className="text-blue-500" />
-              <span className="ml-2 text-gray-500">Loading next actions...</span>
-            </div>
+            <LoadingState message="Loading next actions..." color="blue" />
           )}
 
-          {/* Empty State */}
           {!isLoading && filteredTasks.length === 0 && (
-            <div className="text-center py-12">
-              <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
-              </svg>
-              <h3 className="mt-2 text-sm font-medium text-gray-900">No Next Actions</h3>
-              <p className="mt-1 text-sm text-gray-500">
-                {selectedContextId
-                  ? 'No tasks in this context. Select "All" to see all tasks.'
-                  : 'Process your inbox to create next actions.'}
-              </p>
-            </div>
+            <EmptyState
+              icon={emptyIcon}
+              title="No Next Actions"
+              message={selectedContextId
+                ? 'No tasks in this context. Select "All" to see all tasks.'
+                : 'Process your inbox to create next actions.'}
+            />
           )}
 
-          {/* Task List */}
           {filteredTasks.length > 0 && (
             <div className="bg-white shadow rounded-lg divide-y divide-gray-200">
               {filteredTasks.map((task) => (
-                <div
-                  key={task.id}
-                  className="p-4 hover:bg-gray-50 transition-colors"
-                >
+                <div key={task.id} className="p-4 hover:bg-gray-50 transition-colors">
                   <div className="flex items-start gap-3">
-                    {/* Complete Button */}
                     <button
                       onClick={() => handleCompleteTask(task.id)}
                       className="mt-0.5 flex-shrink-0 w-5 h-5 rounded-full border-2 border-gray-300 hover:border-green-500 hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"
@@ -197,7 +143,6 @@ const NextActionsPage = () => {
                       <span className="sr-only">Complete</span>
                     </button>
 
-                    {/* Task Content */}
                     <div className="flex-1 min-w-0">
                       <p className="text-sm font-medium text-gray-900 break-words">
                         {task.title}
@@ -208,16 +153,13 @@ const NextActionsPage = () => {
                         </p>
                       )}
 
-                      {/* Task metadata */}
                       <div className="mt-2 flex flex-wrap gap-2">
-                        {/* Energy Level */}
                         {task.energy_level && (
                           <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getEnergyBadgeColor(task.energy_level)}`}>
                             {task.energy_level}
                           </span>
                         )}
 
-                        {/* Time Estimate */}
                         {task.time_estimate && (
                           <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800">
                             <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -227,7 +169,6 @@ const NextActionsPage = () => {
                           </span>
                         )}
 
-                        {/* Due Date */}
                         {task.due_date && (
                           <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800">
                             <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -237,15 +178,7 @@ const NextActionsPage = () => {
                           </span>
                         )}
 
-                        {/* Contexts */}
-                        {task.contexts?.map((ctx) => (
-                          <span
-                            key={ctx.id}
-                            className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800"
-                          >
-                            {ctx.name}
-                          </span>
-                        ))}
+                        <TaskContextBadges contexts={task.contexts} />
                       </div>
                     </div>
                   </div>

--- a/web/src/pages/ReferencePage.jsx
+++ b/web/src/pages/ReferencePage.jsx
@@ -12,6 +12,7 @@ import ErrorAlert from '../components/ErrorAlert';
 import PageHeader from '../components/PageHeader';
 import LoadingState from '../components/LoadingState';
 import EmptyState from '../components/EmptyState';
+import TaskList from '../components/TaskList';
 import TaskContextBadges from '../components/TaskContextBadges';
 import useAutoCleanError from '../hooks/useAutoCleanError';
 
@@ -113,51 +114,49 @@ const ReferencePage = () => {
         />
       )}
 
-      {filteredItems.length > 0 && (
-        <div className="bg-white shadow rounded-lg divide-y divide-gray-200">
-          {filteredItems.map((item) => (
-            <div key={item.id} className="p-4 hover:bg-gray-50 transition-colors">
-              <div className="flex items-start gap-3">
-                <div className="mt-0.5 flex-shrink-0 w-5 h-5 text-gray-400">
-                  <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                  </svg>
-                </div>
-
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-gray-900 break-words">
-                    {item.title}
-                  </p>
-                  {item.notes && (
-                    <p className="mt-1 text-sm text-gray-500 break-words line-clamp-2">
-                      {item.notes}
-                    </p>
-                  )}
-
-                  <div className="mt-2 flex flex-wrap items-center gap-2">
-                    <TaskContextBadges contexts={item.contexts} />
-
-                    <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
-                      Added {new Date(item.created_at).toLocaleDateString()}
-                    </span>
-                  </div>
-                </div>
-
-                <button
-                  onClick={() => handleDeleteItem(item.id)}
-                  className="flex-shrink-0 p-1.5 text-gray-400 hover:text-red-500 rounded focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-colors"
-                  aria-label={`Delete "${item.title}"`}
-                  title="Delete item"
-                >
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                  </svg>
-                </button>
+      <TaskList>
+        {filteredItems.map((item) => (
+          <div key={item.id} className="p-4 hover:bg-gray-50 transition-colors">
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 flex-shrink-0 w-5 h-5 text-gray-400">
+                <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                </svg>
               </div>
+
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-gray-900 break-words">
+                  {item.title}
+                </p>
+                {item.notes && (
+                  <p className="mt-1 text-sm text-gray-500 break-words line-clamp-2">
+                    {item.notes}
+                  </p>
+                )}
+
+                <div className="mt-2 flex flex-wrap items-center gap-2">
+                  <TaskContextBadges contexts={item.contexts} />
+
+                  <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
+                    Added {new Date(item.created_at).toLocaleDateString()}
+                  </span>
+                </div>
+              </div>
+
+              <button
+                onClick={() => handleDeleteItem(item.id)}
+                className="flex-shrink-0 p-1.5 text-gray-400 hover:text-red-500 rounded focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-colors"
+                aria-label={`Delete "${item.title}"`}
+                title="Delete item"
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+              </button>
             </div>
-          ))}
-        </div>
-      )}
+          </div>
+        ))}
+      </TaskList>
     </div>
   );
 };

--- a/web/src/pages/ReferencePage.jsx
+++ b/web/src/pages/ReferencePage.jsx
@@ -8,7 +8,12 @@ import {
   selectTasksError,
   clearError,
 } from '../features/tasks/tasksSlice';
-import Spinner from '../components/Spinner';
+import ErrorAlert from '../components/ErrorAlert';
+import PageHeader from '../components/PageHeader';
+import LoadingState from '../components/LoadingState';
+import EmptyState from '../components/EmptyState';
+import TaskContextBadges from '../components/TaskContextBadges';
+import useAutoCleanError from '../hooks/useAutoCleanError';
 
 const ReferencePage = () => {
   const dispatch = useDispatch();
@@ -18,22 +23,12 @@ const ReferencePage = () => {
 
   const [searchQuery, setSearchQuery] = useState('');
 
-  // Fetch reference items on mount
   useEffect(() => {
     dispatch(fetchReference());
   }, [dispatch]);
 
-  // Clear error after 5 seconds
-  useEffect(() => {
-    if (error) {
-      const timer = setTimeout(() => {
-        dispatch(clearError());
-      }, 5000);
-      return () => clearTimeout(timer);
-    }
-  }, [error, dispatch]);
+  useAutoCleanError(error);
 
-  // Filter items by search query
   const filteredItems = useMemo(() => {
     if (!searchQuery.trim()) {
       return items;
@@ -58,33 +53,21 @@ const ReferencePage = () => {
     dispatch(fetchReference());
   };
 
+  const emptyIcon = (
+    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+    </svg>
+  );
+
   return (
     <div className="max-w-4xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-      {/* Header */}
-      <div className="mb-6">
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-2xl font-bold text-gray-900">Reference</h1>
-            <p className="mt-1 text-sm text-gray-500">
-              Non-actionable information for later
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
-              {filteredItems.length}
-            </span>
-            <button
-              onClick={handleRefresh}
-              className="p-2 text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
-              aria-label="Refresh"
-            >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-              </svg>
-            </button>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        title="Reference"
+        description="Non-actionable information for later"
+        count={filteredItems.length}
+        countColor="gray"
+        onRefresh={handleRefresh}
+      />
 
       {/* Search Bar */}
       <div className="mb-4">
@@ -114,68 +97,33 @@ const ReferencePage = () => {
         </div>
       </div>
 
-      {/* Error Message */}
-      {error && (
-        <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg" role="alert">
-          <div className="flex">
-            <svg className="h-5 w-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            <div className="ml-3">
-              <p className="text-sm text-red-700">{error}</p>
-            </div>
-            <button
-              onClick={() => dispatch(clearError())}
-              className="ml-auto pl-3 text-red-500 hover:text-red-700"
-            >
-              <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
-        </div>
-      )}
+      <ErrorAlert message={error} onDismiss={() => dispatch(clearError())} />
 
-      {/* Loading State */}
       {isLoading && items.length === 0 && (
-        <div className="flex justify-center items-center py-12">
-          <Spinner size="lg" className="text-gray-500" />
-          <span className="ml-2 text-gray-500">Loading reference items...</span>
-        </div>
+        <LoadingState message="Loading reference items..." color="gray" />
       )}
 
-      {/* Empty State */}
       {!isLoading && filteredItems.length === 0 && (
-        <div className="text-center py-12">
-          <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-          </svg>
-          <h3 className="mt-2 text-sm font-medium text-gray-900">No Reference Items</h3>
-          <p className="mt-1 text-sm text-gray-500">
-            {searchQuery
-              ? 'No items match your search.'
-              : 'Store important information here for easy access.'}
-          </p>
-        </div>
+        <EmptyState
+          icon={emptyIcon}
+          title="No Reference Items"
+          message={searchQuery
+            ? 'No items match your search.'
+            : 'Store important information here for easy access.'}
+        />
       )}
 
-      {/* Item List */}
       {filteredItems.length > 0 && (
         <div className="bg-white shadow rounded-lg divide-y divide-gray-200">
           {filteredItems.map((item) => (
-            <div
-              key={item.id}
-              className="p-4 hover:bg-gray-50 transition-colors"
-            >
+            <div key={item.id} className="p-4 hover:bg-gray-50 transition-colors">
               <div className="flex items-start gap-3">
-                {/* File Icon */}
                 <div className="mt-0.5 flex-shrink-0 w-5 h-5 text-gray-400">
                   <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                   </svg>
                 </div>
 
-                {/* Item Content */}
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium text-gray-900 break-words">
                     {item.title}
@@ -186,26 +134,15 @@ const ReferencePage = () => {
                     </p>
                   )}
 
-                  {/* Item metadata */}
                   <div className="mt-2 flex flex-wrap items-center gap-2">
-                    {/* Contexts */}
-                    {item.contexts?.map((ctx) => (
-                      <span
-                        key={ctx.id}
-                        className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800"
-                      >
-                        {ctx.name}
-                      </span>
-                    ))}
+                    <TaskContextBadges contexts={item.contexts} />
 
-                    {/* Created date */}
                     <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
                       Added {new Date(item.created_at).toLocaleDateString()}
                     </span>
                   </div>
                 </div>
 
-                {/* Delete Button */}
                 <button
                   onClick={() => handleDeleteItem(item.id)}
                   className="flex-shrink-0 p-1.5 text-gray-400 hover:text-red-500 rounded focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-colors"

--- a/web/src/pages/ReferencePage.jsx
+++ b/web/src/pages/ReferencePage.jsx
@@ -1,0 +1,228 @@
+import { useEffect, useState, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  fetchReference,
+  deleteTask,
+  selectReference,
+  selectTasksLoading,
+  selectTasksError,
+  clearError,
+} from '../features/tasks/tasksSlice';
+import Spinner from '../components/Spinner';
+
+const ReferencePage = () => {
+  const dispatch = useDispatch();
+  const items = useSelector(selectReference);
+  const isLoading = useSelector(selectTasksLoading);
+  const error = useSelector(selectTasksError);
+
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // Fetch reference items on mount
+  useEffect(() => {
+    dispatch(fetchReference());
+  }, [dispatch]);
+
+  // Clear error after 5 seconds
+  useEffect(() => {
+    if (error) {
+      const timer = setTimeout(() => {
+        dispatch(clearError());
+      }, 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [error, dispatch]);
+
+  // Filter items by search query
+  const filteredItems = useMemo(() => {
+    if (!searchQuery.trim()) {
+      return items;
+    }
+    const query = searchQuery.toLowerCase();
+    return items.filter(
+      (item) =>
+        item.title.toLowerCase().includes(query) ||
+        item.notes?.toLowerCase().includes(query)
+    );
+  }, [items, searchQuery]);
+
+  const handleDeleteItem = async (itemId) => {
+    try {
+      await dispatch(deleteTask(itemId)).unwrap();
+    } catch (err) {
+      console.error('Failed to delete item:', err);
+    }
+  };
+
+  const handleRefresh = () => {
+    dispatch(fetchReference());
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+      {/* Header */}
+      <div className="mb-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Reference</h1>
+            <p className="mt-1 text-sm text-gray-500">
+              Non-actionable information for later
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
+              {filteredItems.length}
+            </span>
+            <button
+              onClick={handleRefresh}
+              className="p-2 text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
+              aria-label="Refresh"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Search Bar */}
+      <div className="mb-4">
+        <div className="relative">
+          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <svg className="h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+          </div>
+          <input
+            type="text"
+            placeholder="Search reference items..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md leading-5 bg-white placeholder-gray-500 focus:outline-none focus:placeholder-gray-400 focus:ring-1 focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+          />
+          {searchQuery && (
+            <button
+              onClick={() => setSearchQuery('')}
+              className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600"
+            >
+              <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Error Message */}
+      {error && (
+        <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg" role="alert">
+          <div className="flex">
+            <svg className="h-5 w-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <div className="ml-3">
+              <p className="text-sm text-red-700">{error}</p>
+            </div>
+            <button
+              onClick={() => dispatch(clearError())}
+              className="ml-auto pl-3 text-red-500 hover:text-red-700"
+            >
+              <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Loading State */}
+      {isLoading && items.length === 0 && (
+        <div className="flex justify-center items-center py-12">
+          <Spinner size="lg" className="text-gray-500" />
+          <span className="ml-2 text-gray-500">Loading reference items...</span>
+        </div>
+      )}
+
+      {/* Empty State */}
+      {!isLoading && filteredItems.length === 0 && (
+        <div className="text-center py-12">
+          <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+          </svg>
+          <h3 className="mt-2 text-sm font-medium text-gray-900">No Reference Items</h3>
+          <p className="mt-1 text-sm text-gray-500">
+            {searchQuery
+              ? 'No items match your search.'
+              : 'Store important information here for easy access.'}
+          </p>
+        </div>
+      )}
+
+      {/* Item List */}
+      {filteredItems.length > 0 && (
+        <div className="bg-white shadow rounded-lg divide-y divide-gray-200">
+          {filteredItems.map((item) => (
+            <div
+              key={item.id}
+              className="p-4 hover:bg-gray-50 transition-colors"
+            >
+              <div className="flex items-start gap-3">
+                {/* File Icon */}
+                <div className="mt-0.5 flex-shrink-0 w-5 h-5 text-gray-400">
+                  <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                  </svg>
+                </div>
+
+                {/* Item Content */}
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-gray-900 break-words">
+                    {item.title}
+                  </p>
+                  {item.notes && (
+                    <p className="mt-1 text-sm text-gray-500 break-words line-clamp-2">
+                      {item.notes}
+                    </p>
+                  )}
+
+                  {/* Item metadata */}
+                  <div className="mt-2 flex flex-wrap items-center gap-2">
+                    {/* Contexts */}
+                    {item.contexts?.map((ctx) => (
+                      <span
+                        key={ctx.id}
+                        className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800"
+                      >
+                        {ctx.name}
+                      </span>
+                    ))}
+
+                    {/* Created date */}
+                    <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
+                      Added {new Date(item.created_at).toLocaleDateString()}
+                    </span>
+                  </div>
+                </div>
+
+                {/* Delete Button */}
+                <button
+                  onClick={() => handleDeleteItem(item.id)}
+                  className="flex-shrink-0 p-1.5 text-gray-400 hover:text-red-500 rounded focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-colors"
+                  aria-label={`Delete "${item.title}"`}
+                  title="Delete item"
+                >
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ReferencePage;

--- a/web/src/pages/SomedayMaybePage.jsx
+++ b/web/src/pages/SomedayMaybePage.jsx
@@ -14,6 +14,7 @@ import ErrorAlert from '../components/ErrorAlert';
 import PageHeader from '../components/PageHeader';
 import LoadingState from '../components/LoadingState';
 import EmptyState from '../components/EmptyState';
+import TaskList from '../components/TaskList';
 import TaskContextBadges from '../components/TaskContextBadges';
 import useAutoCleanError from '../hooks/useAutoCleanError';
 
@@ -82,53 +83,51 @@ const SomedayMaybePage = () => {
         />
       )}
 
-      {tasks.length > 0 && (
-        <div className="bg-white shadow rounded-lg divide-y divide-gray-200">
-          {tasks.map((task) => (
-            <div key={task.id} className="p-4 hover:bg-gray-50 transition-colors">
-              <div className="flex items-start gap-3">
-                <button
-                  onClick={() => handleDeleteTask(task.id)}
-                  className="mt-0.5 flex-shrink-0 w-5 h-5 rounded text-gray-400 hover:text-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-colors"
-                  aria-label={`Delete "${task.title}"`}
-                  title="Delete task"
-                >
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                  </svg>
-                </button>
+      <TaskList>
+        {tasks.map((task) => (
+          <div key={task.id} className="p-4 hover:bg-gray-50 transition-colors">
+            <div className="flex items-start gap-3">
+              <button
+                onClick={() => handleDeleteTask(task.id)}
+                className="mt-0.5 flex-shrink-0 w-5 h-5 rounded text-gray-400 hover:text-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-colors"
+                aria-label={`Delete "${task.title}"`}
+                title="Delete task"
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+              </button>
 
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-gray-900 break-words">
-                    {task.title}
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-gray-900 break-words">
+                  {task.title}
+                </p>
+                {task.notes && (
+                  <p className="mt-1 text-sm text-gray-500 break-words line-clamp-2">
+                    {task.notes}
                   </p>
-                  {task.notes && (
-                    <p className="mt-1 text-sm text-gray-500 break-words line-clamp-2">
-                      {task.notes}
-                    </p>
-                  )}
+                )}
 
-                  <div className="mt-2 flex flex-wrap items-center gap-2">
-                    <TaskContextBadges contexts={task.contexts} />
+                <div className="mt-2 flex flex-wrap items-center gap-2">
+                  <TaskContextBadges contexts={task.contexts} />
 
-                    <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
-                      Added {new Date(task.created_at).toLocaleDateString()}
-                    </span>
-                  </div>
+                  <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
+                    Added {new Date(task.created_at).toLocaleDateString()}
+                  </span>
                 </div>
-
-                <button
-                  onClick={() => handleActivateTask(task.id)}
-                  className="flex-shrink-0 px-3 py-1.5 text-xs font-medium text-green-700 bg-green-50 hover:bg-green-100 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"
-                  aria-label="Activate"
-                >
-                  Activate
-                </button>
               </div>
+
+              <button
+                onClick={() => handleActivateTask(task.id)}
+                className="flex-shrink-0 px-3 py-1.5 text-xs font-medium text-green-700 bg-green-50 hover:bg-green-100 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"
+                aria-label="Activate"
+              >
+                Activate
+              </button>
             </div>
-          ))}
-        </div>
-      )}
+          </div>
+        ))}
+      </TaskList>
     </div>
   );
 };

--- a/web/src/pages/SomedayMaybePage.jsx
+++ b/web/src/pages/SomedayMaybePage.jsx
@@ -1,0 +1,199 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  fetchSomedayMaybe,
+  updateTaskStatus,
+  deleteTask,
+  selectSomedayMaybe,
+  selectTasksLoading,
+  selectTasksError,
+  clearError,
+  TASK_STATUS,
+} from '../features/tasks/tasksSlice';
+import Spinner from '../components/Spinner';
+
+const SomedayMaybePage = () => {
+  const dispatch = useDispatch();
+  const tasks = useSelector(selectSomedayMaybe);
+  const isLoading = useSelector(selectTasksLoading);
+  const error = useSelector(selectTasksError);
+
+  // Fetch someday/maybe tasks on mount
+  useEffect(() => {
+    dispatch(fetchSomedayMaybe());
+  }, [dispatch]);
+
+  // Clear error after 5 seconds
+  useEffect(() => {
+    if (error) {
+      const timer = setTimeout(() => {
+        dispatch(clearError());
+      }, 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [error, dispatch]);
+
+  const handleActivateTask = async (taskId) => {
+    try {
+      await dispatch(
+        updateTaskStatus({ taskId, status: TASK_STATUS.NEXT_ACTION })
+      ).unwrap();
+      // Refresh the list
+      dispatch(fetchSomedayMaybe());
+    } catch (err) {
+      console.error('Failed to activate task:', err);
+    }
+  };
+
+  const handleDeleteTask = async (taskId) => {
+    try {
+      await dispatch(deleteTask(taskId)).unwrap();
+    } catch (err) {
+      console.error('Failed to delete task:', err);
+    }
+  };
+
+  const handleRefresh = () => {
+    dispatch(fetchSomedayMaybe());
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+      {/* Header */}
+      <div className="mb-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Someday/Maybe</h1>
+            <p className="mt-1 text-sm text-gray-500">
+              Ideas and tasks deferred for later
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
+              {tasks.length}
+            </span>
+            <button
+              onClick={handleRefresh}
+              className="p-2 text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
+              aria-label="Refresh"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Error Message */}
+      {error && (
+        <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg" role="alert">
+          <div className="flex">
+            <svg className="h-5 w-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <div className="ml-3">
+              <p className="text-sm text-red-700">{error}</p>
+            </div>
+            <button
+              onClick={() => dispatch(clearError())}
+              className="ml-auto pl-3 text-red-500 hover:text-red-700"
+            >
+              <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Loading State */}
+      {isLoading && tasks.length === 0 && (
+        <div className="flex justify-center items-center py-12">
+          <Spinner size="lg" className="text-purple-500" />
+          <span className="ml-2 text-gray-500">Loading someday/maybe tasks...</span>
+        </div>
+      )}
+
+      {/* Empty State */}
+      {!isLoading && tasks.length === 0 && (
+        <div className="text-center py-12">
+          <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+          </svg>
+          <h3 className="mt-2 text-sm font-medium text-gray-900">No Someday/Maybe Items</h3>
+          <p className="mt-1 text-sm text-gray-500">
+            Your dreams and future ideas will appear here.
+          </p>
+        </div>
+      )}
+
+      {/* Task List */}
+      {tasks.length > 0 && (
+        <div className="bg-white shadow rounded-lg divide-y divide-gray-200">
+          {tasks.map((task) => (
+            <div
+              key={task.id}
+              className="p-4 hover:bg-gray-50 transition-colors"
+            >
+              <div className="flex items-start gap-3">
+                {/* Delete Button */}
+                <button
+                  onClick={() => handleDeleteTask(task.id)}
+                  className="mt-0.5 flex-shrink-0 w-5 h-5 rounded text-gray-400 hover:text-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-colors"
+                  aria-label={`Delete "${task.title}"`}
+                  title="Delete task"
+                >
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                </button>
+
+                {/* Task Content */}
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-gray-900 break-words">
+                    {task.title}
+                  </p>
+                  {task.notes && (
+                    <p className="mt-1 text-sm text-gray-500 break-words line-clamp-2">
+                      {task.notes}
+                    </p>
+                  )}
+
+                  {/* Task metadata */}
+                  <div className="mt-2 flex flex-wrap items-center gap-2">
+                    {/* Contexts */}
+                    {task.contexts?.map((ctx) => (
+                      <span
+                        key={ctx.id}
+                        className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800"
+                      >
+                        {ctx.name}
+                      </span>
+                    ))}
+
+                    {/* Created date */}
+                    <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
+                      Added {new Date(task.created_at).toLocaleDateString()}
+                    </span>
+                  </div>
+                </div>
+
+                {/* Action Button */}
+                <button
+                  onClick={() => handleActivateTask(task.id)}
+                  className="flex-shrink-0 px-3 py-1.5 text-xs font-medium text-green-700 bg-green-50 hover:bg-green-100 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"
+                  aria-label="Activate"
+                >
+                  Activate
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SomedayMaybePage;

--- a/web/src/pages/SomedayMaybePage.jsx
+++ b/web/src/pages/SomedayMaybePage.jsx
@@ -10,7 +10,12 @@ import {
   clearError,
   TASK_STATUS,
 } from '../features/tasks/tasksSlice';
-import Spinner from '../components/Spinner';
+import ErrorAlert from '../components/ErrorAlert';
+import PageHeader from '../components/PageHeader';
+import LoadingState from '../components/LoadingState';
+import EmptyState from '../components/EmptyState';
+import TaskContextBadges from '../components/TaskContextBadges';
+import useAutoCleanError from '../hooks/useAutoCleanError';
 
 const SomedayMaybePage = () => {
   const dispatch = useDispatch();
@@ -18,27 +23,17 @@ const SomedayMaybePage = () => {
   const isLoading = useSelector(selectTasksLoading);
   const error = useSelector(selectTasksError);
 
-  // Fetch someday/maybe tasks on mount
   useEffect(() => {
     dispatch(fetchSomedayMaybe());
   }, [dispatch]);
 
-  // Clear error after 5 seconds
-  useEffect(() => {
-    if (error) {
-      const timer = setTimeout(() => {
-        dispatch(clearError());
-      }, 5000);
-      return () => clearTimeout(timer);
-    }
-  }, [error, dispatch]);
+  useAutoCleanError(error);
 
   const handleActivateTask = async (taskId) => {
     try {
       await dispatch(
         updateTaskStatus({ taskId, status: TASK_STATUS.NEXT_ACTION })
       ).unwrap();
-      // Refresh the list
       dispatch(fetchSomedayMaybe());
     } catch (err) {
       console.error('Failed to activate task:', err);
@@ -57,87 +52,41 @@ const SomedayMaybePage = () => {
     dispatch(fetchSomedayMaybe());
   };
 
+  const emptyIcon = (
+    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+    </svg>
+  );
+
   return (
     <div className="max-w-4xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-      {/* Header */}
-      <div className="mb-6">
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-2xl font-bold text-gray-900">Someday/Maybe</h1>
-            <p className="mt-1 text-sm text-gray-500">
-              Ideas and tasks deferred for later
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
-              {tasks.length}
-            </span>
-            <button
-              onClick={handleRefresh}
-              className="p-2 text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
-              aria-label="Refresh"
-            >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-              </svg>
-            </button>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        title="Someday/Maybe"
+        description="Ideas and tasks deferred for later"
+        count={tasks.length}
+        countColor="purple"
+        onRefresh={handleRefresh}
+      />
 
-      {/* Error Message */}
-      {error && (
-        <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg" role="alert">
-          <div className="flex">
-            <svg className="h-5 w-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            <div className="ml-3">
-              <p className="text-sm text-red-700">{error}</p>
-            </div>
-            <button
-              onClick={() => dispatch(clearError())}
-              className="ml-auto pl-3 text-red-500 hover:text-red-700"
-            >
-              <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
-        </div>
-      )}
+      <ErrorAlert message={error} onDismiss={() => dispatch(clearError())} />
 
-      {/* Loading State */}
       {isLoading && tasks.length === 0 && (
-        <div className="flex justify-center items-center py-12">
-          <Spinner size="lg" className="text-purple-500" />
-          <span className="ml-2 text-gray-500">Loading someday/maybe tasks...</span>
-        </div>
+        <LoadingState message="Loading someday/maybe tasks..." color="purple" />
       )}
 
-      {/* Empty State */}
       {!isLoading && tasks.length === 0 && (
-        <div className="text-center py-12">
-          <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
-          </svg>
-          <h3 className="mt-2 text-sm font-medium text-gray-900">No Someday/Maybe Items</h3>
-          <p className="mt-1 text-sm text-gray-500">
-            Your dreams and future ideas will appear here.
-          </p>
-        </div>
+        <EmptyState
+          icon={emptyIcon}
+          title="No Someday/Maybe Items"
+          message="Your dreams and future ideas will appear here."
+        />
       )}
 
-      {/* Task List */}
       {tasks.length > 0 && (
         <div className="bg-white shadow rounded-lg divide-y divide-gray-200">
           {tasks.map((task) => (
-            <div
-              key={task.id}
-              className="p-4 hover:bg-gray-50 transition-colors"
-            >
+            <div key={task.id} className="p-4 hover:bg-gray-50 transition-colors">
               <div className="flex items-start gap-3">
-                {/* Delete Button */}
                 <button
                   onClick={() => handleDeleteTask(task.id)}
                   className="mt-0.5 flex-shrink-0 w-5 h-5 rounded text-gray-400 hover:text-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-colors"
@@ -149,7 +98,6 @@ const SomedayMaybePage = () => {
                   </svg>
                 </button>
 
-                {/* Task Content */}
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium text-gray-900 break-words">
                     {task.title}
@@ -160,26 +108,15 @@ const SomedayMaybePage = () => {
                     </p>
                   )}
 
-                  {/* Task metadata */}
                   <div className="mt-2 flex flex-wrap items-center gap-2">
-                    {/* Contexts */}
-                    {task.contexts?.map((ctx) => (
-                      <span
-                        key={ctx.id}
-                        className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800"
-                      >
-                        {ctx.name}
-                      </span>
-                    ))}
+                    <TaskContextBadges contexts={task.contexts} />
 
-                    {/* Created date */}
                     <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
                       Added {new Date(task.created_at).toLocaleDateString()}
                     </span>
                   </div>
                 </div>
 
-                {/* Action Button */}
                 <button
                   onClick={() => handleActivateTask(task.id)}
                   className="flex-shrink-0 px-3 py-1.5 text-xs font-medium text-green-700 bg-green-50 hover:bg-green-100 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"

--- a/web/src/pages/WaitingForPage.jsx
+++ b/web/src/pages/WaitingForPage.jsx
@@ -1,0 +1,237 @@
+import { useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  fetchWaitingFor,
+  completeTask,
+  updateTaskStatus,
+  selectWaitingFor,
+  selectTasksLoading,
+  selectTasksError,
+  clearError,
+  TASK_STATUS,
+} from '../features/tasks/tasksSlice';
+import Spinner from '../components/Spinner';
+
+const WaitingForPage = () => {
+  const dispatch = useDispatch();
+  const tasks = useSelector(selectWaitingFor);
+  const isLoading = useSelector(selectTasksLoading);
+  const error = useSelector(selectTasksError);
+
+  // Fetch waiting for tasks on mount
+  useEffect(() => {
+    dispatch(fetchWaitingFor());
+  }, [dispatch]);
+
+  // Clear error after 5 seconds
+  useEffect(() => {
+    if (error) {
+      const timer = setTimeout(() => {
+        dispatch(clearError());
+      }, 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [error, dispatch]);
+
+  // Calculate waiting duration for each task
+  const tasksWithDuration = useMemo(() => {
+    return tasks.map((task) => {
+      const createdAt = new Date(task.created_at);
+      const now = new Date();
+      const diffTime = Math.abs(now - createdAt);
+      const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+      return { ...task, waitingDays: diffDays };
+    });
+  }, [tasks]);
+
+  const handleCompleteTask = async (taskId) => {
+    try {
+      await dispatch(completeTask(taskId)).unwrap();
+    } catch (err) {
+      console.error('Failed to complete task:', err);
+    }
+  };
+
+  const handleMoveToNextActions = async (taskId) => {
+    try {
+      await dispatch(
+        updateTaskStatus({ taskId, status: TASK_STATUS.NEXT_ACTION })
+      ).unwrap();
+      // Refresh the list
+      dispatch(fetchWaitingFor());
+    } catch (err) {
+      console.error('Failed to move task:', err);
+    }
+  };
+
+  const handleRefresh = () => {
+    dispatch(fetchWaitingFor());
+  };
+
+  const formatWaitingDuration = (days) => {
+    if (days === 0) return 'Today';
+    if (days === 1) return '1 day';
+    if (days < 7) return `${days} days`;
+    const weeks = Math.floor(days / 7);
+    if (weeks === 1) return '1 week';
+    if (days < 30) return `${weeks} weeks`;
+    const months = Math.floor(days / 30);
+    if (months === 1) return '1 month';
+    return `${months} months`;
+  };
+
+  const getWaitingBadgeColor = (days) => {
+    if (days < 7) return 'bg-green-100 text-green-800';
+    if (days < 14) return 'bg-yellow-100 text-yellow-800';
+    return 'bg-red-100 text-red-800';
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+      {/* Header */}
+      <div className="mb-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Waiting For</h1>
+            <p className="mt-1 text-sm text-gray-500">
+              Tasks delegated or waiting on others
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-orange-100 text-orange-800">
+              {tasks.length}
+            </span>
+            <button
+              onClick={handleRefresh}
+              className="p-2 text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
+              aria-label="Refresh"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Error Message */}
+      {error && (
+        <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg" role="alert">
+          <div className="flex">
+            <svg className="h-5 w-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <div className="ml-3">
+              <p className="text-sm text-red-700">{error}</p>
+            </div>
+            <button
+              onClick={() => dispatch(clearError())}
+              className="ml-auto pl-3 text-red-500 hover:text-red-700"
+            >
+              <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Loading State */}
+      {isLoading && tasks.length === 0 && (
+        <div className="flex justify-center items-center py-12">
+          <Spinner size="lg" className="text-orange-500" />
+          <span className="ml-2 text-gray-500">Loading waiting for tasks...</span>
+        </div>
+      )}
+
+      {/* Empty State */}
+      {!isLoading && tasks.length === 0 && (
+        <div className="text-center py-12">
+          <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <h3 className="mt-2 text-sm font-medium text-gray-900">No Waiting For Items</h3>
+          <p className="mt-1 text-sm text-gray-500">
+            Nothing is blocked or delegated right now.
+          </p>
+        </div>
+      )}
+
+      {/* Task List */}
+      {tasksWithDuration.length > 0 && (
+        <div className="bg-white shadow rounded-lg divide-y divide-gray-200">
+          {tasksWithDuration.map((task) => (
+            <div
+              key={task.id}
+              className="p-4 hover:bg-gray-50 transition-colors"
+            >
+              <div className="flex items-start gap-3">
+                {/* Complete Button */}
+                <button
+                  onClick={() => handleCompleteTask(task.id)}
+                  className="mt-0.5 flex-shrink-0 w-5 h-5 rounded-full border-2 border-gray-300 hover:border-green-500 hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"
+                  aria-label={`Complete "${task.title}"`}
+                  title="Complete task"
+                >
+                  <span className="sr-only">Complete</span>
+                </button>
+
+                {/* Task Content */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <p className="text-sm font-medium text-gray-900 break-words">
+                      {task.title}
+                    </p>
+                    {/* Waiting Duration Badge */}
+                    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getWaitingBadgeColor(task.waitingDays)}`}>
+                      {formatWaitingDuration(task.waitingDays)}
+                    </span>
+                  </div>
+                  {task.notes && (
+                    <p className="mt-1 text-sm text-gray-500 break-words line-clamp-2">
+                      {task.notes}
+                    </p>
+                  )}
+
+                  {/* Task metadata */}
+                  <div className="mt-2 flex flex-wrap items-center gap-2">
+                    {/* Due Date */}
+                    {task.due_date && (
+                      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800">
+                        <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                        </svg>
+                        {new Date(task.due_date).toLocaleDateString()}
+                      </span>
+                    )}
+
+                    {/* Contexts */}
+                    {task.contexts?.map((ctx) => (
+                      <span
+                        key={ctx.id}
+                        className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800"
+                      >
+                        {ctx.name}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Action Button */}
+                <button
+                  onClick={() => handleMoveToNextActions(task.id)}
+                  className="flex-shrink-0 px-3 py-1.5 text-xs font-medium text-blue-700 bg-blue-50 hover:bg-blue-100 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
+                  aria-label="Move to Next Actions"
+                >
+                  Move to Next Actions
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default WaitingForPage;

--- a/web/src/pages/WaitingForPage.jsx
+++ b/web/src/pages/WaitingForPage.jsx
@@ -14,7 +14,9 @@ import ErrorAlert from '../components/ErrorAlert';
 import PageHeader from '../components/PageHeader';
 import LoadingState from '../components/LoadingState';
 import EmptyState from '../components/EmptyState';
-import TaskContextBadges from '../components/TaskContextBadges';
+import TaskList from '../components/TaskList';
+import TaskListItem from '../components/TaskListItem';
+import DueDateBadge from '../components/DueDateBadge';
 import useAutoCleanError from '../hooks/useAutoCleanError';
 
 const WaitingForPage = () => {
@@ -110,61 +112,23 @@ const WaitingForPage = () => {
         />
       )}
 
-      {tasksWithDuration.length > 0 && (
-        <div className="bg-white shadow rounded-lg divide-y divide-gray-200">
-          {tasksWithDuration.map((task) => (
-            <div key={task.id} className="p-4 hover:bg-gray-50 transition-colors">
-              <div className="flex items-start gap-3">
-                <button
-                  onClick={() => handleCompleteTask(task.id)}
-                  className="mt-0.5 flex-shrink-0 w-5 h-5 rounded-full border-2 border-gray-300 hover:border-green-500 hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"
-                  aria-label={`Complete "${task.title}"`}
-                  title="Complete task"
-                >
-                  <span className="sr-only">Complete</span>
-                </button>
-
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <p className="text-sm font-medium text-gray-900 break-words">
-                      {task.title}
-                    </p>
-                    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getWaitingBadgeColor(task.waitingDays)}`}>
-                      {formatWaitingDuration(task.waitingDays)}
-                    </span>
-                  </div>
-                  {task.notes && (
-                    <p className="mt-1 text-sm text-gray-500 break-words line-clamp-2">
-                      {task.notes}
-                    </p>
-                  )}
-
-                  <div className="mt-2 flex flex-wrap items-center gap-2">
-                    {task.due_date && (
-                      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800">
-                        <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                        </svg>
-                        {new Date(task.due_date).toLocaleDateString()}
-                      </span>
-                    )}
-
-                    <TaskContextBadges contexts={task.contexts} />
-                  </div>
-                </div>
-
-                <button
-                  onClick={() => handleMoveToNextActions(task.id)}
-                  className="flex-shrink-0 px-3 py-1.5 text-xs font-medium text-blue-700 bg-blue-50 hover:bg-blue-100 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
-                  aria-label="Move to Next Actions"
-                >
-                  Move to Next Actions
-                </button>
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
+      <TaskList>
+        {tasksWithDuration.map((task) => (
+          <TaskListItem
+            key={task.id}
+            task={task}
+            onComplete={handleCompleteTask}
+            onAction={handleMoveToNextActions}
+            actionLabel="Move to Next Actions"
+            titleBadge={
+              <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getWaitingBadgeColor(task.waitingDays)}`}>
+                {formatWaitingDuration(task.waitingDays)}
+              </span>
+            }
+            metadataBadges={<DueDateBadge date={task.due_date} />}
+          />
+        ))}
+      </TaskList>
     </div>
   );
 };

--- a/web/src/pages/WaitingForPage.jsx
+++ b/web/src/pages/WaitingForPage.jsx
@@ -10,7 +10,12 @@ import {
   clearError,
   TASK_STATUS,
 } from '../features/tasks/tasksSlice';
-import Spinner from '../components/Spinner';
+import ErrorAlert from '../components/ErrorAlert';
+import PageHeader from '../components/PageHeader';
+import LoadingState from '../components/LoadingState';
+import EmptyState from '../components/EmptyState';
+import TaskContextBadges from '../components/TaskContextBadges';
+import useAutoCleanError from '../hooks/useAutoCleanError';
 
 const WaitingForPage = () => {
   const dispatch = useDispatch();
@@ -18,22 +23,12 @@ const WaitingForPage = () => {
   const isLoading = useSelector(selectTasksLoading);
   const error = useSelector(selectTasksError);
 
-  // Fetch waiting for tasks on mount
   useEffect(() => {
     dispatch(fetchWaitingFor());
   }, [dispatch]);
 
-  // Clear error after 5 seconds
-  useEffect(() => {
-    if (error) {
-      const timer = setTimeout(() => {
-        dispatch(clearError());
-      }, 5000);
-      return () => clearTimeout(timer);
-    }
-  }, [error, dispatch]);
+  useAutoCleanError(error);
 
-  // Calculate waiting duration for each task
   const tasksWithDuration = useMemo(() => {
     return tasks.map((task) => {
       const createdAt = new Date(task.created_at);
@@ -57,7 +52,6 @@ const WaitingForPage = () => {
       await dispatch(
         updateTaskStatus({ taskId, status: TASK_STATUS.NEXT_ACTION })
       ).unwrap();
-      // Refresh the list
       dispatch(fetchWaitingFor());
     } catch (err) {
       console.error('Failed to move task:', err);
@@ -86,87 +80,41 @@ const WaitingForPage = () => {
     return 'bg-red-100 text-red-800';
   };
 
+  const emptyIcon = (
+    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  );
+
   return (
     <div className="max-w-4xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-      {/* Header */}
-      <div className="mb-6">
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-2xl font-bold text-gray-900">Waiting For</h1>
-            <p className="mt-1 text-sm text-gray-500">
-              Tasks delegated or waiting on others
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-orange-100 text-orange-800">
-              {tasks.length}
-            </span>
-            <button
-              onClick={handleRefresh}
-              className="p-2 text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
-              aria-label="Refresh"
-            >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-              </svg>
-            </button>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        title="Waiting For"
+        description="Tasks delegated or waiting on others"
+        count={tasks.length}
+        countColor="orange"
+        onRefresh={handleRefresh}
+      />
 
-      {/* Error Message */}
-      {error && (
-        <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg" role="alert">
-          <div className="flex">
-            <svg className="h-5 w-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            <div className="ml-3">
-              <p className="text-sm text-red-700">{error}</p>
-            </div>
-            <button
-              onClick={() => dispatch(clearError())}
-              className="ml-auto pl-3 text-red-500 hover:text-red-700"
-            >
-              <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
-        </div>
-      )}
+      <ErrorAlert message={error} onDismiss={() => dispatch(clearError())} />
 
-      {/* Loading State */}
       {isLoading && tasks.length === 0 && (
-        <div className="flex justify-center items-center py-12">
-          <Spinner size="lg" className="text-orange-500" />
-          <span className="ml-2 text-gray-500">Loading waiting for tasks...</span>
-        </div>
+        <LoadingState message="Loading waiting for tasks..." color="orange" />
       )}
 
-      {/* Empty State */}
       {!isLoading && tasks.length === 0 && (
-        <div className="text-center py-12">
-          <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-          </svg>
-          <h3 className="mt-2 text-sm font-medium text-gray-900">No Waiting For Items</h3>
-          <p className="mt-1 text-sm text-gray-500">
-            Nothing is blocked or delegated right now.
-          </p>
-        </div>
+        <EmptyState
+          icon={emptyIcon}
+          title="No Waiting For Items"
+          message="Nothing is blocked or delegated right now."
+        />
       )}
 
-      {/* Task List */}
       {tasksWithDuration.length > 0 && (
         <div className="bg-white shadow rounded-lg divide-y divide-gray-200">
           {tasksWithDuration.map((task) => (
-            <div
-              key={task.id}
-              className="p-4 hover:bg-gray-50 transition-colors"
-            >
+            <div key={task.id} className="p-4 hover:bg-gray-50 transition-colors">
               <div className="flex items-start gap-3">
-                {/* Complete Button */}
                 <button
                   onClick={() => handleCompleteTask(task.id)}
                   className="mt-0.5 flex-shrink-0 w-5 h-5 rounded-full border-2 border-gray-300 hover:border-green-500 hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"
@@ -176,13 +124,11 @@ const WaitingForPage = () => {
                   <span className="sr-only">Complete</span>
                 </button>
 
-                {/* Task Content */}
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
                     <p className="text-sm font-medium text-gray-900 break-words">
                       {task.title}
                     </p>
-                    {/* Waiting Duration Badge */}
                     <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getWaitingBadgeColor(task.waitingDays)}`}>
                       {formatWaitingDuration(task.waitingDays)}
                     </span>
@@ -193,9 +139,7 @@ const WaitingForPage = () => {
                     </p>
                   )}
 
-                  {/* Task metadata */}
                   <div className="mt-2 flex flex-wrap items-center gap-2">
-                    {/* Due Date */}
                     {task.due_date && (
                       <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800">
                         <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -205,19 +149,10 @@ const WaitingForPage = () => {
                       </span>
                     )}
 
-                    {/* Contexts */}
-                    {task.contexts?.map((ctx) => (
-                      <span
-                        key={ctx.id}
-                        className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800"
-                      >
-                        {ctx.name}
-                      </span>
-                    ))}
+                    <TaskContextBadges contexts={task.contexts} />
                   </div>
                 </div>
 
-                {/* Action Button */}
                 <button
                   onClick={() => handleMoveToNextActions(task.id)}
                   className="flex-shrink-0 px-3 py-1.5 text-xs font-medium text-blue-700 bg-blue-50 hover:bg-blue-100 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"

--- a/web/src/tests/e2e/gtd-lists.spec.jsx
+++ b/web/src/tests/e2e/gtd-lists.spec.jsx
@@ -1,0 +1,594 @@
+/**
+ * E2E Tests for GTD List Views (P4.4)
+ *
+ * Tests the GTD list view pages:
+ * - Next Actions page
+ * - Waiting For page
+ * - Someday/Maybe page
+ * - Reference page
+ * - Navigation between lists
+ * - Context filtering
+ * - Task status transitions
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { configureStore } from '@reduxjs/toolkit';
+import NextActionsPage from '../../pages/NextActionsPage';
+import WaitingForPage from '../../pages/WaitingForPage';
+import SomedayMaybePage from '../../pages/SomedayMaybePage';
+import ReferencePage from '../../pages/ReferencePage';
+import Navigation from '../../components/Navigation';
+import tasksReducer from '../../features/tasks/tasksSlice';
+import contextsReducer from '../../features/contexts/contextsSlice';
+import authReducer from '../../features/auth/authSlice';
+import accountReducer from '../../features/account/accountSlice';
+
+// Mock tasks for different statuses
+const mockNextActions = [
+  {
+    id: 'na-1',
+    title: 'Call client about proposal',
+    notes: 'Discuss pricing and timeline',
+    status: 'next_action',
+    energy_level: 'high',
+    time_estimate: 30,
+    due_date: '2025-12-10',
+    contexts: [{ id: 'ctx-phone', name: '@Phone' }],
+    created_at: '2025-12-01T10:00:00Z',
+    updated_at: '2025-12-01T10:00:00Z',
+  },
+  {
+    id: 'na-2',
+    title: 'Buy groceries',
+    notes: 'Milk, eggs, bread',
+    status: 'next_action',
+    energy_level: 'low',
+    time_estimate: 45,
+    due_date: null,
+    contexts: [{ id: 'ctx-errands', name: '@Errands' }],
+    created_at: '2025-12-02T10:00:00Z',
+    updated_at: '2025-12-02T10:00:00Z',
+  },
+];
+
+const mockWaitingFor = [
+  {
+    id: 'wf-1',
+    title: 'Waiting for contract review',
+    notes: 'Sent to legal team',
+    status: 'waiting_for',
+    energy_level: null,
+    time_estimate: null,
+    due_date: '2025-12-15',
+    contexts: [{ id: 'ctx-work', name: '@Work' }],
+    created_at: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+    updated_at: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+];
+
+const mockSomedayMaybe = [
+  {
+    id: 'sm-1',
+    title: 'Learn to play guitar',
+    notes: 'Maybe take lessons',
+    status: 'someday_maybe',
+    energy_level: null,
+    time_estimate: null,
+    due_date: null,
+    contexts: [],
+    created_at: '2025-11-01T10:00:00Z',
+    updated_at: '2025-11-01T10:00:00Z',
+  },
+];
+
+const mockReference = [
+  {
+    id: 'ref-1',
+    title: 'Meeting notes from Q4 planning',
+    notes: 'Key decisions: budget approved',
+    status: 'reference',
+    energy_level: null,
+    time_estimate: null,
+    due_date: null,
+    contexts: [{ id: 'ctx-work', name: '@Work' }],
+    created_at: '2025-11-15T10:00:00Z',
+    updated_at: '2025-11-15T10:00:00Z',
+  },
+];
+
+const mockContexts = [
+  { id: 'ctx-phone', name: '@Phone', is_default: true, status: 'active' },
+  { id: 'ctx-errands', name: '@Errands', is_default: true, status: 'active' },
+  { id: 'ctx-work', name: '@Work', is_default: true, status: 'active' },
+];
+
+// Mock the API module
+vi.mock('../../services/api', () => ({
+  tasksAPI: {
+    getByStatus: vi.fn(),
+    complete: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+  contextsAPI: {
+    getAll: vi.fn(),
+  },
+  authAPI: {
+    logout: vi.fn(),
+  },
+  accountAPI: {
+    getProfile: vi.fn().mockResolvedValue({ data: { email: 'test@example.com' } }),
+  },
+  default: {
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+    },
+  },
+}));
+
+import { tasksAPI, contextsAPI } from '../../services/api';
+
+// Create a test store with authenticated state
+const createTestStore = (preloadedState = {}) => {
+  return configureStore({
+    reducer: {
+      auth: authReducer,
+      account: accountReducer,
+      tasks: tasksReducer,
+      contexts: contextsReducer,
+    },
+    preloadedState: {
+      auth: {
+        isAuthenticated: true,
+        user: { email: 'test@example.com' },
+        loading: false,
+        error: null,
+      },
+      account: {
+        profile: { email: 'test@example.com' },
+        loading: false,
+        error: null,
+      },
+      tasks: {
+        inbox: [],
+        clarified: [],
+        nextActions: mockNextActions,
+        waitingFor: mockWaitingFor,
+        somedayMaybe: mockSomedayMaybe,
+        reference: mockReference,
+        currentTask: null,
+        loading: false,
+        clarifying: false,
+        error: null,
+        nextCursor: null,
+        total: 0,
+      },
+      contexts: {
+        contexts: mockContexts,
+        loading: false,
+        error: null,
+      },
+      ...preloadedState,
+    },
+  });
+};
+
+const renderWithProviders = (ui, { store = createTestStore(), route = '/' } = {}) => {
+  return {
+    store,
+    user: userEvent.setup(),
+    ...render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[route]}>{ui}</MemoryRouter>
+      </Provider>
+    ),
+  };
+};
+
+describe('GTD List Views E2E Tests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tasksAPI.getByStatus.mockImplementation((status) => {
+      switch (status) {
+        case 'next_action':
+          return Promise.resolve({ data: { tasks: mockNextActions, count: mockNextActions.length } });
+        case 'waiting_for':
+          return Promise.resolve({ data: { tasks: mockWaitingFor, count: mockWaitingFor.length } });
+        case 'someday_maybe':
+          return Promise.resolve({ data: { tasks: mockSomedayMaybe, count: mockSomedayMaybe.length } });
+        case 'reference':
+          return Promise.resolve({ data: { tasks: mockReference, count: mockReference.length } });
+        default:
+          return Promise.resolve({ data: { tasks: [], count: 0 } });
+      }
+    });
+    tasksAPI.complete.mockResolvedValue({
+      data: { task: { ...mockNextActions[0], status: 'completed' }, message: 'Task completed' },
+    });
+    tasksAPI.update.mockResolvedValue({
+      data: { ...mockWaitingFor[0], status: 'next_action' },
+    });
+    tasksAPI.delete.mockResolvedValue({});
+    contextsAPI.getAll.mockResolvedValue({
+      data: { contexts: mockContexts, count: mockContexts.length },
+    });
+  });
+
+  describe('Next Actions Page', () => {
+    it('displays next actions list with task details', async () => {
+      renderWithProviders(<NextActionsPage />, { route: '/next-actions' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Call client about proposal')).toBeInTheDocument();
+        expect(screen.getByText('Buy groceries')).toBeInTheDocument();
+      });
+
+      // Check task count in sidebar (All Contexts count)
+      expect(screen.getByTestId('all-contexts-count')).toHaveTextContent('2');
+
+      // Check energy level badge
+      expect(screen.getByText('high')).toBeInTheDocument();
+
+      // Check time estimate
+      expect(screen.getByText(/30.*min/i)).toBeInTheDocument();
+
+      // Check context badge (appears in both sidebar and task - use getAllByText)
+      expect(screen.getAllByText('@Phone').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('filters tasks by context', async () => {
+      const { user } = renderWithProviders(<NextActionsPage />, { route: '/next-actions' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Call client about proposal')).toBeInTheDocument();
+        expect(screen.getByText('Buy groceries')).toBeInTheDocument();
+      });
+
+      // Click on @Phone context filter
+      const phoneFilter = screen.getByRole('button', { name: '@Phone' });
+      await user.click(phoneFilter);
+
+      await waitFor(() => {
+        // Should show only @Phone task
+        expect(screen.getByText('Call client about proposal')).toBeInTheDocument();
+        // @Errands task should be hidden
+        expect(screen.queryByText('Buy groceries')).not.toBeInTheDocument();
+      });
+    });
+
+    it('completes a task from the list', async () => {
+      const { user } = renderWithProviders(<NextActionsPage />, { route: '/next-actions' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Call client about proposal')).toBeInTheDocument();
+      });
+
+      // Click complete button
+      const completeButton = screen.getByRole('button', { name: /complete "call client about proposal"/i });
+      await user.click(completeButton);
+
+      await waitFor(() => {
+        expect(tasksAPI.complete).toHaveBeenCalledWith('na-1');
+      });
+    });
+  });
+
+  describe('Waiting For Page', () => {
+    it('displays waiting for list with duration', async () => {
+      renderWithProviders(<WaitingForPage />, { route: '/waiting-for' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Waiting for contract review')).toBeInTheDocument();
+      });
+
+      // Check waiting duration (1 week = 7 days)
+      expect(screen.getByText(/1 week/i)).toBeInTheDocument();
+
+      // Check page title
+      expect(screen.getByRole('heading', { name: /waiting for/i })).toBeInTheDocument();
+    });
+
+    it('moves task to next actions', async () => {
+      const { user } = renderWithProviders(<WaitingForPage />, { route: '/waiting-for' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Waiting for contract review')).toBeInTheDocument();
+      });
+
+      // Click "Move to Next Actions" button
+      const moveButton = screen.getByRole('button', { name: /move to next actions/i });
+      await user.click(moveButton);
+
+      await waitFor(() => {
+        expect(tasksAPI.update).toHaveBeenCalledWith('wf-1', { status: 'next_action' });
+      });
+    });
+  });
+
+  describe('Someday Maybe Page', () => {
+    it('displays someday/maybe list', async () => {
+      renderWithProviders(<SomedayMaybePage />, { route: '/someday-maybe' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Learn to play guitar')).toBeInTheDocument();
+      });
+
+      // Check page title
+      expect(screen.getByRole('heading', { name: /someday\/maybe/i })).toBeInTheDocument();
+    });
+
+    it('activates a task (moves to next actions)', async () => {
+      const { user } = renderWithProviders(<SomedayMaybePage />, { route: '/someday-maybe' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Learn to play guitar')).toBeInTheDocument();
+      });
+
+      // Click activate button
+      const activateButton = screen.getByRole('button', { name: /activate/i });
+      await user.click(activateButton);
+
+      await waitFor(() => {
+        expect(tasksAPI.update).toHaveBeenCalledWith('sm-1', { status: 'next_action' });
+      });
+    });
+
+    it('deletes a deferred task', async () => {
+      const { user } = renderWithProviders(<SomedayMaybePage />, { route: '/someday-maybe' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Learn to play guitar')).toBeInTheDocument();
+      });
+
+      // Click delete button
+      const deleteButton = screen.getByRole('button', { name: /delete "learn to play guitar"/i });
+      await user.click(deleteButton);
+
+      await waitFor(() => {
+        expect(tasksAPI.delete).toHaveBeenCalledWith('sm-1');
+      });
+    });
+  });
+
+  describe('Reference Page', () => {
+    it('displays reference items', async () => {
+      renderWithProviders(<ReferencePage />, { route: '/reference' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Meeting notes from Q4 planning')).toBeInTheDocument();
+      });
+
+      // Check page title
+      expect(screen.getByRole('heading', { name: /reference/i })).toBeInTheDocument();
+    });
+
+    it('searches reference items', async () => {
+      // Mock multiple reference items for search test
+      tasksAPI.getByStatus.mockImplementation((status) => {
+        if (status === 'reference') {
+          return Promise.resolve({
+            data: {
+              tasks: [
+                mockReference[0],
+                {
+                  id: 'ref-2',
+                  title: 'Passport number',
+                  notes: 'AB123456',
+                  status: 'reference',
+                  contexts: [],
+                  created_at: '2025-10-20T10:00:00Z',
+                  updated_at: '2025-10-20T10:00:00Z',
+                },
+              ],
+              count: 2,
+            },
+          });
+        }
+        return Promise.resolve({ data: { tasks: [], count: 0 } });
+      });
+
+      const store = createTestStore({
+        tasks: {
+          inbox: [],
+          clarified: [],
+          nextActions: [],
+          waitingFor: [],
+          somedayMaybe: [],
+          reference: [
+            mockReference[0],
+            {
+              id: 'ref-2',
+              title: 'Passport number',
+              notes: 'AB123456',
+              status: 'reference',
+              contexts: [],
+              created_at: '2025-10-20T10:00:00Z',
+              updated_at: '2025-10-20T10:00:00Z',
+            },
+          ],
+          currentTask: null,
+          loading: false,
+          clarifying: false,
+          error: null,
+          nextCursor: null,
+          total: 0,
+        },
+        contexts: {
+          contexts: mockContexts,
+          loading: false,
+          error: null,
+        },
+      });
+
+      const { user } = renderWithProviders(<ReferencePage />, { store, route: '/reference' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Meeting notes from Q4 planning')).toBeInTheDocument();
+        expect(screen.getByText('Passport number')).toBeInTheDocument();
+      });
+
+      // Type in search box
+      const searchInput = screen.getByPlaceholderText(/search reference/i);
+      await user.type(searchInput, 'passport');
+
+      await waitFor(() => {
+        expect(screen.getByText('Passport number')).toBeInTheDocument();
+        expect(screen.queryByText('Meeting notes from Q4 planning')).not.toBeInTheDocument();
+      });
+    });
+
+    it('deletes a reference item', async () => {
+      const { user } = renderWithProviders(<ReferencePage />, { route: '/reference' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Meeting notes from Q4 planning')).toBeInTheDocument();
+      });
+
+      // Click delete button
+      const deleteButton = screen.getByRole('button', { name: /delete "meeting notes from q4 planning"/i });
+      await user.click(deleteButton);
+
+      await waitFor(() => {
+        expect(tasksAPI.delete).toHaveBeenCalledWith('ref-1');
+      });
+    });
+  });
+
+  describe('Navigation Between GTD Lists', () => {
+    const AppWithRoutes = () => (
+      <>
+        <Navigation />
+        <Routes>
+          <Route path="/next-actions" element={<NextActionsPage />} />
+          <Route path="/waiting-for" element={<WaitingForPage />} />
+          <Route path="/someday-maybe" element={<SomedayMaybePage />} />
+          <Route path="/reference" element={<ReferencePage />} />
+        </Routes>
+      </>
+    );
+
+    it('navigates from Next Actions to Waiting For', async () => {
+      const { user } = renderWithProviders(<AppWithRoutes />, { route: '/next-actions' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Call client about proposal')).toBeInTheDocument();
+      });
+
+      // Click Waiting For link in navigation
+      const waitingForLink = screen.getByRole('link', { name: /waiting for/i });
+      await user.click(waitingForLink);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /waiting for/i })).toBeInTheDocument();
+      });
+    });
+
+    it('navigates from Waiting For to Someday/Maybe', async () => {
+      const { user } = renderWithProviders(<AppWithRoutes />, { route: '/waiting-for' });
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /waiting for/i })).toBeInTheDocument();
+      });
+
+      // Click Someday link in navigation
+      const somedayLink = screen.getByRole('link', { name: /someday/i });
+      await user.click(somedayLink);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /someday\/maybe/i })).toBeInTheDocument();
+      });
+    });
+
+    it('navigates from Someday/Maybe to Reference', async () => {
+      const { user } = renderWithProviders(<AppWithRoutes />, { route: '/someday-maybe' });
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /someday\/maybe/i })).toBeInTheDocument();
+      });
+
+      // Click Reference link in navigation
+      const referenceLink = screen.getByRole('link', { name: /reference/i });
+      await user.click(referenceLink);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /reference/i })).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Empty States', () => {
+    it('shows empty state for Next Actions when no tasks', async () => {
+      tasksAPI.getByStatus.mockResolvedValue({ data: { tasks: [], count: 0 } });
+
+      const emptyStore = createTestStore({
+        tasks: {
+          inbox: [],
+          clarified: [],
+          nextActions: [],
+          waitingFor: [],
+          somedayMaybe: [],
+          reference: [],
+          currentTask: null,
+          loading: false,
+          clarifying: false,
+          error: null,
+          nextCursor: null,
+          total: 0,
+        },
+      });
+
+      renderWithProviders(<NextActionsPage />, { store: emptyStore, route: '/next-actions' });
+
+      await waitFor(() => {
+        expect(screen.getByText(/no next actions/i)).toBeInTheDocument();
+      });
+    });
+
+    it('shows empty state for Waiting For when no tasks', async () => {
+      tasksAPI.getByStatus.mockResolvedValue({ data: { tasks: [], count: 0 } });
+
+      const emptyStore = createTestStore({
+        tasks: {
+          inbox: [],
+          clarified: [],
+          nextActions: [],
+          waitingFor: [],
+          somedayMaybe: [],
+          reference: [],
+          currentTask: null,
+          loading: false,
+          clarifying: false,
+          error: null,
+          nextCursor: null,
+          total: 0,
+        },
+      });
+
+      renderWithProviders(<WaitingForPage />, { store: emptyStore, route: '/waiting-for' });
+
+      await waitFor(() => {
+        expect(screen.getByText(/no waiting for items/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('displays error message when API fails on Next Actions', async () => {
+      tasksAPI.getByStatus.mockRejectedValue({
+        response: { data: { message: 'Failed to fetch tasks' } },
+      });
+
+      renderWithProviders(<NextActionsPage />, { route: '/next-actions' });
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+        expect(screen.getByText(/failed to fetch/i)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/web/src/tests/helpers/gtdTestHelpers.js
+++ b/web/src/tests/helpers/gtdTestHelpers.js
@@ -1,0 +1,90 @@
+import { configureStore } from '@reduxjs/toolkit';
+import tasksReducer from '../../features/tasks/tasksSlice';
+import contextsReducer from '../../features/contexts/contextsSlice';
+
+/**
+ * Default tasks state for GTD page tests
+ */
+export const defaultTasksState = {
+  inbox: [],
+  clarified: [],
+  nextActions: [],
+  waitingFor: [],
+  somedayMaybe: [],
+  reference: [],
+  currentTask: null,
+  loading: false,
+  clarifying: false,
+  error: null,
+  nextCursor: null,
+  total: 0,
+};
+
+/**
+ * Default contexts state for GTD page tests
+ */
+export const defaultContextsState = {
+  contexts: [],
+  loading: false,
+  error: null,
+};
+
+/**
+ * Creates a Redux store for testing GTD pages
+ * @param {Object} tasksState - Override tasks state
+ * @param {Object} contextsState - Override contexts state
+ * @returns {Object} Configured Redux store
+ */
+export const createGtdStore = (tasksState = {}, contextsState = {}) => {
+  return configureStore({
+    reducer: {
+      tasks: tasksReducer,
+      contexts: contextsReducer,
+    },
+    preloadedState: {
+      tasks: { ...defaultTasksState, ...tasksState },
+      contexts: { ...defaultContextsState, ...contextsState },
+    },
+  });
+};
+
+/**
+ * Creates a mock task for testing
+ * @param {Object} overrides - Override default task properties
+ * @returns {Object} Mock task object
+ */
+export const createMockTask = (overrides = {}) => ({
+  id: `task-${Date.now()}`,
+  title: 'Test Task',
+  notes: '',
+  status: 'next_action',
+  energy_level: null,
+  time_estimate: null,
+  due_date: null,
+  contexts: [],
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  ...overrides,
+});
+
+/**
+ * Creates a mock context for testing
+ * @param {Object} overrides - Override default context properties
+ * @returns {Object} Mock context object
+ */
+export const createMockContext = (overrides = {}) => ({
+  id: `ctx-${Date.now()}`,
+  name: '@Test',
+  is_default: false,
+  status: 'active',
+  ...overrides,
+});
+
+/**
+ * Standard mock contexts used across tests
+ */
+export const standardMockContexts = [
+  { id: 'ctx-1', name: '@Errands', is_default: true, status: 'active' },
+  { id: 'ctx-2', name: '@Phone', is_default: true, status: 'active' },
+  { id: 'ctx-3', name: '@Office', is_default: true, status: 'active' },
+];

--- a/web/src/tests/unit/pages/NextActionsPage.test.jsx
+++ b/web/src/tests/unit/pages/NextActionsPage.test.jsx
@@ -1,0 +1,355 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
+import tasksReducer from '../../../features/tasks/tasksSlice';
+import contextsReducer from '../../../features/contexts/contextsSlice';
+import NextActionsPage from '../../../pages/NextActionsPage';
+
+// Mock the API module
+vi.mock('../../../services/api', () => ({
+  tasksAPI: {
+    getByStatus: vi.fn(),
+    complete: vi.fn(),
+    update: vi.fn(),
+  },
+  contextsAPI: {
+    getAll: vi.fn(),
+  },
+}));
+
+import { tasksAPI, contextsAPI } from '../../../services/api';
+
+describe('NextActionsPage', () => {
+  const mockTask1 = {
+    id: 'task-1',
+    title: 'Buy groceries',
+    notes: 'Milk, eggs, bread',
+    status: 'next_action',
+    energy_level: 'low',
+    time_estimate: 30,
+    due_date: null,
+    contexts: [{ id: 'ctx-1', name: '@Errands' }],
+    created_at: '2025-12-01T10:00:00Z',
+    updated_at: '2025-12-01T10:00:00Z',
+  };
+
+  const mockTask2 = {
+    id: 'task-2',
+    title: 'Call dentist',
+    notes: 'Schedule checkup',
+    status: 'next_action',
+    energy_level: 'low',
+    time_estimate: 5,
+    due_date: '2025-12-10',
+    contexts: [{ id: 'ctx-2', name: '@Phone' }],
+    created_at: '2025-12-02T10:00:00Z',
+    updated_at: '2025-12-02T10:00:00Z',
+  };
+
+  const mockTask3 = {
+    id: 'task-3',
+    title: 'Write report',
+    notes: 'Q4 summary',
+    status: 'next_action',
+    energy_level: 'high',
+    time_estimate: 120,
+    due_date: null,
+    contexts: [{ id: 'ctx-3', name: '@Office' }],
+    created_at: '2025-12-03T10:00:00Z',
+    updated_at: '2025-12-03T10:00:00Z',
+  };
+
+  const mockContexts = [
+    { id: 'ctx-1', name: '@Errands', is_default: true, status: 'active' },
+    { id: 'ctx-2', name: '@Phone', is_default: true, status: 'active' },
+    { id: 'ctx-3', name: '@Office', is_default: true, status: 'active' },
+  ];
+
+  const createStore = (tasksState = {}, contextsState = {}) => {
+    return configureStore({
+      reducer: {
+        tasks: tasksReducer,
+        contexts: contextsReducer,
+      },
+      preloadedState: {
+        tasks: {
+          inbox: [],
+          clarified: [],
+          nextActions: [],
+          waitingFor: [],
+          somedayMaybe: [],
+          reference: [],
+          currentTask: null,
+          loading: false,
+          clarifying: false,
+          error: null,
+          nextCursor: null,
+          total: 0,
+          ...tasksState,
+        },
+        contexts: {
+          contexts: [],
+          loading: false,
+          error: null,
+          ...contextsState,
+        },
+      },
+    });
+  };
+
+  const renderPage = (store) => {
+    return render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <NextActionsPage />
+        </MemoryRouter>
+      </Provider>
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tasksAPI.getByStatus.mockResolvedValue({
+      data: { tasks: [], count: 0 },
+    });
+    tasksAPI.complete.mockResolvedValue({
+      data: { task: { ...mockTask1, status: 'completed' }, message: 'Task completed' },
+    });
+    contextsAPI.getAll.mockResolvedValue({
+      data: { contexts: mockContexts, count: mockContexts.length },
+    });
+  });
+
+  describe('loading state', () => {
+    it('should show loading spinner while fetching', () => {
+      const store = createStore({ loading: true });
+      renderPage(store);
+
+      expect(screen.getByText(/loading next actions/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('task list', () => {
+    it('should render tasks with next_action status', async () => {
+      tasksAPI.getByStatus.mockResolvedValue({
+        data: { tasks: [mockTask1, mockTask2, mockTask3], count: 3 },
+      });
+      const store = createStore({ nextActions: [mockTask1, mockTask2, mockTask3] });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText('Buy groceries')).toBeInTheDocument();
+        expect(screen.getByText('Call dentist')).toBeInTheDocument();
+        expect(screen.getByText('Write report')).toBeInTheDocument();
+      });
+    });
+
+    it('should show empty state when no tasks', async () => {
+      tasksAPI.getByStatus.mockResolvedValue({
+        data: { tasks: [], count: 0 },
+      });
+      const store = createStore({ nextActions: [] });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText(/no next actions/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should show error message on fetch failure', async () => {
+      // Simulate a fetch failure
+      tasksAPI.getByStatus.mockRejectedValue({
+        response: { data: { message: 'Failed to fetch tasks' } },
+      });
+      const store = createStore();
+      renderPage(store);
+
+      // Wait for the error message to appear after the rejected fetch
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+        expect(screen.getByText(/failed to fetch/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should display task count in header', async () => {
+      const store = createStore({ nextActions: [mockTask1, mockTask2] });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText('2')).toBeInTheDocument();
+      });
+    });
+
+    it('should display energy level badge', async () => {
+      const store = createStore({ nextActions: [mockTask1] });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText(/low/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should display time estimate', async () => {
+      const store = createStore({ nextActions: [mockTask1] });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText(/30.*min/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('context filtering', () => {
+    it('should render ContextFilterSidebar', async () => {
+      const store = createStore(
+        { nextActions: [mockTask1, mockTask2, mockTask3] },
+        { contexts: mockContexts }
+      );
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText('@Errands')).toBeInTheDocument();
+        expect(screen.getByText('@Phone')).toBeInTheDocument();
+        expect(screen.getByText('@Office')).toBeInTheDocument();
+      });
+    });
+
+    it('should filter tasks by selected context', async () => {
+      // Mock API to return all tasks
+      tasksAPI.getByStatus.mockResolvedValue({
+        data: { tasks: [mockTask1, mockTask2, mockTask3], count: 3 },
+      });
+      const store = createStore(
+        { nextActions: [mockTask1, mockTask2, mockTask3] },
+        { contexts: mockContexts }
+      );
+      renderPage(store);
+
+      const user = userEvent.setup();
+
+      // Wait for all tasks to be displayed
+      await waitFor(() => {
+        expect(screen.getByText('Buy groceries')).toBeInTheDocument();
+        expect(screen.getByText('Write report')).toBeInTheDocument();
+      });
+
+      // Find the @Office button in the sidebar by its aria-label
+      const officeFilter = screen.getByRole('button', { name: '@Office' });
+      await user.click(officeFilter);
+
+      // Should show only the @Office task
+      await waitFor(() => {
+        expect(screen.getByText('Write report')).toBeInTheDocument();
+        // Other tasks should be filtered out
+        expect(screen.queryByText('Buy groceries')).not.toBeInTheDocument();
+        expect(screen.queryByText('Call dentist')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should show "All" option that displays all tasks', async () => {
+      const store = createStore(
+        { nextActions: [mockTask1, mockTask2, mockTask3] },
+        { contexts: mockContexts }
+      );
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /all/i })).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('task actions', () => {
+    it('should allow completing a task', async () => {
+      // Mock API to return the task
+      tasksAPI.getByStatus.mockResolvedValue({
+        data: { tasks: [mockTask1], count: 1 },
+      });
+      const store = createStore({ nextActions: [mockTask1] });
+      renderPage(store);
+
+      const user = userEvent.setup();
+
+      await waitFor(() => {
+        expect(screen.getByText('Buy groceries')).toBeInTheDocument();
+      });
+
+      // Find and click complete button (aria-label contains "Complete" and the task title)
+      const completeButton = screen.getByRole('button', { name: /complete "buy groceries"/i });
+      await user.click(completeButton);
+
+      await waitFor(() => {
+        expect(tasksAPI.complete).toHaveBeenCalledWith('task-1');
+      });
+    });
+
+    it('should remove completed task from list', async () => {
+      // Mock API to return tasks
+      tasksAPI.getByStatus.mockResolvedValue({
+        data: { tasks: [mockTask1, mockTask2], count: 2 },
+      });
+      tasksAPI.complete.mockResolvedValue({
+        data: { task: { ...mockTask1, status: 'completed' }, message: 'Task completed' },
+      });
+
+      const store = createStore({ nextActions: [mockTask1, mockTask2] });
+      renderPage(store);
+
+      const user = userEvent.setup();
+
+      await waitFor(() => {
+        expect(screen.getByText('Buy groceries')).toBeInTheDocument();
+      });
+
+      // Complete first task
+      const completeButton = screen.getByRole('button', { name: /complete "buy groceries"/i });
+      await user.click(completeButton);
+
+      // Task should be removed after completion (handled by Redux)
+      await waitFor(() => {
+        expect(tasksAPI.complete).toHaveBeenCalledWith('task-1');
+      });
+    });
+  });
+
+  describe('page header', () => {
+    it('should display page title', () => {
+      const store = createStore();
+      renderPage(store);
+
+      expect(screen.getByRole('heading', { name: /next actions/i })).toBeInTheDocument();
+    });
+
+    it('should display GTD description', () => {
+      const store = createStore();
+      renderPage(store);
+
+      expect(screen.getByText(/tasks you can do right now/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('refresh functionality', () => {
+    it('should have refresh button', () => {
+      const store = createStore();
+      renderPage(store);
+
+      expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument();
+    });
+
+    it('should fetch tasks when refresh clicked', async () => {
+      const store = createStore();
+      renderPage(store);
+
+      const user = userEvent.setup();
+      const refreshButton = screen.getByRole('button', { name: /refresh/i });
+      await user.click(refreshButton);
+
+      await waitFor(() => {
+        expect(tasksAPI.getByStatus).toHaveBeenCalledWith('next_action');
+      });
+    });
+  });
+});

--- a/web/src/tests/unit/pages/NextActionsPage.test.jsx
+++ b/web/src/tests/unit/pages/NextActionsPage.test.jsx
@@ -1,14 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
-import { configureStore } from '@reduxjs/toolkit';
 import { MemoryRouter } from 'react-router-dom';
-import tasksReducer from '../../../features/tasks/tasksSlice';
-import contextsReducer from '../../../features/contexts/contextsSlice';
+import { createGtdStore, standardMockContexts } from '../../helpers/gtdTestHelpers';
 import NextActionsPage from '../../../pages/NextActionsPage';
 
-// Mock the API module
 vi.mock('../../../services/api', () => ({
   tasksAPI: {
     getByStatus: vi.fn(),
@@ -62,44 +59,6 @@ describe('NextActionsPage', () => {
     updated_at: '2025-12-03T10:00:00Z',
   };
 
-  const mockContexts = [
-    { id: 'ctx-1', name: '@Errands', is_default: true, status: 'active' },
-    { id: 'ctx-2', name: '@Phone', is_default: true, status: 'active' },
-    { id: 'ctx-3', name: '@Office', is_default: true, status: 'active' },
-  ];
-
-  const createStore = (tasksState = {}, contextsState = {}) => {
-    return configureStore({
-      reducer: {
-        tasks: tasksReducer,
-        contexts: contextsReducer,
-      },
-      preloadedState: {
-        tasks: {
-          inbox: [],
-          clarified: [],
-          nextActions: [],
-          waitingFor: [],
-          somedayMaybe: [],
-          reference: [],
-          currentTask: null,
-          loading: false,
-          clarifying: false,
-          error: null,
-          nextCursor: null,
-          total: 0,
-          ...tasksState,
-        },
-        contexts: {
-          contexts: [],
-          loading: false,
-          error: null,
-          ...contextsState,
-        },
-      },
-    });
-  };
-
   const renderPage = (store) => {
     return render(
       <Provider store={store}>
@@ -119,15 +78,14 @@ describe('NextActionsPage', () => {
       data: { task: { ...mockTask1, status: 'completed' }, message: 'Task completed' },
     });
     contextsAPI.getAll.mockResolvedValue({
-      data: { contexts: mockContexts, count: mockContexts.length },
+      data: { contexts: standardMockContexts, count: standardMockContexts.length },
     });
   });
 
   describe('loading state', () => {
     it('should show loading spinner while fetching', () => {
-      const store = createStore({ loading: true });
+      const store = createGtdStore({ loading: true });
       renderPage(store);
-
       expect(screen.getByText(/loading next actions/i)).toBeInTheDocument();
     });
   });
@@ -137,7 +95,7 @@ describe('NextActionsPage', () => {
       tasksAPI.getByStatus.mockResolvedValue({
         data: { tasks: [mockTask1, mockTask2, mockTask3], count: 3 },
       });
-      const store = createStore({ nextActions: [mockTask1, mockTask2, mockTask3] });
+      const store = createGtdStore({ nextActions: [mockTask1, mockTask2, mockTask3] });
       renderPage(store);
 
       await waitFor(() => {
@@ -148,10 +106,7 @@ describe('NextActionsPage', () => {
     });
 
     it('should show empty state when no tasks', async () => {
-      tasksAPI.getByStatus.mockResolvedValue({
-        data: { tasks: [], count: 0 },
-      });
-      const store = createStore({ nextActions: [] });
+      const store = createGtdStore({ nextActions: [] });
       renderPage(store);
 
       await waitFor(() => {
@@ -160,14 +115,12 @@ describe('NextActionsPage', () => {
     });
 
     it('should show error message on fetch failure', async () => {
-      // Simulate a fetch failure
       tasksAPI.getByStatus.mockRejectedValue({
         response: { data: { message: 'Failed to fetch tasks' } },
       });
-      const store = createStore();
+      const store = createGtdStore();
       renderPage(store);
 
-      // Wait for the error message to appear after the rejected fetch
       await waitFor(() => {
         expect(screen.getByRole('alert')).toBeInTheDocument();
         expect(screen.getByText(/failed to fetch/i)).toBeInTheDocument();
@@ -175,7 +128,7 @@ describe('NextActionsPage', () => {
     });
 
     it('should display task count in header', async () => {
-      const store = createStore({ nextActions: [mockTask1, mockTask2] });
+      const store = createGtdStore({ nextActions: [mockTask1, mockTask2] });
       renderPage(store);
 
       await waitFor(() => {
@@ -184,7 +137,7 @@ describe('NextActionsPage', () => {
     });
 
     it('should display energy level badge', async () => {
-      const store = createStore({ nextActions: [mockTask1] });
+      const store = createGtdStore({ nextActions: [mockTask1] });
       renderPage(store);
 
       await waitFor(() => {
@@ -193,7 +146,7 @@ describe('NextActionsPage', () => {
     });
 
     it('should display time estimate', async () => {
-      const store = createStore({ nextActions: [mockTask1] });
+      const store = createGtdStore({ nextActions: [mockTask1] });
       renderPage(store);
 
       await waitFor(() => {
@@ -204,9 +157,9 @@ describe('NextActionsPage', () => {
 
   describe('context filtering', () => {
     it('should render ContextFilterSidebar', async () => {
-      const store = createStore(
+      const store = createGtdStore(
         { nextActions: [mockTask1, mockTask2, mockTask3] },
-        { contexts: mockContexts }
+        { contexts: standardMockContexts }
       );
       renderPage(store);
 
@@ -218,41 +171,36 @@ describe('NextActionsPage', () => {
     });
 
     it('should filter tasks by selected context', async () => {
-      // Mock API to return all tasks
       tasksAPI.getByStatus.mockResolvedValue({
         data: { tasks: [mockTask1, mockTask2, mockTask3], count: 3 },
       });
-      const store = createStore(
+      const store = createGtdStore(
         { nextActions: [mockTask1, mockTask2, mockTask3] },
-        { contexts: mockContexts }
+        { contexts: standardMockContexts }
       );
       renderPage(store);
 
       const user = userEvent.setup();
 
-      // Wait for all tasks to be displayed
       await waitFor(() => {
         expect(screen.getByText('Buy groceries')).toBeInTheDocument();
         expect(screen.getByText('Write report')).toBeInTheDocument();
       });
 
-      // Find the @Office button in the sidebar by its aria-label
       const officeFilter = screen.getByRole('button', { name: '@Office' });
       await user.click(officeFilter);
 
-      // Should show only the @Office task
       await waitFor(() => {
         expect(screen.getByText('Write report')).toBeInTheDocument();
-        // Other tasks should be filtered out
         expect(screen.queryByText('Buy groceries')).not.toBeInTheDocument();
         expect(screen.queryByText('Call dentist')).not.toBeInTheDocument();
       });
     });
 
     it('should show "All" option that displays all tasks', async () => {
-      const store = createStore(
+      const store = createGtdStore(
         { nextActions: [mockTask1, mockTask2, mockTask3] },
-        { contexts: mockContexts }
+        { contexts: standardMockContexts }
       );
       renderPage(store);
 
@@ -264,11 +212,10 @@ describe('NextActionsPage', () => {
 
   describe('task actions', () => {
     it('should allow completing a task', async () => {
-      // Mock API to return the task
       tasksAPI.getByStatus.mockResolvedValue({
         data: { tasks: [mockTask1], count: 1 },
       });
-      const store = createStore({ nextActions: [mockTask1] });
+      const store = createGtdStore({ nextActions: [mockTask1] });
       renderPage(store);
 
       const user = userEvent.setup();
@@ -277,7 +224,6 @@ describe('NextActionsPage', () => {
         expect(screen.getByText('Buy groceries')).toBeInTheDocument();
       });
 
-      // Find and click complete button (aria-label contains "Complete" and the task title)
       const completeButton = screen.getByRole('button', { name: /complete "buy groceries"/i });
       await user.click(completeButton);
 
@@ -287,7 +233,6 @@ describe('NextActionsPage', () => {
     });
 
     it('should remove completed task from list', async () => {
-      // Mock API to return tasks
       tasksAPI.getByStatus.mockResolvedValue({
         data: { tasks: [mockTask1, mockTask2], count: 2 },
       });
@@ -295,7 +240,7 @@ describe('NextActionsPage', () => {
         data: { task: { ...mockTask1, status: 'completed' }, message: 'Task completed' },
       });
 
-      const store = createStore({ nextActions: [mockTask1, mockTask2] });
+      const store = createGtdStore({ nextActions: [mockTask1, mockTask2] });
       renderPage(store);
 
       const user = userEvent.setup();
@@ -304,11 +249,9 @@ describe('NextActionsPage', () => {
         expect(screen.getByText('Buy groceries')).toBeInTheDocument();
       });
 
-      // Complete first task
       const completeButton = screen.getByRole('button', { name: /complete "buy groceries"/i });
       await user.click(completeButton);
 
-      // Task should be removed after completion (handled by Redux)
       await waitFor(() => {
         expect(tasksAPI.complete).toHaveBeenCalledWith('task-1');
       });
@@ -317,30 +260,27 @@ describe('NextActionsPage', () => {
 
   describe('page header', () => {
     it('should display page title', () => {
-      const store = createStore();
+      const store = createGtdStore();
       renderPage(store);
-
       expect(screen.getByRole('heading', { name: /next actions/i })).toBeInTheDocument();
     });
 
     it('should display GTD description', () => {
-      const store = createStore();
+      const store = createGtdStore();
       renderPage(store);
-
       expect(screen.getByText(/tasks you can do right now/i)).toBeInTheDocument();
     });
   });
 
   describe('refresh functionality', () => {
     it('should have refresh button', () => {
-      const store = createStore();
+      const store = createGtdStore();
       renderPage(store);
-
       expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument();
     });
 
     it('should fetch tasks when refresh clicked', async () => {
-      const store = createStore();
+      const store = createGtdStore();
       renderPage(store);
 
       const user = userEvent.setup();

--- a/web/src/tests/unit/pages/ReferencePage.test.jsx
+++ b/web/src/tests/unit/pages/ReferencePage.test.jsx
@@ -1,0 +1,295 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
+import tasksReducer from '../../../features/tasks/tasksSlice';
+import contextsReducer from '../../../features/contexts/contextsSlice';
+import ReferencePage from '../../../pages/ReferencePage';
+
+// Mock the API module
+vi.mock('../../../services/api', () => ({
+  tasksAPI: {
+    getByStatus: vi.fn(),
+    delete: vi.fn(),
+  },
+  contextsAPI: {
+    getAll: vi.fn(),
+  },
+}));
+
+import { tasksAPI, contextsAPI } from '../../../services/api';
+
+describe('ReferencePage', () => {
+  const mockItem1 = {
+    id: 'ref-1',
+    title: 'Meeting notes from Q4 planning',
+    notes: 'Key decisions: budget approved, timeline confirmed',
+    status: 'reference',
+    energy_level: null,
+    time_estimate: null,
+    due_date: null,
+    contexts: [{ id: 'ctx-1', name: '@Work' }],
+    created_at: '2025-11-15T10:00:00Z',
+    updated_at: '2025-11-15T10:00:00Z',
+  };
+
+  const mockItem2 = {
+    id: 'ref-2',
+    title: 'Passport number',
+    notes: 'AB123456',
+    status: 'reference',
+    energy_level: null,
+    time_estimate: null,
+    due_date: null,
+    contexts: [{ id: 'ctx-2', name: '@Personal' }],
+    created_at: '2025-10-20T10:00:00Z',
+    updated_at: '2025-10-20T10:00:00Z',
+  };
+
+  const mockItem3 = {
+    id: 'ref-3',
+    title: 'Recipe for chocolate cake',
+    notes: 'Grandmas secret recipe',
+    status: 'reference',
+    energy_level: null,
+    time_estimate: null,
+    due_date: null,
+    contexts: [],
+    created_at: '2025-09-01T10:00:00Z',
+    updated_at: '2025-09-01T10:00:00Z',
+  };
+
+  const mockContexts = [
+    { id: 'ctx-1', name: '@Work', is_default: false, status: 'active' },
+    { id: 'ctx-2', name: '@Personal', is_default: false, status: 'active' },
+  ];
+
+  const createStore = (tasksState = {}, contextsState = {}) => {
+    return configureStore({
+      reducer: {
+        tasks: tasksReducer,
+        contexts: contextsReducer,
+      },
+      preloadedState: {
+        tasks: {
+          inbox: [],
+          clarified: [],
+          nextActions: [],
+          waitingFor: [],
+          somedayMaybe: [],
+          reference: [],
+          currentTask: null,
+          loading: false,
+          clarifying: false,
+          error: null,
+          nextCursor: null,
+          total: 0,
+          ...tasksState,
+        },
+        contexts: {
+          contexts: [],
+          loading: false,
+          error: null,
+          ...contextsState,
+        },
+      },
+    });
+  };
+
+  const renderPage = (store) => {
+    return render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <ReferencePage />
+        </MemoryRouter>
+      </Provider>
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tasksAPI.getByStatus.mockResolvedValue({
+      data: { tasks: [], count: 0 },
+    });
+    tasksAPI.delete.mockResolvedValue({});
+    contextsAPI.getAll.mockResolvedValue({
+      data: { contexts: mockContexts, count: mockContexts.length },
+    });
+  });
+
+  describe('loading state', () => {
+    it('should show loading spinner while fetching', () => {
+      const store = createStore({ loading: true });
+      renderPage(store);
+
+      expect(screen.getByText(/loading reference/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('reference list', () => {
+    it('should render items with reference status', async () => {
+      tasksAPI.getByStatus.mockResolvedValue({
+        data: { tasks: [mockItem1, mockItem2, mockItem3], count: 3 },
+      });
+      const store = createStore({ reference: [mockItem1, mockItem2, mockItem3] });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText('Meeting notes from Q4 planning')).toBeInTheDocument();
+        expect(screen.getByText('Passport number')).toBeInTheDocument();
+        expect(screen.getByText('Recipe for chocolate cake')).toBeInTheDocument();
+      });
+    });
+
+    it('should show empty state when no items', async () => {
+      tasksAPI.getByStatus.mockResolvedValue({
+        data: { tasks: [], count: 0 },
+      });
+      const store = createStore({ reference: [] });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText(/no reference items/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should show error message on fetch failure', async () => {
+      tasksAPI.getByStatus.mockRejectedValue({
+        response: { data: { message: 'Failed to fetch items' } },
+      });
+      const store = createStore();
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+        expect(screen.getByText(/failed to fetch/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should display item count in header', async () => {
+      const store = createStore({ reference: [mockItem1, mockItem2] });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText('2')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('search', () => {
+    it('should filter items by search query', async () => {
+      // Mock API to return all items
+      tasksAPI.getByStatus.mockResolvedValue({
+        data: { tasks: [mockItem1, mockItem2, mockItem3], count: 3 },
+      });
+      const store = createStore({ reference: [mockItem1, mockItem2, mockItem3] });
+      renderPage(store);
+
+      const user = userEvent.setup();
+
+      await waitFor(() => {
+        expect(screen.getByText('Meeting notes from Q4 planning')).toBeInTheDocument();
+      });
+
+      // Type in search box
+      const searchInput = screen.getByPlaceholderText(/search reference/i);
+      await user.type(searchInput, 'passport');
+
+      await waitFor(() => {
+        // Should show matching item
+        expect(screen.getByText('Passport number')).toBeInTheDocument();
+        // Should hide non-matching items
+        expect(screen.queryByText('Meeting notes from Q4 planning')).not.toBeInTheDocument();
+        expect(screen.queryByText('Recipe for chocolate cake')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should search in notes as well', async () => {
+      // Mock API to return all items
+      tasksAPI.getByStatus.mockResolvedValue({
+        data: { tasks: [mockItem1, mockItem2, mockItem3], count: 3 },
+      });
+      const store = createStore({ reference: [mockItem1, mockItem2, mockItem3] });
+      renderPage(store);
+
+      const user = userEvent.setup();
+
+      await waitFor(() => {
+        expect(screen.getByText('Recipe for chocolate cake')).toBeInTheDocument();
+      });
+
+      // Search for content in notes (case insensitive)
+      const searchInput = screen.getByPlaceholderText(/search reference/i);
+      await user.type(searchInput, 'grandma');
+
+      await waitFor(() => {
+        expect(screen.getByText('Recipe for chocolate cake')).toBeInTheDocument();
+        expect(screen.queryByText('Meeting notes from Q4 planning')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('item actions', () => {
+    it('should allow deleting reference item', async () => {
+      tasksAPI.getByStatus.mockResolvedValue({
+        data: { tasks: [mockItem1], count: 1 },
+      });
+      const store = createStore({ reference: [mockItem1] });
+      renderPage(store);
+
+      const user = userEvent.setup();
+
+      await waitFor(() => {
+        expect(screen.getByText('Meeting notes from Q4 planning')).toBeInTheDocument();
+      });
+
+      // Find and click the delete button
+      const deleteButton = screen.getByRole('button', { name: /delete "meeting notes from q4 planning"/i });
+      await user.click(deleteButton);
+
+      await waitFor(() => {
+        expect(tasksAPI.delete).toHaveBeenCalledWith('ref-1');
+      });
+    });
+  });
+
+  describe('page header', () => {
+    it('should display page title', () => {
+      const store = createStore();
+      renderPage(store);
+
+      expect(screen.getByRole('heading', { name: /reference/i })).toBeInTheDocument();
+    });
+
+    it('should display GTD description', () => {
+      const store = createStore();
+      renderPage(store);
+
+      expect(screen.getByText(/non-actionable information for later/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('refresh functionality', () => {
+    it('should have refresh button', () => {
+      const store = createStore();
+      renderPage(store);
+
+      expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument();
+    });
+
+    it('should fetch items when refresh clicked', async () => {
+      const store = createStore();
+      renderPage(store);
+
+      const user = userEvent.setup();
+      const refreshButton = screen.getByRole('button', { name: /refresh/i });
+      await user.click(refreshButton);
+
+      await waitFor(() => {
+        expect(tasksAPI.getByStatus).toHaveBeenCalledWith('reference');
+      });
+    });
+  });
+});

--- a/web/src/tests/unit/pages/ReferencePage.test.jsx
+++ b/web/src/tests/unit/pages/ReferencePage.test.jsx
@@ -2,10 +2,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
-import { configureStore } from '@reduxjs/toolkit';
 import { MemoryRouter } from 'react-router-dom';
-import tasksReducer from '../../../features/tasks/tasksSlice';
-import contextsReducer from '../../../features/contexts/contextsSlice';
+import { createGtdStore } from '../../helpers/gtdTestHelpers';
 import ReferencePage from '../../../pages/ReferencePage';
 
 // Mock the API module
@@ -66,38 +64,6 @@ describe('ReferencePage', () => {
     { id: 'ctx-2', name: '@Personal', is_default: false, status: 'active' },
   ];
 
-  const createStore = (tasksState = {}, contextsState = {}) => {
-    return configureStore({
-      reducer: {
-        tasks: tasksReducer,
-        contexts: contextsReducer,
-      },
-      preloadedState: {
-        tasks: {
-          inbox: [],
-          clarified: [],
-          nextActions: [],
-          waitingFor: [],
-          somedayMaybe: [],
-          reference: [],
-          currentTask: null,
-          loading: false,
-          clarifying: false,
-          error: null,
-          nextCursor: null,
-          total: 0,
-          ...tasksState,
-        },
-        contexts: {
-          contexts: [],
-          loading: false,
-          error: null,
-          ...contextsState,
-        },
-      },
-    });
-  };
-
   const renderPage = (store) => {
     return render(
       <Provider store={store}>
@@ -121,7 +87,7 @@ describe('ReferencePage', () => {
 
   describe('loading state', () => {
     it('should show loading spinner while fetching', () => {
-      const store = createStore({ loading: true });
+      const store = createGtdStore({ loading: true });
       renderPage(store);
 
       expect(screen.getByText(/loading reference/i)).toBeInTheDocument();
@@ -133,7 +99,7 @@ describe('ReferencePage', () => {
       tasksAPI.getByStatus.mockResolvedValue({
         data: { tasks: [mockItem1, mockItem2, mockItem3], count: 3 },
       });
-      const store = createStore({ reference: [mockItem1, mockItem2, mockItem3] });
+      const store = createGtdStore({ reference: [mockItem1, mockItem2, mockItem3] });
       renderPage(store);
 
       await waitFor(() => {
@@ -147,7 +113,7 @@ describe('ReferencePage', () => {
       tasksAPI.getByStatus.mockResolvedValue({
         data: { tasks: [], count: 0 },
       });
-      const store = createStore({ reference: [] });
+      const store = createGtdStore({ reference: [] });
       renderPage(store);
 
       await waitFor(() => {
@@ -159,7 +125,7 @@ describe('ReferencePage', () => {
       tasksAPI.getByStatus.mockRejectedValue({
         response: { data: { message: 'Failed to fetch items' } },
       });
-      const store = createStore();
+      const store = createGtdStore();
       renderPage(store);
 
       await waitFor(() => {
@@ -169,7 +135,7 @@ describe('ReferencePage', () => {
     });
 
     it('should display item count in header', async () => {
-      const store = createStore({ reference: [mockItem1, mockItem2] });
+      const store = createGtdStore({ reference: [mockItem1, mockItem2] });
       renderPage(store);
 
       await waitFor(() => {
@@ -184,7 +150,7 @@ describe('ReferencePage', () => {
       tasksAPI.getByStatus.mockResolvedValue({
         data: { tasks: [mockItem1, mockItem2, mockItem3], count: 3 },
       });
-      const store = createStore({ reference: [mockItem1, mockItem2, mockItem3] });
+      const store = createGtdStore({ reference: [mockItem1, mockItem2, mockItem3] });
       renderPage(store);
 
       const user = userEvent.setup();
@@ -211,7 +177,7 @@ describe('ReferencePage', () => {
       tasksAPI.getByStatus.mockResolvedValue({
         data: { tasks: [mockItem1, mockItem2, mockItem3], count: 3 },
       });
-      const store = createStore({ reference: [mockItem1, mockItem2, mockItem3] });
+      const store = createGtdStore({ reference: [mockItem1, mockItem2, mockItem3] });
       renderPage(store);
 
       const user = userEvent.setup();
@@ -236,7 +202,7 @@ describe('ReferencePage', () => {
       tasksAPI.getByStatus.mockResolvedValue({
         data: { tasks: [mockItem1], count: 1 },
       });
-      const store = createStore({ reference: [mockItem1] });
+      const store = createGtdStore({ reference: [mockItem1] });
       renderPage(store);
 
       const user = userEvent.setup();
@@ -257,14 +223,14 @@ describe('ReferencePage', () => {
 
   describe('page header', () => {
     it('should display page title', () => {
-      const store = createStore();
+      const store = createGtdStore();
       renderPage(store);
 
       expect(screen.getByRole('heading', { name: /reference/i })).toBeInTheDocument();
     });
 
     it('should display GTD description', () => {
-      const store = createStore();
+      const store = createGtdStore();
       renderPage(store);
 
       expect(screen.getByText(/non-actionable information for later/i)).toBeInTheDocument();
@@ -273,14 +239,14 @@ describe('ReferencePage', () => {
 
   describe('refresh functionality', () => {
     it('should have refresh button', () => {
-      const store = createStore();
+      const store = createGtdStore();
       renderPage(store);
 
       expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument();
     });
 
     it('should fetch items when refresh clicked', async () => {
-      const store = createStore();
+      const store = createGtdStore();
       renderPage(store);
 
       const user = userEvent.setup();

--- a/web/src/tests/unit/pages/SomedayMaybePage.test.jsx
+++ b/web/src/tests/unit/pages/SomedayMaybePage.test.jsx
@@ -2,10 +2,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
-import { configureStore } from '@reduxjs/toolkit';
 import { MemoryRouter } from 'react-router-dom';
-import tasksReducer from '../../../features/tasks/tasksSlice';
-import contextsReducer from '../../../features/contexts/contextsSlice';
+import { createGtdStore } from '../../helpers/gtdTestHelpers';
 import SomedayMaybePage from '../../../pages/SomedayMaybePage';
 
 // Mock the API module
@@ -54,38 +52,6 @@ describe('SomedayMaybePage', () => {
     { id: 'ctx-1', name: '@Travel', is_default: false, status: 'active' },
   ];
 
-  const createStore = (tasksState = {}, contextsState = {}) => {
-    return configureStore({
-      reducer: {
-        tasks: tasksReducer,
-        contexts: contextsReducer,
-      },
-      preloadedState: {
-        tasks: {
-          inbox: [],
-          clarified: [],
-          nextActions: [],
-          waitingFor: [],
-          somedayMaybe: [],
-          reference: [],
-          currentTask: null,
-          loading: false,
-          clarifying: false,
-          error: null,
-          nextCursor: null,
-          total: 0,
-          ...tasksState,
-        },
-        contexts: {
-          contexts: [],
-          loading: false,
-          error: null,
-          ...contextsState,
-        },
-      },
-    });
-  };
-
   const renderPage = (store) => {
     return render(
       <Provider store={store}>
@@ -112,7 +78,7 @@ describe('SomedayMaybePage', () => {
 
   describe('loading state', () => {
     it('should show loading spinner while fetching', () => {
-      const store = createStore({ loading: true });
+      const store = createGtdStore({ loading: true });
       renderPage(store);
 
       expect(screen.getByText(/loading someday/i)).toBeInTheDocument();
@@ -124,7 +90,7 @@ describe('SomedayMaybePage', () => {
       tasksAPI.getByStatus.mockResolvedValue({
         data: { tasks: [mockTask1, mockTask2], count: 2 },
       });
-      const store = createStore({ somedayMaybe: [mockTask1, mockTask2] });
+      const store = createGtdStore({ somedayMaybe: [mockTask1, mockTask2] });
       renderPage(store);
 
       await waitFor(() => {
@@ -137,7 +103,7 @@ describe('SomedayMaybePage', () => {
       tasksAPI.getByStatus.mockResolvedValue({
         data: { tasks: [], count: 0 },
       });
-      const store = createStore({ somedayMaybe: [] });
+      const store = createGtdStore({ somedayMaybe: [] });
       renderPage(store);
 
       await waitFor(() => {
@@ -149,7 +115,7 @@ describe('SomedayMaybePage', () => {
       tasksAPI.getByStatus.mockRejectedValue({
         response: { data: { message: 'Failed to fetch tasks' } },
       });
-      const store = createStore();
+      const store = createGtdStore();
       renderPage(store);
 
       await waitFor(() => {
@@ -159,7 +125,7 @@ describe('SomedayMaybePage', () => {
     });
 
     it('should display task count in header', async () => {
-      const store = createStore({ somedayMaybe: [mockTask1, mockTask2] });
+      const store = createGtdStore({ somedayMaybe: [mockTask1, mockTask2] });
       renderPage(store);
 
       await waitFor(() => {
@@ -176,7 +142,7 @@ describe('SomedayMaybePage', () => {
       tasksAPI.update.mockResolvedValue({
         data: { ...mockTask1, status: 'next_action' },
       });
-      const store = createStore({ somedayMaybe: [mockTask1] });
+      const store = createGtdStore({ somedayMaybe: [mockTask1] });
       renderPage(store);
 
       const user = userEvent.setup();
@@ -198,7 +164,7 @@ describe('SomedayMaybePage', () => {
       tasksAPI.getByStatus.mockResolvedValue({
         data: { tasks: [mockTask1], count: 1 },
       });
-      const store = createStore({ somedayMaybe: [mockTask1] });
+      const store = createGtdStore({ somedayMaybe: [mockTask1] });
       renderPage(store);
 
       const user = userEvent.setup();
@@ -219,14 +185,14 @@ describe('SomedayMaybePage', () => {
 
   describe('page header', () => {
     it('should display page title', () => {
-      const store = createStore();
+      const store = createGtdStore();
       renderPage(store);
 
       expect(screen.getByRole('heading', { name: /someday\/maybe/i })).toBeInTheDocument();
     });
 
     it('should display GTD description', () => {
-      const store = createStore();
+      const store = createGtdStore();
       renderPage(store);
 
       expect(screen.getByText(/ideas and tasks deferred for later/i)).toBeInTheDocument();
@@ -235,14 +201,14 @@ describe('SomedayMaybePage', () => {
 
   describe('refresh functionality', () => {
     it('should have refresh button', () => {
-      const store = createStore();
+      const store = createGtdStore();
       renderPage(store);
 
       expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument();
     });
 
     it('should fetch tasks when refresh clicked', async () => {
-      const store = createStore();
+      const store = createGtdStore();
       renderPage(store);
 
       const user = userEvent.setup();

--- a/web/src/tests/unit/pages/SomedayMaybePage.test.jsx
+++ b/web/src/tests/unit/pages/SomedayMaybePage.test.jsx
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
+import tasksReducer from '../../../features/tasks/tasksSlice';
+import contextsReducer from '../../../features/contexts/contextsSlice';
+import SomedayMaybePage from '../../../pages/SomedayMaybePage';
+
+// Mock the API module
+vi.mock('../../../services/api', () => ({
+  tasksAPI: {
+    getByStatus: vi.fn(),
+    complete: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+  contextsAPI: {
+    getAll: vi.fn(),
+  },
+}));
+
+import { tasksAPI, contextsAPI } from '../../../services/api';
+
+describe('SomedayMaybePage', () => {
+  const mockTask1 = {
+    id: 'task-1',
+    title: 'Learn French',
+    notes: 'Maybe take classes',
+    status: 'someday_maybe',
+    energy_level: null,
+    time_estimate: null,
+    due_date: null,
+    contexts: [],
+    created_at: '2025-11-01T10:00:00Z',
+    updated_at: '2025-11-01T10:00:00Z',
+  };
+
+  const mockTask2 = {
+    id: 'task-2',
+    title: 'Visit Japan',
+    notes: 'Cherry blossom season',
+    status: 'someday_maybe',
+    energy_level: null,
+    time_estimate: null,
+    due_date: null,
+    contexts: [{ id: 'ctx-1', name: '@Travel' }],
+    created_at: '2025-10-15T10:00:00Z',
+    updated_at: '2025-10-15T10:00:00Z',
+  };
+
+  const mockContexts = [
+    { id: 'ctx-1', name: '@Travel', is_default: false, status: 'active' },
+  ];
+
+  const createStore = (tasksState = {}, contextsState = {}) => {
+    return configureStore({
+      reducer: {
+        tasks: tasksReducer,
+        contexts: contextsReducer,
+      },
+      preloadedState: {
+        tasks: {
+          inbox: [],
+          clarified: [],
+          nextActions: [],
+          waitingFor: [],
+          somedayMaybe: [],
+          reference: [],
+          currentTask: null,
+          loading: false,
+          clarifying: false,
+          error: null,
+          nextCursor: null,
+          total: 0,
+          ...tasksState,
+        },
+        contexts: {
+          contexts: [],
+          loading: false,
+          error: null,
+          ...contextsState,
+        },
+      },
+    });
+  };
+
+  const renderPage = (store) => {
+    return render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <SomedayMaybePage />
+        </MemoryRouter>
+      </Provider>
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tasksAPI.getByStatus.mockResolvedValue({
+      data: { tasks: [], count: 0 },
+    });
+    tasksAPI.update.mockResolvedValue({
+      data: { ...mockTask1, status: 'next_action' },
+    });
+    tasksAPI.delete.mockResolvedValue({});
+    contextsAPI.getAll.mockResolvedValue({
+      data: { contexts: mockContexts, count: mockContexts.length },
+    });
+  });
+
+  describe('loading state', () => {
+    it('should show loading spinner while fetching', () => {
+      const store = createStore({ loading: true });
+      renderPage(store);
+
+      expect(screen.getByText(/loading someday/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('task list', () => {
+    it('should render tasks with someday_maybe status', async () => {
+      tasksAPI.getByStatus.mockResolvedValue({
+        data: { tasks: [mockTask1, mockTask2], count: 2 },
+      });
+      const store = createStore({ somedayMaybe: [mockTask1, mockTask2] });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText('Learn French')).toBeInTheDocument();
+        expect(screen.getByText('Visit Japan')).toBeInTheDocument();
+      });
+    });
+
+    it('should show empty state when no tasks', async () => {
+      tasksAPI.getByStatus.mockResolvedValue({
+        data: { tasks: [], count: 0 },
+      });
+      const store = createStore({ somedayMaybe: [] });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText(/no someday\/maybe items/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should show error message on fetch failure', async () => {
+      tasksAPI.getByStatus.mockRejectedValue({
+        response: { data: { message: 'Failed to fetch tasks' } },
+      });
+      const store = createStore();
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+        expect(screen.getByText(/failed to fetch/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should display task count in header', async () => {
+      const store = createStore({ somedayMaybe: [mockTask1, mockTask2] });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText('2')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('task actions', () => {
+    it('should allow activating task (move to next_action)', async () => {
+      tasksAPI.getByStatus.mockResolvedValue({
+        data: { tasks: [mockTask1], count: 1 },
+      });
+      tasksAPI.update.mockResolvedValue({
+        data: { ...mockTask1, status: 'next_action' },
+      });
+      const store = createStore({ somedayMaybe: [mockTask1] });
+      renderPage(store);
+
+      const user = userEvent.setup();
+
+      await waitFor(() => {
+        expect(screen.getByText('Learn French')).toBeInTheDocument();
+      });
+
+      // Find and click the "Activate" button
+      const activateButton = screen.getByRole('button', { name: /activate/i });
+      await user.click(activateButton);
+
+      await waitFor(() => {
+        expect(tasksAPI.update).toHaveBeenCalledWith('task-1', { status: 'next_action' });
+      });
+    });
+
+    it('should allow deleting deferred task', async () => {
+      tasksAPI.getByStatus.mockResolvedValue({
+        data: { tasks: [mockTask1], count: 1 },
+      });
+      const store = createStore({ somedayMaybe: [mockTask1] });
+      renderPage(store);
+
+      const user = userEvent.setup();
+
+      await waitFor(() => {
+        expect(screen.getByText('Learn French')).toBeInTheDocument();
+      });
+
+      // Find and click the delete button
+      const deleteButton = screen.getByRole('button', { name: /delete "learn french"/i });
+      await user.click(deleteButton);
+
+      await waitFor(() => {
+        expect(tasksAPI.delete).toHaveBeenCalledWith('task-1');
+      });
+    });
+  });
+
+  describe('page header', () => {
+    it('should display page title', () => {
+      const store = createStore();
+      renderPage(store);
+
+      expect(screen.getByRole('heading', { name: /someday\/maybe/i })).toBeInTheDocument();
+    });
+
+    it('should display GTD description', () => {
+      const store = createStore();
+      renderPage(store);
+
+      expect(screen.getByText(/ideas and tasks deferred for later/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('refresh functionality', () => {
+    it('should have refresh button', () => {
+      const store = createStore();
+      renderPage(store);
+
+      expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument();
+    });
+
+    it('should fetch tasks when refresh clicked', async () => {
+      const store = createStore();
+      renderPage(store);
+
+      const user = userEvent.setup();
+      const refreshButton = screen.getByRole('button', { name: /refresh/i });
+      await user.click(refreshButton);
+
+      await waitFor(() => {
+        expect(tasksAPI.getByStatus).toHaveBeenCalledWith('someday_maybe');
+      });
+    });
+  });
+});

--- a/web/src/tests/unit/pages/WaitingForPage.test.jsx
+++ b/web/src/tests/unit/pages/WaitingForPage.test.jsx
@@ -1,0 +1,271 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
+import tasksReducer from '../../../features/tasks/tasksSlice';
+import contextsReducer from '../../../features/contexts/contextsSlice';
+import WaitingForPage from '../../../pages/WaitingForPage';
+
+// Mock the API module
+vi.mock('../../../services/api', () => ({
+  tasksAPI: {
+    getByStatus: vi.fn(),
+    complete: vi.fn(),
+    update: vi.fn(),
+  },
+  contextsAPI: {
+    getAll: vi.fn(),
+  },
+}));
+
+import { tasksAPI, contextsAPI } from '../../../services/api';
+
+describe('WaitingForPage', () => {
+  // Task waiting for 5 days
+  const mockTask1 = {
+    id: 'task-1',
+    title: 'Waiting for client feedback',
+    notes: 'Sent proposal last week',
+    status: 'waiting_for',
+    energy_level: 'low',
+    time_estimate: null,
+    due_date: null,
+    contexts: [{ id: 'ctx-1', name: '@Waiting' }],
+    created_at: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+    updated_at: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+  };
+
+  // Task waiting for 2 weeks
+  const mockTask2 = {
+    id: 'task-2',
+    title: 'Waiting for parts delivery',
+    notes: 'Order #12345',
+    status: 'waiting_for',
+    energy_level: null,
+    time_estimate: null,
+    due_date: '2025-12-20',
+    contexts: [{ id: 'ctx-2', name: '@Home' }],
+    created_at: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString(),
+    updated_at: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString(),
+  };
+
+  const mockContexts = [
+    { id: 'ctx-1', name: '@Waiting', is_default: false, status: 'active' },
+    { id: 'ctx-2', name: '@Home', is_default: true, status: 'active' },
+  ];
+
+  const createStore = (tasksState = {}, contextsState = {}) => {
+    return configureStore({
+      reducer: {
+        tasks: tasksReducer,
+        contexts: contextsReducer,
+      },
+      preloadedState: {
+        tasks: {
+          inbox: [],
+          clarified: [],
+          nextActions: [],
+          waitingFor: [],
+          somedayMaybe: [],
+          reference: [],
+          currentTask: null,
+          loading: false,
+          clarifying: false,
+          error: null,
+          nextCursor: null,
+          total: 0,
+          ...tasksState,
+        },
+        contexts: {
+          contexts: [],
+          loading: false,
+          error: null,
+          ...contextsState,
+        },
+      },
+    });
+  };
+
+  const renderPage = (store) => {
+    return render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <WaitingForPage />
+        </MemoryRouter>
+      </Provider>
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tasksAPI.getByStatus.mockResolvedValue({
+      data: { tasks: [], count: 0 },
+    });
+    tasksAPI.complete.mockResolvedValue({
+      data: { task: { ...mockTask1, status: 'completed' }, message: 'Task completed' },
+    });
+    tasksAPI.update.mockResolvedValue({
+      data: { ...mockTask1, status: 'next_action' },
+    });
+    contextsAPI.getAll.mockResolvedValue({
+      data: { contexts: mockContexts, count: mockContexts.length },
+    });
+  });
+
+  describe('loading state', () => {
+    it('should show loading spinner while fetching', () => {
+      const store = createStore({ loading: true });
+      renderPage(store);
+
+      expect(screen.getByText(/loading waiting for/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('task list', () => {
+    it('should render tasks with waiting_for status', async () => {
+      tasksAPI.getByStatus.mockResolvedValue({
+        data: { tasks: [mockTask1, mockTask2], count: 2 },
+      });
+      const store = createStore({ waitingFor: [mockTask1, mockTask2] });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText('Waiting for client feedback')).toBeInTheDocument();
+        expect(screen.getByText('Waiting for parts delivery')).toBeInTheDocument();
+      });
+    });
+
+    it('should show empty state when no tasks', async () => {
+      tasksAPI.getByStatus.mockResolvedValue({
+        data: { tasks: [], count: 0 },
+      });
+      const store = createStore({ waitingFor: [] });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText(/no waiting for items/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should show error message on fetch failure', async () => {
+      tasksAPI.getByStatus.mockRejectedValue({
+        response: { data: { message: 'Failed to fetch tasks' } },
+      });
+      const store = createStore();
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+        expect(screen.getByText(/failed to fetch/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should display task count in header', async () => {
+      const store = createStore({ waitingFor: [mockTask1, mockTask2] });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText('2')).toBeInTheDocument();
+      });
+    });
+
+    it('should show "waiting since" duration', async () => {
+      const store = createStore({ waitingFor: [mockTask1] });
+      renderPage(store);
+
+      await waitFor(() => {
+        // Task1 is 5 days old
+        expect(screen.getByText(/5 days/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('task actions', () => {
+    it('should allow moving task to next_action', async () => {
+      tasksAPI.getByStatus.mockResolvedValue({
+        data: { tasks: [mockTask1], count: 1 },
+      });
+      tasksAPI.update.mockResolvedValue({
+        data: { ...mockTask1, status: 'next_action' },
+      });
+      const store = createStore({ waitingFor: [mockTask1] });
+      renderPage(store);
+
+      const user = userEvent.setup();
+
+      await waitFor(() => {
+        expect(screen.getByText('Waiting for client feedback')).toBeInTheDocument();
+      });
+
+      // Find and click the "Move to Next Actions" button
+      const moveButton = screen.getByRole('button', { name: /move to next actions/i });
+      await user.click(moveButton);
+
+      await waitFor(() => {
+        expect(tasksAPI.update).toHaveBeenCalledWith('task-1', { status: 'next_action' });
+      });
+    });
+
+    it('should allow completing a task', async () => {
+      tasksAPI.getByStatus.mockResolvedValue({
+        data: { tasks: [mockTask1], count: 1 },
+      });
+      const store = createStore({ waitingFor: [mockTask1] });
+      renderPage(store);
+
+      const user = userEvent.setup();
+
+      await waitFor(() => {
+        expect(screen.getByText('Waiting for client feedback')).toBeInTheDocument();
+      });
+
+      // Find and click complete button
+      const completeButton = screen.getByRole('button', { name: /complete "waiting for client feedback"/i });
+      await user.click(completeButton);
+
+      await waitFor(() => {
+        expect(tasksAPI.complete).toHaveBeenCalledWith('task-1');
+      });
+    });
+  });
+
+  describe('page header', () => {
+    it('should display page title', () => {
+      const store = createStore();
+      renderPage(store);
+
+      expect(screen.getByRole('heading', { name: /waiting for/i })).toBeInTheDocument();
+    });
+
+    it('should display GTD description', () => {
+      const store = createStore();
+      renderPage(store);
+
+      expect(screen.getByText(/tasks delegated or waiting on others/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('refresh functionality', () => {
+    it('should have refresh button', () => {
+      const store = createStore();
+      renderPage(store);
+
+      expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument();
+    });
+
+    it('should fetch tasks when refresh clicked', async () => {
+      const store = createStore();
+      renderPage(store);
+
+      const user = userEvent.setup();
+      const refreshButton = screen.getByRole('button', { name: /refresh/i });
+      await user.click(refreshButton);
+
+      await waitFor(() => {
+        expect(tasksAPI.getByStatus).toHaveBeenCalledWith('waiting_for');
+      });
+    });
+  });
+});

--- a/web/src/tests/unit/pages/WaitingForPage.test.jsx
+++ b/web/src/tests/unit/pages/WaitingForPage.test.jsx
@@ -2,13 +2,10 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
-import { configureStore } from '@reduxjs/toolkit';
 import { MemoryRouter } from 'react-router-dom';
-import tasksReducer from '../../../features/tasks/tasksSlice';
-import contextsReducer from '../../../features/contexts/contextsSlice';
+import { createGtdStore } from '../../helpers/gtdTestHelpers';
 import WaitingForPage from '../../../pages/WaitingForPage';
 
-// Mock the API module
 vi.mock('../../../services/api', () => ({
   tasksAPI: {
     getByStatus: vi.fn(),
@@ -23,7 +20,6 @@ vi.mock('../../../services/api', () => ({
 import { tasksAPI, contextsAPI } from '../../../services/api';
 
 describe('WaitingForPage', () => {
-  // Task waiting for 5 days
   const mockTask1 = {
     id: 'task-1',
     title: 'Waiting for client feedback',
@@ -37,7 +33,6 @@ describe('WaitingForPage', () => {
     updated_at: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
   };
 
-  // Task waiting for 2 weeks
   const mockTask2 = {
     id: 'task-2',
     title: 'Waiting for parts delivery',
@@ -56,38 +51,6 @@ describe('WaitingForPage', () => {
     { id: 'ctx-2', name: '@Home', is_default: true, status: 'active' },
   ];
 
-  const createStore = (tasksState = {}, contextsState = {}) => {
-    return configureStore({
-      reducer: {
-        tasks: tasksReducer,
-        contexts: contextsReducer,
-      },
-      preloadedState: {
-        tasks: {
-          inbox: [],
-          clarified: [],
-          nextActions: [],
-          waitingFor: [],
-          somedayMaybe: [],
-          reference: [],
-          currentTask: null,
-          loading: false,
-          clarifying: false,
-          error: null,
-          nextCursor: null,
-          total: 0,
-          ...tasksState,
-        },
-        contexts: {
-          contexts: [],
-          loading: false,
-          error: null,
-          ...contextsState,
-        },
-      },
-    });
-  };
-
   const renderPage = (store) => {
     return render(
       <Provider store={store}>
@@ -100,15 +63,11 @@ describe('WaitingForPage', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    tasksAPI.getByStatus.mockResolvedValue({
-      data: { tasks: [], count: 0 },
-    });
+    tasksAPI.getByStatus.mockResolvedValue({ data: { tasks: [], count: 0 } });
     tasksAPI.complete.mockResolvedValue({
       data: { task: { ...mockTask1, status: 'completed' }, message: 'Task completed' },
     });
-    tasksAPI.update.mockResolvedValue({
-      data: { ...mockTask1, status: 'next_action' },
-    });
+    tasksAPI.update.mockResolvedValue({ data: { ...mockTask1, status: 'next_action' } });
     contextsAPI.getAll.mockResolvedValue({
       data: { contexts: mockContexts, count: mockContexts.length },
     });
@@ -116,9 +75,8 @@ describe('WaitingForPage', () => {
 
   describe('loading state', () => {
     it('should show loading spinner while fetching', () => {
-      const store = createStore({ loading: true });
+      const store = createGtdStore({ loading: true });
       renderPage(store);
-
       expect(screen.getByText(/loading waiting for/i)).toBeInTheDocument();
     });
   });
@@ -128,7 +86,7 @@ describe('WaitingForPage', () => {
       tasksAPI.getByStatus.mockResolvedValue({
         data: { tasks: [mockTask1, mockTask2], count: 2 },
       });
-      const store = createStore({ waitingFor: [mockTask1, mockTask2] });
+      const store = createGtdStore({ waitingFor: [mockTask1, mockTask2] });
       renderPage(store);
 
       await waitFor(() => {
@@ -138,12 +96,8 @@ describe('WaitingForPage', () => {
     });
 
     it('should show empty state when no tasks', async () => {
-      tasksAPI.getByStatus.mockResolvedValue({
-        data: { tasks: [], count: 0 },
-      });
-      const store = createStore({ waitingFor: [] });
+      const store = createGtdStore({ waitingFor: [] });
       renderPage(store);
-
       await waitFor(() => {
         expect(screen.getByText(/no waiting for items/i)).toBeInTheDocument();
       });
@@ -153,7 +107,7 @@ describe('WaitingForPage', () => {
       tasksAPI.getByStatus.mockRejectedValue({
         response: { data: { message: 'Failed to fetch tasks' } },
       });
-      const store = createStore();
+      const store = createGtdStore();
       renderPage(store);
 
       await waitFor(() => {
@@ -163,20 +117,17 @@ describe('WaitingForPage', () => {
     });
 
     it('should display task count in header', async () => {
-      const store = createStore({ waitingFor: [mockTask1, mockTask2] });
+      const store = createGtdStore({ waitingFor: [mockTask1, mockTask2] });
       renderPage(store);
-
       await waitFor(() => {
         expect(screen.getByText('2')).toBeInTheDocument();
       });
     });
 
     it('should show "waiting since" duration', async () => {
-      const store = createStore({ waitingFor: [mockTask1] });
+      const store = createGtdStore({ waitingFor: [mockTask1] });
       renderPage(store);
-
       await waitFor(() => {
-        // Task1 is 5 days old
         expect(screen.getByText(/5 days/i)).toBeInTheDocument();
       });
     });
@@ -184,22 +135,15 @@ describe('WaitingForPage', () => {
 
   describe('task actions', () => {
     it('should allow moving task to next_action', async () => {
-      tasksAPI.getByStatus.mockResolvedValue({
-        data: { tasks: [mockTask1], count: 1 },
-      });
-      tasksAPI.update.mockResolvedValue({
-        data: { ...mockTask1, status: 'next_action' },
-      });
-      const store = createStore({ waitingFor: [mockTask1] });
+      tasksAPI.getByStatus.mockResolvedValue({ data: { tasks: [mockTask1], count: 1 } });
+      const store = createGtdStore({ waitingFor: [mockTask1] });
       renderPage(store);
 
       const user = userEvent.setup();
-
       await waitFor(() => {
         expect(screen.getByText('Waiting for client feedback')).toBeInTheDocument();
       });
 
-      // Find and click the "Move to Next Actions" button
       const moveButton = screen.getByRole('button', { name: /move to next actions/i });
       await user.click(moveButton);
 
@@ -209,19 +153,15 @@ describe('WaitingForPage', () => {
     });
 
     it('should allow completing a task', async () => {
-      tasksAPI.getByStatus.mockResolvedValue({
-        data: { tasks: [mockTask1], count: 1 },
-      });
-      const store = createStore({ waitingFor: [mockTask1] });
+      tasksAPI.getByStatus.mockResolvedValue({ data: { tasks: [mockTask1], count: 1 } });
+      const store = createGtdStore({ waitingFor: [mockTask1] });
       renderPage(store);
 
       const user = userEvent.setup();
-
       await waitFor(() => {
         expect(screen.getByText('Waiting for client feedback')).toBeInTheDocument();
       });
 
-      // Find and click complete button
       const completeButton = screen.getByRole('button', { name: /complete "waiting for client feedback"/i });
       await user.click(completeButton);
 
@@ -233,30 +173,27 @@ describe('WaitingForPage', () => {
 
   describe('page header', () => {
     it('should display page title', () => {
-      const store = createStore();
+      const store = createGtdStore();
       renderPage(store);
-
       expect(screen.getByRole('heading', { name: /waiting for/i })).toBeInTheDocument();
     });
 
     it('should display GTD description', () => {
-      const store = createStore();
+      const store = createGtdStore();
       renderPage(store);
-
       expect(screen.getByText(/tasks delegated or waiting on others/i)).toBeInTheDocument();
     });
   });
 
   describe('refresh functionality', () => {
     it('should have refresh button', () => {
-      const store = createStore();
+      const store = createGtdStore();
       renderPage(store);
-
       expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument();
     });
 
     it('should fetch tasks when refresh clicked', async () => {
-      const store = createStore();
+      const store = createGtdStore();
       renderPage(store);
 
       const user = userEvent.setup();


### PR DESCRIPTION
## Summary

Implements Phase 4.4 - Frontend GTD List Views (FR-016), providing dedicated pages for each GTD workflow status:

- **Next Actions Page** - Actionable tasks ready to do, with context filtering sidebar
- **Waiting For Page** - Delegated/blocked tasks with waiting duration display  
- **Someday/Maybe Page** - Deferred tasks with activate/delete actions
- **Reference Page** - Non-actionable information with search functionality

### Changes

- Add 4 new GTD list view pages with consistent patterns
- Add context filtering sidebar for Next Actions
- Add waiting duration calculation (days/weeks/months)
- Add search/filter functionality for Reference items
- Add navigation links for all GTD lists
- Add comprehensive unit tests (51 tests across 4 pages)
- Add E2E tests covering all GTD workflows (17 tests)

### Files Changed (12 files, +2,871 lines)

| File | Description |
|------|-------------|
| `web/src/pages/NextActionsPage.jsx` | Next Actions list with context filtering |
| `web/src/pages/WaitingForPage.jsx` | Waiting For list with duration display |
| `web/src/pages/SomedayMaybePage.jsx` | Someday/Maybe list with activate/delete |
| `web/src/pages/ReferencePage.jsx` | Reference items with search |
| `web/src/features/tasks/tasksSlice.js` | Added fetch thunks for each status |
| `web/src/App.jsx` | Added routes for GTD pages |
| `web/src/components/Navigation.jsx` | Added nav links |
| `web/src/tests/unit/pages/*.test.jsx` | Unit tests (4 files) |
| `web/src/tests/e2e/gtd-lists.spec.jsx` | E2E tests |

## Test plan

- [x] All 667 tests pass
- [x] Unit tests cover loading, error, empty states
- [x] E2E tests cover navigation, filtering, actions
- [ ] Manual testing of navigation between GTD lists
- [ ] Verify context filtering on Next Actions
- [ ] Verify search on Reference page

🤖 Generated with [Claude Code](https://claude.com/claude-code)