### PR TITLE
feat(api): P5.2 Backend - Project Endpoints Implementation

### DIFF
--- a/api/src/Controller/ProjectController.php
+++ b/api/src/Controller/ProjectController.php
@@ -1,0 +1,372 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\Project;
+use App\Entity\User;
+use App\Repository\ProjectRepository;
+use App\Repository\TaskRepository;
+use App\Service\ProjectService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[Route('/api/v1')]
+class ProjectController extends AbstractController
+{
+    private const UUID_PATTERN = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+
+    public function __construct(
+        private readonly ProjectRepository $projectRepository,
+        private readonly TaskRepository $taskRepository,
+        private readonly ProjectService $projectService,
+        private readonly ValidatorInterface $validator,
+    ) {
+    }
+
+    // =========================================================================
+    // List Endpoints
+    // =========================================================================
+
+    #[Route('/projects', name: 'api_projects_list', methods: ['GET'])]
+    public function list(Request $request): JsonResponse
+    {
+        $user = $this->getAuthenticatedUser();
+        if ($user instanceof JsonResponse) {
+            return $user;
+        }
+
+        $status = $request->query->get('status');
+
+        if ($status !== null) {
+            $projects = $this->projectRepository->findByStatus($user, $status);
+        } else {
+            $projects = $this->projectRepository->findAllByUser($user);
+        }
+
+        return $this->projectListResponse($projects);
+    }
+
+    #[Route('/projects/needing-attention', name: 'api_projects_needing_attention', methods: ['GET'])]
+    public function needingAttention(): JsonResponse
+    {
+        $user = $this->getAuthenticatedUser();
+        if ($user instanceof JsonResponse) {
+            return $user;
+        }
+
+        $projects = $this->projectService->getProjectsNeedingAttention($user);
+
+        return $this->projectListResponse($projects);
+    }
+
+    #[Route('/projects/due-for-review', name: 'api_projects_due_for_review', methods: ['GET'])]
+    public function dueForReview(): JsonResponse
+    {
+        $user = $this->getAuthenticatedUser();
+        if ($user instanceof JsonResponse) {
+            return $user;
+        }
+
+        $projects = $this->projectService->getProjectsDueForReview($user);
+
+        return $this->projectListResponse($projects);
+    }
+
+    // =========================================================================
+    // CRUD Endpoints
+    // =========================================================================
+
+    #[Route('/projects/{id}', name: 'api_projects_get', methods: ['GET'], requirements: ['id' => self::UUID_PATTERN])]
+    public function get(string $id): JsonResponse
+    {
+        $result = $this->getAuthenticatedUserAndProject($id);
+        if ($result instanceof JsonResponse) {
+            return $result;
+        }
+
+        $project = $result['project'];
+
+        // Get tasks for this project
+        $tasks = $this->taskRepository->findByProject($project);
+
+        // Get next action
+        $nextAction = $this->projectService->getNextAction($project);
+
+        return $this->json([
+            'project' => $this->projectToDetailArray($project, $tasks, $nextAction),
+        ]);
+    }
+
+    #[Route('/projects', name: 'api_projects_create', methods: ['POST'])]
+    public function create(Request $request): JsonResponse
+    {
+        $user = $this->getAuthenticatedUser();
+        if ($user instanceof JsonResponse) {
+            return $user;
+        }
+
+        $data = json_decode($request->getContent(), true) ?? [];
+
+        if (!isset($data['title']) || trim($data['title']) === '') {
+            return $this->errorResponse('Title is required', 'MISSING_TITLE', Response::HTTP_BAD_REQUEST);
+        }
+
+        $title = trim($data['title']);
+        $outcome = isset($data['outcome']) ? trim($data['outcome']) : null;
+
+        $project = $this->projectService->create($user, $title, $outcome);
+
+        return $this->json([
+            'message' => 'Project created successfully',
+            'project' => $this->projectToArray($project),
+        ], Response::HTTP_CREATED);
+    }
+
+    #[Route('/projects/{id}', name: 'api_projects_update', methods: ['PATCH'], requirements: ['id' => self::UUID_PATTERN])]
+    public function update(string $id, Request $request): JsonResponse
+    {
+        $result = $this->getAuthenticatedUserAndProject($id);
+        if ($result instanceof JsonResponse) {
+            return $result;
+        }
+
+        $project = $result['project'];
+        $data = json_decode($request->getContent(), true) ?? [];
+
+        // Update title if provided
+        if (isset($data['title'])) {
+            $newTitle = trim($data['title']);
+            if ($newTitle === '') {
+                return $this->errorResponse('Title cannot be empty', 'INVALID_TITLE', Response::HTTP_BAD_REQUEST);
+            }
+            $project->setTitle($newTitle);
+        }
+
+        // Update outcome if provided (FR-019)
+        if (array_key_exists('outcome', $data)) {
+            $project->setOutcome($data['outcome']);
+        }
+
+        // Update position if provided
+        if (isset($data['position']) && is_int($data['position'])) {
+            $project->setPosition($data['position']);
+        }
+
+        // Update review_date if provided
+        if (isset($data['review_date'])) {
+            try {
+                $project->setReviewDate(new \DateTimeImmutable($data['review_date']));
+            } catch (\Exception) {
+                return $this->errorResponse('Invalid review date format', 'INVALID_DATE', Response::HTTP_BAD_REQUEST);
+            }
+        }
+
+        return $this->saveProjectWithValidation($project, 'Project updated successfully');
+    }
+
+    #[Route('/projects/{id}', name: 'api_projects_delete', methods: ['DELETE'], requirements: ['id' => self::UUID_PATTERN])]
+    public function delete(string $id): JsonResponse
+    {
+        $result = $this->getAuthenticatedUserAndProject($id);
+        if ($result instanceof JsonResponse) {
+            return $result;
+        }
+
+        $project = $result['project'];
+
+        // Soft delete by cancelling
+        $project->cancel();
+        $this->projectRepository->save($project);
+
+        return $this->json(['message' => 'Project deleted successfully']);
+    }
+
+    // =========================================================================
+    // Status Transition Endpoints
+    // =========================================================================
+
+    #[Route('/projects/{id}/complete', name: 'api_projects_complete', methods: ['POST'], requirements: ['id' => self::UUID_PATTERN])]
+    public function complete(string $id): JsonResponse
+    {
+        $result = $this->getAuthenticatedUserAndProject($id);
+        if ($result instanceof JsonResponse) {
+            return $result;
+        }
+
+        $project = $result['project'];
+
+        try {
+            $this->projectService->complete($project);
+        } catch (\InvalidArgumentException $e) {
+            return $this->errorResponse($e->getMessage(), 'INVALID_TRANSITION', Response::HTTP_BAD_REQUEST);
+        }
+
+        return $this->json([
+            'message' => 'Project completed',
+            'project' => $this->projectToArray($project),
+        ]);
+    }
+
+    #[Route('/projects/{id}/hold', name: 'api_projects_hold', methods: ['POST'], requirements: ['id' => self::UUID_PATTERN])]
+    public function hold(string $id): JsonResponse
+    {
+        $result = $this->getAuthenticatedUserAndProject($id);
+        if ($result instanceof JsonResponse) {
+            return $result;
+        }
+
+        $project = $result['project'];
+
+        try {
+            $this->projectService->putOnHold($project);
+        } catch (\InvalidArgumentException $e) {
+            return $this->errorResponse($e->getMessage(), 'INVALID_TRANSITION', Response::HTTP_BAD_REQUEST);
+        }
+
+        return $this->json([
+            'message' => 'Project put on hold',
+            'project' => $this->projectToArray($project),
+        ]);
+    }
+
+    #[Route('/projects/{id}/activate', name: 'api_projects_activate', methods: ['POST'], requirements: ['id' => self::UUID_PATTERN])]
+    public function activate(string $id): JsonResponse
+    {
+        $result = $this->getAuthenticatedUserAndProject($id);
+        if ($result instanceof JsonResponse) {
+            return $result;
+        }
+
+        $project = $result['project'];
+
+        try {
+            $this->projectService->activate($project);
+        } catch (\InvalidArgumentException $e) {
+            return $this->errorResponse($e->getMessage(), 'INVALID_TRANSITION', Response::HTTP_BAD_REQUEST);
+        }
+
+        return $this->json([
+            'message' => 'Project activated',
+            'project' => $this->projectToArray($project),
+        ]);
+    }
+
+    // =========================================================================
+    // Helper Methods
+    // =========================================================================
+
+    private function getAuthenticatedUser(): User|JsonResponse
+    {
+        $user = $this->getUser();
+
+        return $user instanceof User
+            ? $user
+            : $this->errorResponse('Not authenticated', 'NOT_AUTHENTICATED', Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * @return array{user: User, project: Project}|JsonResponse
+     */
+    private function getAuthenticatedUserAndProject(string $id): array|JsonResponse
+    {
+        $user = $this->getAuthenticatedUser();
+        if ($user instanceof JsonResponse) {
+            return $user;
+        }
+
+        if (!Uuid::isValid($id)) {
+            return $this->errorResponse('Invalid project ID', 'INVALID_ID', Response::HTTP_BAD_REQUEST);
+        }
+
+        $project = $this->projectRepository->findById(Uuid::fromString($id));
+
+        if ($project === null) {
+            return $this->errorResponse('Project not found', 'NOT_FOUND', Response::HTTP_NOT_FOUND);
+        }
+
+        // Verify ownership
+        if ($project->getUser()->getId()->toRfc4122() !== $user->getId()->toRfc4122()) {
+            return $this->errorResponse('Project not found', 'NOT_FOUND', Response::HTTP_NOT_FOUND);
+        }
+
+        return ['user' => $user, 'project' => $project];
+    }
+
+    private function errorResponse(string $message, string $code, int $status): JsonResponse
+    {
+        return $this->json(['error' => $message, 'code' => $code], $status);
+    }
+
+    /**
+     * @param Project[] $projects
+     */
+    private function projectListResponse(array $projects): JsonResponse
+    {
+        $projectsArray = array_map(fn(Project $project) => $this->projectToArray($project), $projects);
+
+        return $this->json([
+            'projects' => $projectsArray,
+            'count' => count($projects),
+        ]);
+    }
+
+    private function projectToArray(Project $project): array
+    {
+        $baseArray = $project->toArray();
+
+        // Add computed properties
+        $baseArray['task_count'] = $this->projectService->countTasks($project);
+        $baseArray['next_action_count'] = $this->projectService->countNextActions($project);
+        $baseArray['has_next_action'] = $this->projectService->hasNextAction($project);
+
+        return $baseArray;
+    }
+
+    /**
+     * @param \App\Entity\Task[] $tasks
+     */
+    private function projectToDetailArray(Project $project, array $tasks, ?\App\Entity\Task $nextAction): array
+    {
+        $baseArray = $this->projectToArray($project);
+
+        // Add tasks
+        $baseArray['tasks'] = array_map(fn($task) => $task->toArray(), $tasks);
+
+        // Add next action
+        $baseArray['next_action'] = $nextAction?->toArray();
+
+        return $baseArray;
+    }
+
+    private function saveProjectWithValidation(Project $project, string $message, int $status = Response::HTTP_OK): JsonResponse
+    {
+        $errors = $this->validator->validate($project);
+
+        if (count($errors) > 0) {
+            $errorMessages = [];
+            foreach ($errors as $error) {
+                $errorMessages[$error->getPropertyPath()] = $error->getMessage();
+            }
+
+            return $this->json([
+                'error' => 'Validation failed',
+                'code' => 'VALIDATION_ERROR',
+                'details' => $errorMessages,
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $this->projectRepository->save($project);
+
+        return $this->json([
+            'message' => $message,
+            'project' => $this->projectToArray($project),
+        ], $status);
+    }
+}

--- a/api/src/Controller/TaskController.php
+++ b/api/src/Controller/TaskController.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Entity\Project;
 use App\Entity\Task;
 use App\Entity\User;
+use App\Repository\ProjectRepository;
 use App\Repository\TaskRepository;
 use App\Service\TaskService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -26,6 +28,7 @@ class TaskController extends AbstractController
 
     public function __construct(
         private readonly TaskRepository $taskRepository,
+        private readonly ProjectRepository $projectRepository,
         private readonly ValidatorInterface $validator,
         private readonly TaskService $taskService,
     ) {
@@ -532,6 +535,14 @@ class TaskController extends AbstractController
             $task->setNotes($data['notes']);
         }
 
+        // Handle project_id separately since it requires lookup
+        if (array_key_exists('project_id', $data)) {
+            $projectError = $this->validateAndSetProject($task, $data['project_id']);
+            if ($projectError !== null) {
+                return $projectError;
+            }
+        }
+
         foreach ($fieldUpdaters as $field => $updater) {
             if (array_key_exists($field, $data)) {
                 $error = $updater($data[$field]);
@@ -604,6 +615,34 @@ class TaskController extends AbstractController
             return $this->errorResponse('Position must be a non-negative integer', 'INVALID_POSITION', Response::HTTP_BAD_REQUEST);
         }
         $task->setPosition($value);
+
+        return null;
+    }
+
+    private function validateAndSetProject(Task $task, mixed $projectId): ?JsonResponse
+    {
+        if ($projectId === null) {
+            $task->setProject(null);
+
+            return null;
+        }
+
+        if (!is_string($projectId) || !Uuid::isValid($projectId)) {
+            return $this->errorResponse('Invalid project_id format', 'INVALID_PROJECT_ID', Response::HTTP_BAD_REQUEST);
+        }
+
+        $project = $this->projectRepository->findById(Uuid::fromString($projectId));
+
+        if ($project === null) {
+            return $this->errorResponse('Project not found', 'PROJECT_NOT_FOUND', Response::HTTP_NOT_FOUND);
+        }
+
+        // Verify the project belongs to the same user as the task
+        if ($project->getUser()->getId()->toRfc4122() !== $task->getUser()->getId()->toRfc4122()) {
+            return $this->errorResponse('Project not found', 'PROJECT_NOT_FOUND', Response::HTTP_NOT_FOUND);
+        }
+
+        $task->setProject($project);
 
         return null;
     }

--- a/api/src/Repository/TaskRepository.php
+++ b/api/src/Repository/TaskRepository.php
@@ -179,6 +179,38 @@ class TaskRepository extends ServiceEntityRepository
     }
 
     /**
+     * Find all next_action tasks for a project ordered by position
+     *
+     * @return Task[]
+     */
+    public function findNextActionsByProject(object $project): array
+    {
+        return $this->createQueryBuilder('t')
+            ->where('t.project = :project')
+            ->andWhere(self::STATUS_FILTER)
+            ->setParameter('project', $project)
+            ->setParameter('status', Task::STATUS_NEXT_ACTION)
+            ->orderBy('t.position', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Count all non-deleted tasks for a project
+     */
+    public function countByProject(object $project): int
+    {
+        return (int) $this->createQueryBuilder('t')
+            ->select('COUNT(t.id)')
+            ->where('t.project = :project')
+            ->andWhere('t.status != :deleted')
+            ->setParameter('project', $project)
+            ->setParameter('deleted', Task::STATUS_DELETED)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /**
      * @return Task[]
      */
     public function findModifiedSince(User $user, \DateTimeImmutable $since): array

--- a/api/src/Service/ProjectService.php
+++ b/api/src/Service/ProjectService.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Project;
+use App\Entity\Task;
+use App\Entity\User;
+use App\Repository\ProjectRepository;
+use App\Repository\TaskRepository;
+
+/**
+ * ProjectService handles GTD project workflow and status transitions.
+ *
+ * GTD Project Concepts:
+ * - A project is any outcome requiring more than one action
+ * - Each active project should have at least one "next action" defined
+ * - Projects without next actions need review attention (FR-018)
+ * - Projects can have a review date for weekly review
+ */
+class ProjectService
+{
+    /**
+     * Valid status transitions from each status.
+     * Key = current status, Value = array of allowed target statuses
+     */
+    private const STATUS_TRANSITIONS = [
+        Project::STATUS_ACTIVE => [
+            Project::STATUS_ON_HOLD,
+            Project::STATUS_COMPLETED,
+            Project::STATUS_CANCELLED,
+        ],
+        Project::STATUS_ON_HOLD => [
+            Project::STATUS_ACTIVE,
+            Project::STATUS_CANCELLED,
+        ],
+        Project::STATUS_COMPLETED => [
+            Project::STATUS_ACTIVE, // Can reopen
+        ],
+        Project::STATUS_CANCELLED => [
+            Project::STATUS_ACTIVE, // Can reopen
+        ],
+    ];
+
+    public function __construct(
+        private readonly ProjectRepository $projectRepository,
+        private readonly TaskRepository $taskRepository,
+    ) {
+    }
+
+    // =========================================================================
+    // Status Transition Validation
+    // =========================================================================
+
+    /**
+     * Check if a status transition is valid.
+     */
+    public function isValidTransition(string $fromStatus, string $toStatus): bool
+    {
+        if ($fromStatus === $toStatus) {
+            return true; // No change is always valid
+        }
+
+        $allowedTransitions = self::STATUS_TRANSITIONS[$fromStatus] ?? [];
+
+        return in_array($toStatus, $allowedTransitions, true);
+    }
+
+    /**
+     * Get allowed target statuses from a given status.
+     *
+     * @return string[]
+     */
+    public function getAllowedTransitions(string $fromStatus): array
+    {
+        return self::STATUS_TRANSITIONS[$fromStatus] ?? [];
+    }
+
+    // =========================================================================
+    // Project CRUD Operations
+    // =========================================================================
+
+    /**
+     * Create a new project.
+     */
+    public function create(User $user, string $title, ?string $outcome = null): Project
+    {
+        $project = new Project();
+        $project->setUser($user);
+        $project->setTitle($title);
+
+        if ($outcome !== null) {
+            $project->setOutcome($outcome);
+        }
+
+        // Set position to max + 1
+        $maxPosition = $this->projectRepository->getMaxPositionByUser($user);
+        $project->setPosition($maxPosition + 1);
+
+        $this->projectRepository->save($project);
+
+        return $project;
+    }
+
+    /**
+     * Update project status with validation.
+     *
+     * @throws \InvalidArgumentException If transition is invalid
+     */
+    public function updateStatus(Project $project, string $targetStatus): Project
+    {
+        $currentStatus = $project->getStatus();
+
+        if (!$this->isValidTransition($currentStatus, $targetStatus)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Invalid status transition from "%s" to "%s". Allowed transitions: %s',
+                    $currentStatus,
+                    $targetStatus,
+                    implode(', ', $this->getAllowedTransitions($currentStatus))
+                )
+            );
+        }
+
+        // Use entity methods for status changes to ensure side effects are applied
+        match ($targetStatus) {
+            Project::STATUS_COMPLETED => $project->complete(),
+            Project::STATUS_ON_HOLD => $project->putOnHold(),
+            Project::STATUS_ACTIVE => $project->activate(),
+            Project::STATUS_CANCELLED => $project->cancel(),
+            default => null,
+        };
+
+        $this->projectRepository->save($project);
+
+        return $project;
+    }
+
+    /**
+     * Mark project as completed.
+     */
+    public function complete(Project $project): Project
+    {
+        return $this->updateStatus($project, Project::STATUS_COMPLETED);
+    }
+
+    /**
+     * Put project on hold.
+     */
+    public function putOnHold(Project $project): Project
+    {
+        return $this->updateStatus($project, Project::STATUS_ON_HOLD);
+    }
+
+    /**
+     * Activate a project (from on_hold, completed, or cancelled).
+     */
+    public function activate(Project $project): Project
+    {
+        return $this->updateStatus($project, Project::STATUS_ACTIVE);
+    }
+
+    /**
+     * Cancel a project.
+     */
+    public function cancel(Project $project): Project
+    {
+        return $this->updateStatus($project, Project::STATUS_CANCELLED);
+    }
+
+    // =========================================================================
+    // Next Action Logic (FR-017)
+    // =========================================================================
+
+    /**
+     * Get the project's next action (first next_action task by position).
+     * FR-017: System MUST automatically identify the next action of a project.
+     */
+    public function getNextAction(Project $project): ?Task
+    {
+        $nextActions = $this->taskRepository->findNextActionsByProject($project);
+
+        return $nextActions[0] ?? null;
+    }
+
+    /**
+     * Check if project has at least one next action defined.
+     */
+    public function hasNextAction(Project $project): bool
+    {
+        return $this->getNextAction($project) !== null;
+    }
+
+    /**
+     * Count the number of next actions for a project.
+     */
+    public function countNextActions(Project $project): int
+    {
+        return count($this->taskRepository->findNextActionsByProject($project));
+    }
+
+    // =========================================================================
+    // Review Logic (FR-018)
+    // =========================================================================
+
+    /**
+     * Check if a project needs review.
+     * FR-018: System MUST flag projects without a defined next action.
+     *
+     * A project needs review if:
+     * - It has no next action defined, OR
+     * - Its review date has passed
+     */
+    public function needsReview(Project $project): bool
+    {
+        // No next action means project needs attention
+        if (!$this->hasNextAction($project)) {
+            return true;
+        }
+
+        // Check if review date has passed
+        $reviewDate = $project->getReviewDate();
+        if ($reviewDate !== null) {
+            $today = new \DateTimeImmutable('today');
+            if ($reviewDate <= $today) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get all active projects that need attention (no next action).
+     * FR-018: System MUST flag projects without a defined next action.
+     *
+     * @return Project[]
+     */
+    public function getProjectsNeedingAttention(User $user): array
+    {
+        return $this->projectRepository->findWithoutNextAction($user);
+    }
+
+    /**
+     * Get all projects due for review.
+     *
+     * @return Project[]
+     */
+    public function getProjectsDueForReview(User $user): array
+    {
+        return $this->projectRepository->findDueForReview($user);
+    }
+
+    // =========================================================================
+    // Task Statistics
+    // =========================================================================
+
+    /**
+     * Count all non-deleted tasks in a project.
+     */
+    public function countTasks(Project $project): int
+    {
+        return $this->taskRepository->countByProject($project);
+    }
+}

--- a/api/tests/Functional/Project/ProjectTest.php
+++ b/api/tests/Functional/Project/ProjectTest.php
@@ -1,0 +1,826 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Project;
+
+use App\Entity\Task;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Functional tests for Project CRUD endpoints (FR-017, FR-018, FR-019)
+ */
+class ProjectTest extends WebTestCase
+{
+    private $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+    }
+
+    // =========================================================================
+    // List Projects Tests
+    // =========================================================================
+
+    public function testListProjectsReturnsUserProjects(): void
+    {
+        $tokens = $this->authenticateUser('list-projects@example.com');
+
+        // Create a project
+        $this->createProject($tokens['access_token'], 'Test Project');
+
+        $this->client->request('GET', '/api/v1/projects', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertArrayHasKey('projects', $response);
+        $this->assertArrayHasKey('count', $response);
+        $this->assertIsArray($response['projects']);
+        $this->assertGreaterThanOrEqual(1, $response['count']);
+
+        $titles = array_column($response['projects'], 'title');
+        $this->assertContains('Test Project', $titles);
+    }
+
+    public function testListProjectsRequiresAuthentication(): void
+    {
+        $this->client->request('GET', '/api/v1/projects');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function testListProjectsExcludesOtherUsers(): void
+    {
+        // User 1 creates a project
+        $tokens1 = $this->authenticateUser('list-user1@example.com');
+        $this->createProject($tokens1['access_token'], 'User1 Project');
+
+        // User 2 should not see User 1's project
+        $tokens2 = $this->authenticateUser('list-user2@example.com');
+        $this->createProject($tokens2['access_token'], 'User2 Project');
+
+        $this->client->request('GET', '/api/v1/projects', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens2['access_token'],
+        ]);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $titles = array_column($response['projects'], 'title');
+
+        $this->assertContains('User2 Project', $titles);
+        $this->assertNotContains('User1 Project', $titles);
+    }
+
+    public function testListProjectsFilterByStatus(): void
+    {
+        $tokens = $this->authenticateUser('list-status@example.com');
+
+        // Create an active project
+        $this->createProject($tokens['access_token'], 'Active Project');
+
+        // Create and complete a project
+        $projectId = $this->createProject($tokens['access_token'], 'Completed Project');
+        $this->client->request('POST', '/api/v1/projects/' . $projectId . '/complete', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        // Filter by active only
+        $this->client->request('GET', '/api/v1/projects?status=active', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $titles = array_column($response['projects'], 'title');
+
+        $this->assertContains('Active Project', $titles);
+        $this->assertNotContains('Completed Project', $titles);
+    }
+
+    public function testListProjectsOrdersByPosition(): void
+    {
+        $tokens = $this->authenticateUser('list-order@example.com');
+
+        // Create projects (they should be ordered by position automatically)
+        $this->createProject($tokens['access_token'], 'First Project');
+        $this->createProject($tokens['access_token'], 'Second Project');
+        $this->createProject($tokens['access_token'], 'Third Project');
+
+        $this->client->request('GET', '/api/v1/projects', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $titles = array_column($response['projects'], 'title');
+
+        // First created should be first in list
+        $this->assertEquals('First Project', $titles[0]);
+        $this->assertEquals('Second Project', $titles[1]);
+        $this->assertEquals('Third Project', $titles[2]);
+    }
+
+    // =========================================================================
+    // Get Single Project Tests
+    // =========================================================================
+
+    public function testGetProjectById(): void
+    {
+        $tokens = $this->authenticateUser('get-project@example.com');
+        $projectId = $this->createProject($tokens['access_token'], 'Get Project');
+
+        $this->client->request('GET', '/api/v1/projects/' . $projectId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertArrayHasKey('project', $response);
+        $this->assertEquals('Get Project', $response['project']['title']);
+        $this->assertEquals('active', $response['project']['status']);
+    }
+
+    public function testGetProjectReturnsTasksList(): void
+    {
+        $tokens = $this->authenticateUser('get-tasks@example.com');
+        $projectId = $this->createProject($tokens['access_token'], 'Project With Tasks');
+
+        // Create a task assigned to this project
+        $this->createTaskForProject($tokens['access_token'], $projectId, 'Task 1');
+
+        $this->client->request('GET', '/api/v1/projects/' . $projectId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertArrayHasKey('tasks', $response['project']);
+        $this->assertCount(1, $response['project']['tasks']);
+        $this->assertEquals('Task 1', $response['project']['tasks'][0]['title']);
+    }
+
+    public function testGetProjectReturnsNextAction(): void
+    {
+        $tokens = $this->authenticateUser('get-nextaction@example.com');
+        $projectId = $this->createProject($tokens['access_token'], 'Project With Next Action');
+
+        // Create a next_action task
+        $taskId = $this->createTaskForProject($tokens['access_token'], $projectId, 'Next Action Task');
+        $this->updateTaskStatus($tokens['access_token'], $taskId, Task::STATUS_NEXT_ACTION);
+
+        $this->client->request('GET', '/api/v1/projects/' . $projectId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertArrayHasKey('next_action', $response['project']);
+        $this->assertEquals('Next Action Task', $response['project']['next_action']['title']);
+    }
+
+    public function testGetProjectNotFound(): void
+    {
+        $tokens = $this->authenticateUser('get-notfound@example.com');
+
+        // Use a valid UUID format that doesn't exist in the database
+        $this->client->request('GET', '/api/v1/projects/11111111-1111-4111-8111-111111111111', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('NOT_FOUND', $response['code']);
+    }
+
+    public function testCannotGetOtherUserProject(): void
+    {
+        // User 1 creates a project
+        $tokens1 = $this->authenticateUser('get-other1@example.com');
+        $projectId = $this->createProject($tokens1['access_token'], 'User1 Secret Project');
+
+        // User 2 tries to get it
+        $tokens2 = $this->authenticateUser('get-other2@example.com');
+
+        $this->client->request('GET', '/api/v1/projects/' . $projectId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens2['access_token'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    // =========================================================================
+    // Create Project Tests (FR-019)
+    // =========================================================================
+
+    public function testCreateProject(): void
+    {
+        $tokens = $this->authenticateUser('create-project@example.com');
+
+        $this->client->request('POST', '/api/v1/projects', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'title' => 'New Project',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertArrayHasKey('project', $response);
+        $this->assertEquals('New Project', $response['project']['title']);
+        $this->assertEquals('active', $response['project']['status']);
+        $this->assertNotNull($response['project']['id']);
+    }
+
+    public function testCreateProjectWithOutcome(): void
+    {
+        $tokens = $this->authenticateUser('create-outcome@example.com');
+
+        $this->client->request('POST', '/api/v1/projects', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'title' => 'Project With Outcome',
+            'outcome' => 'Successfully launch the new feature',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals('Successfully launch the new feature', $response['project']['outcome']);
+    }
+
+    public function testCreateProjectRequiresTitle(): void
+    {
+        $tokens = $this->authenticateUser('create-notitle@example.com');
+
+        $this->client->request('POST', '/api/v1/projects', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('MISSING_TITLE', $response['code']);
+    }
+
+    public function testCreateProjectRequiresAuthentication(): void
+    {
+        $this->client->request('POST', '/api/v1/projects', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'title' => 'Test Project',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function testCreateProjectSetsDefaultPosition(): void
+    {
+        $tokens = $this->authenticateUser('create-position@example.com');
+
+        // Create two projects
+        $this->createProject($tokens['access_token'], 'First');
+        $projectId = $this->createProject($tokens['access_token'], 'Second');
+
+        // Get the second project
+        $this->client->request('GET', '/api/v1/projects/' . $projectId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        // Second project should have position 2 (or higher)
+        $this->assertGreaterThan(0, $response['project']['position']);
+    }
+
+    // =========================================================================
+    // Update Project Tests (FR-019)
+    // =========================================================================
+
+    public function testUpdateProjectTitle(): void
+    {
+        $tokens = $this->authenticateUser('update-title@example.com');
+        $projectId = $this->createProject($tokens['access_token'], 'Old Title');
+
+        $this->client->request('PATCH', '/api/v1/projects/' . $projectId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'title' => 'New Title',
+        ]));
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('New Title', $response['project']['title']);
+    }
+
+    public function testUpdateProjectOutcome(): void
+    {
+        $tokens = $this->authenticateUser('update-outcome@example.com');
+        $projectId = $this->createProject($tokens['access_token'], 'Update Outcome');
+
+        $this->client->request('PATCH', '/api/v1/projects/' . $projectId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'outcome' => 'New expected outcome',
+        ]));
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('New expected outcome', $response['project']['outcome']);
+    }
+
+    public function testUpdateProjectPosition(): void
+    {
+        $tokens = $this->authenticateUser('update-position@example.com');
+        $projectId = $this->createProject($tokens['access_token'], 'Reposition');
+
+        $this->client->request('PATCH', '/api/v1/projects/' . $projectId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'position' => 99,
+        ]));
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals(99, $response['project']['position']);
+    }
+
+    public function testUpdateProjectReviewDate(): void
+    {
+        $tokens = $this->authenticateUser('update-review@example.com');
+        $projectId = $this->createProject($tokens['access_token'], 'Review Date');
+
+        $this->client->request('PATCH', '/api/v1/projects/' . $projectId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'review_date' => '2025-12-31',
+        ]));
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('2025-12-31', $response['project']['review_date']);
+    }
+
+    public function testCannotUpdateOtherUserProject(): void
+    {
+        // User 1 creates a project
+        $tokens1 = $this->authenticateUser('update-other1@example.com');
+        $projectId = $this->createProject($tokens1['access_token'], 'User1 Project');
+
+        // User 2 tries to update it
+        $tokens2 = $this->authenticateUser('update-other2@example.com');
+
+        $this->client->request('PATCH', '/api/v1/projects/' . $projectId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens2['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'title' => 'Hacked',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    // =========================================================================
+    // Delete Project Tests
+    // =========================================================================
+
+    public function testDeleteProjectSoftDeletes(): void
+    {
+        $tokens = $this->authenticateUser('delete-project@example.com');
+        $projectId = $this->createProject($tokens['access_token'], 'To Delete');
+
+        $this->client->request('DELETE', '/api/v1/projects/' . $projectId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertStringContainsString('deleted', strtolower($response['message']));
+
+        // Verify project is no longer in default (active) list
+        $this->client->request('GET', '/api/v1/projects?status=active', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $listResponse = json_decode($this->client->getResponse()->getContent(), true);
+        $titles = array_column($listResponse['projects'], 'title');
+        $this->assertNotContains('To Delete', $titles);
+
+        // But project still exists with cancelled status
+        $this->client->request('GET', '/api/v1/projects?status=cancelled', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $cancelledResponse = json_decode($this->client->getResponse()->getContent(), true);
+        $cancelledTitles = array_column($cancelledResponse['projects'], 'title');
+        $this->assertContains('To Delete', $cancelledTitles);
+    }
+
+    public function testCannotDeleteOtherUserProject(): void
+    {
+        // User 1 creates a project
+        $tokens1 = $this->authenticateUser('delete-other1@example.com');
+        $projectId = $this->createProject($tokens1['access_token'], 'User1 Project');
+
+        // User 2 tries to delete it
+        $tokens2 = $this->authenticateUser('delete-other2@example.com');
+
+        $this->client->request('DELETE', '/api/v1/projects/' . $projectId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens2['access_token'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    // =========================================================================
+    // Status Transition Tests
+    // =========================================================================
+
+    public function testCompleteProject(): void
+    {
+        $tokens = $this->authenticateUser('complete-project@example.com');
+        $projectId = $this->createProject($tokens['access_token'], 'To Complete');
+
+        $this->client->request('POST', '/api/v1/projects/' . $projectId . '/complete', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('completed', $response['project']['status']);
+        $this->assertNotNull($response['project']['completed_at']);
+    }
+
+    public function testPutProjectOnHold(): void
+    {
+        $tokens = $this->authenticateUser('hold-project@example.com');
+        $projectId = $this->createProject($tokens['access_token'], 'To Hold');
+
+        $this->client->request('POST', '/api/v1/projects/' . $projectId . '/hold', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('on_hold', $response['project']['status']);
+    }
+
+    public function testActivateProjectFromHold(): void
+    {
+        $tokens = $this->authenticateUser('activate-project@example.com');
+        $projectId = $this->createProject($tokens['access_token'], 'To Activate');
+
+        // Put on hold first
+        $this->client->request('POST', '/api/v1/projects/' . $projectId . '/hold', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        // Now activate
+        $this->client->request('POST', '/api/v1/projects/' . $projectId . '/activate', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('active', $response['project']['status']);
+    }
+
+    public function testCompletingAlreadyCompletedProjectIsIdempotent(): void
+    {
+        $tokens = $this->authenticateUser('complete-twice@example.com');
+        $projectId = $this->createProject($tokens['access_token'], 'Complete Twice');
+
+        // Complete once
+        $this->client->request('POST', '/api/v1/projects/' . $projectId . '/complete', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        // Complete again - should be idempotent (same status transition is allowed)
+        $this->client->request('POST', '/api/v1/projects/' . $projectId . '/complete', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        // Should still succeed (no-op but returns 200)
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('completed', $response['project']['status']);
+    }
+
+    public function testCannotPutCompletedProjectOnHold(): void
+    {
+        $tokens = $this->authenticateUser('complete-hold@example.com');
+        $projectId = $this->createProject($tokens['access_token'], 'Complete Then Hold');
+
+        // Complete the project
+        $this->client->request('POST', '/api/v1/projects/' . $projectId . '/complete', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        // Try to put on hold - should fail
+        $this->client->request('POST', '/api/v1/projects/' . $projectId . '/hold', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals('INVALID_TRANSITION', $response['code']);
+    }
+
+    // =========================================================================
+    // GTD-Specific Tests (FR-017, FR-018)
+    // =========================================================================
+
+    public function testGetProjectsNeedingAttention(): void
+    {
+        // Use unique email to avoid leftover data from previous test runs
+        $uniqueId = uniqid();
+        $tokens = $this->authenticateUser("attention-{$uniqueId}@example.com");
+
+        $needsAttentionTitle = "Needs Attention {$uniqueId}";
+        $hasNextActionTitle = "Has Next Action {$uniqueId}";
+
+        // Create project without next action
+        $this->createProject($tokens['access_token'], $needsAttentionTitle);
+
+        // Create project with next action
+        $projectWithAction = $this->createProject($tokens['access_token'], $hasNextActionTitle);
+        $taskId = $this->createTaskForProject($tokens['access_token'], $projectWithAction, 'NA Task');
+        $this->updateTaskStatus($tokens['access_token'], $taskId, Task::STATUS_NEXT_ACTION);
+
+        $this->client->request('GET', '/api/v1/projects/needing-attention', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $titles = array_column($response['projects'], 'title');
+
+        $this->assertContains($needsAttentionTitle, $titles);
+        $this->assertNotContains($hasNextActionTitle, $titles);
+    }
+
+    public function testGetProjectsDueForReview(): void
+    {
+        $tokens = $this->authenticateUser('review-due@example.com');
+
+        // Create project due for review (past date)
+        $projectId = $this->createProject($tokens['access_token'], 'Due For Review');
+        $this->client->request('PATCH', '/api/v1/projects/' . $projectId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'review_date' => (new \DateTimeImmutable('-1 day'))->format('Y-m-d'),
+        ]));
+
+        // Create project with future review date
+        $futureProjectId = $this->createProject($tokens['access_token'], 'Future Review');
+        $this->client->request('PATCH', '/api/v1/projects/' . $futureProjectId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'review_date' => (new \DateTimeImmutable('+7 days'))->format('Y-m-d'),
+        ]));
+
+        $this->client->request('GET', '/api/v1/projects/due-for-review', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $titles = array_column($response['projects'], 'title');
+
+        $this->assertContains('Due For Review', $titles);
+        $this->assertNotContains('Future Review', $titles);
+    }
+
+    public function testProjectWithNextActionNotInNeedingAttention(): void
+    {
+        // Use unique email to avoid leftover data from previous test runs
+        $uniqueId = uniqid();
+        $tokens = $this->authenticateUser("not-needing-{$uniqueId}@example.com");
+
+        $projectWithAction = "Has Action {$uniqueId}";
+        $projectId = $this->createProject($tokens['access_token'], $projectWithAction);
+
+        // Add a next action
+        $taskId = $this->createTaskForProject($tokens['access_token'], $projectId, 'The Next Action');
+        $this->updateTaskStatus($tokens['access_token'], $taskId, Task::STATUS_NEXT_ACTION);
+
+        $this->client->request('GET', '/api/v1/projects/needing-attention', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $titles = array_column($response['projects'], 'title');
+
+        $this->assertNotContains($projectWithAction, $titles);
+    }
+
+    // =========================================================================
+    // Additional Tests
+    // =========================================================================
+
+    public function testUpdateProjectRequiresAuthentication(): void
+    {
+        $this->client->request('PATCH', '/api/v1/projects/00000000-0000-0000-0000-000000000001', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'title' => 'Test',
+        ]));
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function testDeleteProjectRequiresAuthentication(): void
+    {
+        $this->client->request('DELETE', '/api/v1/projects/00000000-0000-0000-0000-000000000001');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function testGetProjectRequiresAuthentication(): void
+    {
+        $this->client->request('GET', '/api/v1/projects/00000000-0000-0000-0000-000000000001');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function testInvalidUuidReturnsError(): void
+    {
+        $tokens = $this->authenticateUser('invalid-uuid@example.com');
+
+        // Invalid UUID format - doesn't match the route pattern, so returns 404
+        $this->client->request('GET', '/api/v1/projects/invalid-uuid', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testProjectListIncludesHasNextActionFlag(): void
+    {
+        // Use unique email to avoid leftover data from previous test runs
+        $uniqueId = uniqid();
+        $tokens = $this->authenticateUser("list-hasnextaction-{$uniqueId}@example.com");
+
+        $withNATitle = "With NA {$uniqueId}";
+        $withoutNATitle = "Without NA {$uniqueId}";
+
+        // Create project with next action
+        $projectId = $this->createProject($tokens['access_token'], $withNATitle);
+        $taskId = $this->createTaskForProject($tokens['access_token'], $projectId, 'Next');
+        $this->updateTaskStatus($tokens['access_token'], $taskId, Task::STATUS_NEXT_ACTION);
+
+        // Create project without
+        $this->createProject($tokens['access_token'], $withoutNATitle);
+
+        $this->client->request('GET', '/api/v1/projects', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $tokens['access_token'],
+        ]);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        foreach ($response['projects'] as $project) {
+            $this->assertArrayHasKey('has_next_action', $project);
+            if ($project['title'] === $withNATitle) {
+                $this->assertTrue($project['has_next_action']);
+            }
+            if ($project['title'] === $withoutNATitle) {
+                $this->assertFalse($project['has_next_action']);
+            }
+        }
+    }
+
+    // =========================================================================
+    // Helper Methods
+    // =========================================================================
+
+    private function authenticateUser(string $email = 'test@example.com'): array
+    {
+        $password = 'Password123!';
+
+        // Register user
+        $this->client->request('POST', '/api/v1/auth/register', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'email' => $email,
+            'password' => $password,
+        ]));
+
+        // Verify user
+        $container = static::getContainer();
+        $userRepository = $container->get('App\Repository\UserRepository');
+        $user = $userRepository->findByEmail($email);
+
+        if ($user && $user->getVerificationToken()) {
+            $this->client->request('POST', '/api/v1/auth/verify-email', [], [], [
+                'CONTENT_TYPE' => 'application/json',
+            ], json_encode([
+                'token' => $user->getVerificationToken(),
+            ]));
+        }
+
+        // Login
+        $this->client->request('POST', '/api/v1/auth/login', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'email' => $email,
+            'password' => $password,
+        ]));
+
+        return json_decode($this->client->getResponse()->getContent(), true);
+    }
+
+    private function createProject(string $accessToken, string $title): string
+    {
+        $this->client->request('POST', '/api/v1/projects', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $accessToken,
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'title' => $title,
+        ]));
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        if (!isset($response['project']['id'])) {
+            throw new \RuntimeException(sprintf(
+                'Failed to create project "%s": %s',
+                $title,
+                json_encode($response)
+            ));
+        }
+
+        return $response['project']['id'];
+    }
+
+    private function createTaskForProject(string $accessToken, string $projectId, string $title): string
+    {
+        // Create task first
+        $this->client->request('POST', '/api/v1/tasks', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $accessToken,
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'title' => $title,
+        ]));
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        if (!isset($response['task']['id'])) {
+            throw new \RuntimeException(sprintf(
+                'Failed to create task "%s": %s',
+                $title,
+                json_encode($response)
+            ));
+        }
+
+        $taskId = $response['task']['id'];
+
+        // Assign to project
+        $this->client->request('PATCH', '/api/v1/tasks/' . $taskId, [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $accessToken,
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'project_id' => $projectId,
+        ]));
+
+        return $taskId;
+    }
+
+    private function updateTaskStatus(string $accessToken, string $taskId, string $status): void
+    {
+        $this->client->request('PATCH', '/api/v1/tasks/' . $taskId . '/clarify', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $accessToken,
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            'target_status' => $status,
+        ]));
+    }
+}

--- a/api/tests/Unit/Service/ProjectServiceTest.php
+++ b/api/tests/Unit/Service/ProjectServiceTest.php
@@ -1,0 +1,493 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\Project;
+use App\Entity\Task;
+use App\Entity\User;
+use App\Repository\ProjectRepository;
+use App\Repository\TaskRepository;
+use App\Service\ProjectService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+class ProjectServiceTest extends TestCase
+{
+    private ProjectService $projectService;
+    private ProjectRepository&MockObject $projectRepository;
+    private TaskRepository&MockObject $taskRepository;
+
+    protected function setUp(): void
+    {
+        $this->projectRepository = $this->createMock(ProjectRepository::class);
+        $this->taskRepository = $this->createMock(TaskRepository::class);
+        $this->projectService = new ProjectService($this->projectRepository, $this->taskRepository);
+    }
+
+    private function createUser(): User
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(Uuid::v4());
+
+        return $user;
+    }
+
+    private function createProject(string $status = Project::STATUS_ACTIVE): Project
+    {
+        $user = $this->createUser();
+        $project = new Project();
+        $project->setTitle('Test Project');
+        $project->setUser($user);
+
+        // Use reflection to set status directly
+        if ($status !== Project::STATUS_ACTIVE) {
+            $reflection = new \ReflectionClass($project);
+            $property = $reflection->getProperty('status');
+            $property->setAccessible(true);
+            $property->setValue($project, $status);
+        }
+
+        return $project;
+    }
+
+    private function createTask(string $status = Task::STATUS_INBOX, int $position = 0): Task
+    {
+        $user = $this->createMock(User::class);
+        $task = new Task();
+        $task->setUser($user);
+        $task->setTitle('Test Task');
+        $task->setPosition($position);
+
+        // Use reflection to set status directly
+        $reflection = new \ReflectionClass($task);
+        $property = $reflection->getProperty('status');
+        $property->setAccessible(true);
+        $property->setValue($task, $status);
+
+        return $task;
+    }
+
+    // =========================================================================
+    // Status Transition Validation Tests
+    // =========================================================================
+
+    public function testIsValidTransitionFromActive(): void
+    {
+        // Valid transitions from active
+        $this->assertTrue($this->projectService->isValidTransition(Project::STATUS_ACTIVE, Project::STATUS_ON_HOLD));
+        $this->assertTrue($this->projectService->isValidTransition(Project::STATUS_ACTIVE, Project::STATUS_COMPLETED));
+        $this->assertTrue($this->projectService->isValidTransition(Project::STATUS_ACTIVE, Project::STATUS_CANCELLED));
+
+        // Same status is always valid
+        $this->assertTrue($this->projectService->isValidTransition(Project::STATUS_ACTIVE, Project::STATUS_ACTIVE));
+    }
+
+    public function testIsValidTransitionFromOnHold(): void
+    {
+        $this->assertTrue($this->projectService->isValidTransition(Project::STATUS_ON_HOLD, Project::STATUS_ACTIVE));
+        $this->assertTrue($this->projectService->isValidTransition(Project::STATUS_ON_HOLD, Project::STATUS_CANCELLED));
+
+        // Cannot complete directly from on_hold
+        $this->assertFalse($this->projectService->isValidTransition(Project::STATUS_ON_HOLD, Project::STATUS_COMPLETED));
+    }
+
+    public function testIsValidTransitionFromCompleted(): void
+    {
+        // Can reopen a completed project
+        $this->assertTrue($this->projectService->isValidTransition(Project::STATUS_COMPLETED, Project::STATUS_ACTIVE));
+
+        // Cannot transition to other statuses
+        $this->assertFalse($this->projectService->isValidTransition(Project::STATUS_COMPLETED, Project::STATUS_ON_HOLD));
+        $this->assertFalse($this->projectService->isValidTransition(Project::STATUS_COMPLETED, Project::STATUS_CANCELLED));
+    }
+
+    public function testIsValidTransitionFromCancelled(): void
+    {
+        // Can reopen a cancelled project
+        $this->assertTrue($this->projectService->isValidTransition(Project::STATUS_CANCELLED, Project::STATUS_ACTIVE));
+
+        // Cannot transition to other statuses
+        $this->assertFalse($this->projectService->isValidTransition(Project::STATUS_CANCELLED, Project::STATUS_ON_HOLD));
+        $this->assertFalse($this->projectService->isValidTransition(Project::STATUS_CANCELLED, Project::STATUS_COMPLETED));
+    }
+
+    public function testSameStatusTransitionIsValid(): void
+    {
+        foreach (Project::STATUSES as $status) {
+            $this->assertTrue(
+                $this->projectService->isValidTransition($status, $status),
+                "Transition from $status to itself should be valid"
+            );
+        }
+    }
+
+    public function testGetAllowedTransitionsFromActive(): void
+    {
+        $allowed = $this->projectService->getAllowedTransitions(Project::STATUS_ACTIVE);
+
+        $this->assertContains(Project::STATUS_ON_HOLD, $allowed);
+        $this->assertContains(Project::STATUS_COMPLETED, $allowed);
+        $this->assertContains(Project::STATUS_CANCELLED, $allowed);
+    }
+
+    public function testGetAllowedTransitionsFromUnknownStatus(): void
+    {
+        $allowed = $this->projectService->getAllowedTransitions('unknown_status');
+
+        $this->assertEmpty($allowed);
+    }
+
+    // =========================================================================
+    // Create Project Tests
+    // =========================================================================
+
+    public function testCreateProject(): void
+    {
+        $user = $this->createUser();
+
+        $this->projectRepository->expects($this->once())
+            ->method('getMaxPositionByUser')
+            ->with($user)
+            ->willReturn(5);
+
+        $this->projectRepository->expects($this->once())
+            ->method('save');
+
+        $project = $this->projectService->create($user, 'New Project');
+
+        $this->assertSame('New Project', $project->getTitle());
+        $this->assertSame(Project::STATUS_ACTIVE, $project->getStatus());
+        $this->assertSame(6, $project->getPosition());
+        $this->assertNull($project->getOutcome());
+    }
+
+    public function testCreateProjectWithOutcome(): void
+    {
+        $user = $this->createUser();
+
+        $this->projectRepository->expects($this->once())
+            ->method('getMaxPositionByUser')
+            ->with($user)
+            ->willReturn(0);
+
+        $this->projectRepository->expects($this->once())
+            ->method('save');
+
+        $project = $this->projectService->create($user, 'Project with Outcome', 'Complete the feature');
+
+        $this->assertSame('Project with Outcome', $project->getTitle());
+        $this->assertSame('Complete the feature', $project->getOutcome());
+    }
+
+    // =========================================================================
+    // Update Status Tests
+    // =========================================================================
+
+    public function testUpdateStatus(): void
+    {
+        $project = $this->createProject(Project::STATUS_ACTIVE);
+
+        $this->projectRepository->expects($this->once())
+            ->method('save')
+            ->with($project);
+
+        $result = $this->projectService->updateStatus($project, Project::STATUS_ON_HOLD);
+
+        $this->assertSame(Project::STATUS_ON_HOLD, $result->getStatus());
+    }
+
+    public function testUpdateStatusThrowsOnInvalidTransition(): void
+    {
+        $project = $this->createProject(Project::STATUS_COMPLETED);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid status transition');
+
+        $this->projectService->updateStatus($project, Project::STATUS_ON_HOLD);
+    }
+
+    public function testCompleteProject(): void
+    {
+        $project = $this->createProject(Project::STATUS_ACTIVE);
+
+        $this->projectRepository->expects($this->once())
+            ->method('save')
+            ->with($project);
+
+        $result = $this->projectService->complete($project);
+
+        $this->assertSame(Project::STATUS_COMPLETED, $result->getStatus());
+        $this->assertNotNull($result->getCompletedAt());
+    }
+
+    public function testPutProjectOnHold(): void
+    {
+        $project = $this->createProject(Project::STATUS_ACTIVE);
+
+        $this->projectRepository->expects($this->once())
+            ->method('save')
+            ->with($project);
+
+        $result = $this->projectService->putOnHold($project);
+
+        $this->assertSame(Project::STATUS_ON_HOLD, $result->getStatus());
+    }
+
+    public function testActivateProject(): void
+    {
+        $project = $this->createProject(Project::STATUS_ON_HOLD);
+
+        $this->projectRepository->expects($this->once())
+            ->method('save')
+            ->with($project);
+
+        $result = $this->projectService->activate($project);
+
+        $this->assertSame(Project::STATUS_ACTIVE, $result->getStatus());
+    }
+
+    public function testCancelProject(): void
+    {
+        $project = $this->createProject(Project::STATUS_ACTIVE);
+
+        $this->projectRepository->expects($this->once())
+            ->method('save')
+            ->with($project);
+
+        $result = $this->projectService->cancel($project);
+
+        $this->assertSame(Project::STATUS_CANCELLED, $result->getStatus());
+    }
+
+    // =========================================================================
+    // Next Action Tests (FR-017)
+    // =========================================================================
+
+    public function testGetNextActionReturnsFirstNextActionTask(): void
+    {
+        $project = $this->createProject();
+        $task1 = $this->createTask(Task::STATUS_NEXT_ACTION, 0);
+        $task2 = $this->createTask(Task::STATUS_NEXT_ACTION, 1);
+
+        $this->taskRepository->expects($this->once())
+            ->method('findNextActionsByProject')
+            ->with($project)
+            ->willReturn([$task1, $task2]);
+
+        $result = $this->projectService->getNextAction($project);
+
+        $this->assertSame($task1, $result);
+    }
+
+    public function testGetNextActionReturnsNullWhenNoNextActionTasks(): void
+    {
+        $project = $this->createProject();
+
+        $this->taskRepository->expects($this->once())
+            ->method('findNextActionsByProject')
+            ->with($project)
+            ->willReturn([]);
+
+        $result = $this->projectService->getNextAction($project);
+
+        $this->assertNull($result);
+    }
+
+    public function testHasNextActionReturnsTrueWhenNextActionExists(): void
+    {
+        $project = $this->createProject();
+        $task = $this->createTask(Task::STATUS_NEXT_ACTION);
+
+        $this->taskRepository->expects($this->once())
+            ->method('findNextActionsByProject')
+            ->with($project)
+            ->willReturn([$task]);
+
+        $this->assertTrue($this->projectService->hasNextAction($project));
+    }
+
+    public function testHasNextActionReturnsFalseWhenNoNextAction(): void
+    {
+        $project = $this->createProject();
+
+        $this->taskRepository->expects($this->once())
+            ->method('findNextActionsByProject')
+            ->with($project)
+            ->willReturn([]);
+
+        $this->assertFalse($this->projectService->hasNextAction($project));
+    }
+
+    public function testCountNextActions(): void
+    {
+        $project = $this->createProject();
+        $task1 = $this->createTask(Task::STATUS_NEXT_ACTION, 0);
+        $task2 = $this->createTask(Task::STATUS_NEXT_ACTION, 1);
+
+        $this->taskRepository->expects($this->once())
+            ->method('findNextActionsByProject')
+            ->with($project)
+            ->willReturn([$task1, $task2]);
+
+        $this->assertSame(2, $this->projectService->countNextActions($project));
+    }
+
+    // =========================================================================
+    // Review Tests (FR-018)
+    // =========================================================================
+
+    public function testNeedsReviewWhenNoNextAction(): void
+    {
+        $project = $this->createProject();
+
+        $this->taskRepository->expects($this->once())
+            ->method('findNextActionsByProject')
+            ->with($project)
+            ->willReturn([]);
+
+        $this->assertTrue($this->projectService->needsReview($project));
+    }
+
+    public function testNeedsReviewWhenReviewDatePassed(): void
+    {
+        $project = $this->createProject();
+        $project->setReviewDate(new \DateTimeImmutable('-1 day'));
+        $task = $this->createTask(Task::STATUS_NEXT_ACTION);
+
+        $this->taskRepository->expects($this->once())
+            ->method('findNextActionsByProject')
+            ->with($project)
+            ->willReturn([$task]);
+
+        $this->assertTrue($this->projectService->needsReview($project));
+    }
+
+    public function testDoesNotNeedReviewWhenHasNextActionAndFutureReviewDate(): void
+    {
+        $project = $this->createProject();
+        $project->setReviewDate(new \DateTimeImmutable('+7 days'));
+        $task = $this->createTask(Task::STATUS_NEXT_ACTION);
+
+        $this->taskRepository->expects($this->once())
+            ->method('findNextActionsByProject')
+            ->with($project)
+            ->willReturn([$task]);
+
+        $this->assertFalse($this->projectService->needsReview($project));
+    }
+
+    public function testDoesNotNeedReviewWhenHasNextActionAndNoReviewDate(): void
+    {
+        $project = $this->createProject();
+        $task = $this->createTask(Task::STATUS_NEXT_ACTION);
+
+        $this->taskRepository->expects($this->once())
+            ->method('findNextActionsByProject')
+            ->with($project)
+            ->willReturn([$task]);
+
+        $this->assertFalse($this->projectService->needsReview($project));
+    }
+
+    public function testGetProjectsNeedingAttention(): void
+    {
+        $user = $this->createUser();
+        $project1 = $this->createProject();
+        $project2 = $this->createProject();
+
+        $this->projectRepository->expects($this->once())
+            ->method('findWithoutNextAction')
+            ->with($user)
+            ->willReturn([$project1, $project2]);
+
+        $result = $this->projectService->getProjectsNeedingAttention($user);
+
+        $this->assertCount(2, $result);
+        $this->assertContains($project1, $result);
+        $this->assertContains($project2, $result);
+    }
+
+    public function testGetProjectsDueForReview(): void
+    {
+        $user = $this->createUser();
+        $project = $this->createProject();
+        $project->setReviewDate(new \DateTimeImmutable('-1 day'));
+
+        $this->projectRepository->expects($this->once())
+            ->method('findDueForReview')
+            ->with($user)
+            ->willReturn([$project]);
+
+        $result = $this->projectService->getProjectsDueForReview($user);
+
+        $this->assertCount(1, $result);
+        $this->assertSame($project, $result[0]);
+    }
+
+    // =========================================================================
+    // Task Count Tests
+    // =========================================================================
+
+    public function testCountTasksByProject(): void
+    {
+        $project = $this->createProject();
+
+        $this->taskRepository->expects($this->once())
+            ->method('countByProject')
+            ->with($project)
+            ->willReturn(5);
+
+        $this->assertSame(5, $this->projectService->countTasks($project));
+    }
+
+    // =========================================================================
+    // Edge Cases
+    // =========================================================================
+
+    public function testActivateCompletedProject(): void
+    {
+        $project = $this->createProject(Project::STATUS_COMPLETED);
+
+        $this->projectRepository->expects($this->once())
+            ->method('save')
+            ->with($project);
+
+        $result = $this->projectService->activate($project);
+
+        $this->assertSame(Project::STATUS_ACTIVE, $result->getStatus());
+    }
+
+    public function testActivateCancelledProject(): void
+    {
+        $project = $this->createProject(Project::STATUS_CANCELLED);
+
+        $this->projectRepository->expects($this->once())
+            ->method('save')
+            ->with($project);
+
+        $result = $this->projectService->activate($project);
+
+        $this->assertSame(Project::STATUS_ACTIVE, $result->getStatus());
+    }
+
+    public function testCannotCompleteOnHoldProject(): void
+    {
+        $project = $this->createProject(Project::STATUS_ON_HOLD);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->projectService->complete($project);
+    }
+
+    public function testCannotPutCompletedProjectOnHold(): void
+    {
+        $project = $this->createProject(Project::STATUS_COMPLETED);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->projectService->putOnHold($project);
+    }
+}

--- a/docs/implementation/phase-5-2.md
+++ b/docs/implementation/phase-5-2.md
@@ -1,0 +1,318 @@
+# Phase 5.2: Backend - Project Endpoints
+
+**Feature**: 001-gtd-todo-app
+**Phase**: 5.2 Backend - Project Endpoints
+**Date**: 2025-12-03
+**Status**: Implementation
+
+## Overview
+
+This phase implements the backend service layer and REST API endpoints for Project management, following GTD methodology requirements (FR-017, FR-018, FR-019).
+
+## Tasks
+
+| Task ID | Description | File |
+|---------|-------------|------|
+| P5-005 | Create ProjectService with next action logic | `api/src/Service/ProjectService.php` |
+| P5-006 | Write unit tests for next action computation | `api/tests/Unit/Service/ProjectServiceTest.php` |
+| P5-007 | Create ProjectController with CRUD endpoints | `api/src/Controller/ProjectController.php` |
+| P5-008 | Write functional tests for project endpoints | `api/tests/Functional/Project/ProjectTest.php` |
+
+## Requirements Addressed
+
+- **FR-017**: System MUST automatically identify the next action of a project
+- **FR-018**: System MUST flag projects without a defined next action
+- **FR-019**: System MUST allow defining an expected outcome for each project
+
+## Implementation Plan
+
+### 1. ProjectService (P5-005)
+
+**File**: `api/src/Service/ProjectService.php`
+
+The service will handle business logic for projects, following the pattern established by `TaskService.php`.
+
+**Methods**:
+```php
+class ProjectService
+{
+    // Status transitions (similar to TaskService)
+    private const STATUS_TRANSITIONS = [
+        Project::STATUS_ACTIVE => [
+            Project::STATUS_ON_HOLD,
+            Project::STATUS_COMPLETED,
+            Project::STATUS_CANCELLED,
+        ],
+        Project::STATUS_ON_HOLD => [
+            Project::STATUS_ACTIVE,
+            Project::STATUS_CANCELLED,
+        ],
+        Project::STATUS_COMPLETED => [
+            Project::STATUS_ACTIVE, // Can reopen
+        ],
+        Project::STATUS_CANCELLED => [
+            Project::STATUS_ACTIVE, // Can reopen
+        ],
+    ];
+
+    // Transition validation
+    public function isValidTransition(string $from, string $to): bool;
+    public function getAllowedTransitions(string $from): array;
+
+    // Project operations
+    public function create(User $user, string $title, ?string $outcome = null): Project;
+    public function updateStatus(Project $project, string $status): Project;
+    public function complete(Project $project): Project;
+    public function putOnHold(Project $project): Project;
+    public function activate(Project $project): Project;
+    public function cancel(Project $project): Project;
+
+    // Next Action Logic (FR-017)
+    public function getNextAction(Project $project): ?Task;
+    public function hasNextAction(Project $project): bool;
+
+    // Review Logic (FR-018)
+    public function needsReview(Project $project): bool;
+    public function getProjectsNeedingAttention(User $user): array;
+}
+```
+
+**Next Action Logic (FR-017)**:
+- A project's "next action" is the first task with `status = 'next_action'` ordered by position
+- When a next action is completed, the system should not auto-promote another task (user decides what's next)
+- The `getNextAction()` method queries tasks where `project_id = ?` AND `status = 'next_action'` ORDER BY `position ASC` LIMIT 1
+
+**Projects Needing Attention (FR-018)**:
+- Active projects without any `next_action` task need attention
+- Uses `ProjectRepository::findWithoutNextAction()` already implemented in Phase 5.1
+
+### 2. ProjectServiceTest (P5-006)
+
+**File**: `api/tests/Unit/Service/ProjectServiceTest.php`
+
+**Test Cases**:
+```php
+// Status transition tests
+testValidStatusTransitions()
+testInvalidStatusTransitions()
+testTransitionFromActiveToOnHold()
+testTransitionFromActiveToCompleted()
+testTransitionFromCompletedToActive()
+
+// Project creation tests
+testCreateProject()
+testCreateProjectWithOutcome()
+testCreateProjectSetsInitialPosition()
+
+// Status update tests
+testCompleteProject()
+testPutProjectOnHold()
+testActivateProject()
+testCancelProject()
+
+// Next action tests (FR-017)
+testGetNextActionReturnsFirstNextActionTask()
+testGetNextActionReturnsNullWhenNoNextActionTasks()
+testGetNextActionIgnoresCompletedTasks()
+testGetNextActionRespectsPositionOrder()
+testHasNextActionReturnsTrueWhenNextActionExists()
+testHasNextActionReturnsFalseWhenNoNextAction()
+
+// Review tests (FR-018)
+testNeedsReviewWhenNoNextAction()
+testNeedsReviewWhenReviewDatePassed()
+testDoesNotNeedReviewWhenHasNextAction()
+testGetProjectsNeedingAttention()
+```
+
+### 3. ProjectController (P5-007)
+
+**File**: `api/src/Controller/ProjectController.php`
+
+Following the pattern from `ContextController.php`:
+
+**Endpoints**:
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/projects` | List all projects for user |
+| GET | `/api/v1/projects/{id}` | Get single project with tasks |
+| POST | `/api/v1/projects` | Create new project |
+| PATCH | `/api/v1/projects/{id}` | Update project |
+| DELETE | `/api/v1/projects/{id}` | Delete (soft) project |
+| POST | `/api/v1/projects/{id}/complete` | Mark project as completed |
+| POST | `/api/v1/projects/{id}/hold` | Put project on hold |
+| POST | `/api/v1/projects/{id}/activate` | Activate project |
+| GET | `/api/v1/projects/needing-attention` | Get projects without next action (FR-018) |
+| GET | `/api/v1/projects/due-for-review` | Get projects due for review |
+
+**Request/Response Formats**:
+
+**List Projects (GET /api/v1/projects)**:
+Query params: `?status=active` (optional filter)
+```json
+{
+  "projects": [
+    {
+      "id": "uuid",
+      "title": "Project Title",
+      "outcome": "Expected outcome",
+      "status": "active",
+      "position": 0,
+      "review_date": "2025-12-10",
+      "version": 1,
+      "created_at": "2025-12-03T10:00:00+00:00",
+      "updated_at": "2025-12-03T10:00:00+00:00",
+      "completed_at": null,
+      "task_count": 5,
+      "next_action_count": 2,
+      "has_next_action": true
+    }
+  ],
+  "count": 1
+}
+```
+
+**Get Project (GET /api/v1/projects/{id})**:
+```json
+{
+  "project": {
+    "id": "uuid",
+    "title": "Project Title",
+    "outcome": "Expected outcome",
+    "status": "active",
+    "position": 0,
+    "review_date": "2025-12-10",
+    "version": 1,
+    "created_at": "...",
+    "updated_at": "...",
+    "completed_at": null,
+    "next_action": {
+      "id": "task-uuid",
+      "title": "Next task to do"
+    },
+    "tasks": [
+      { "id": "...", "title": "...", "status": "next_action" },
+      { "id": "...", "title": "...", "status": "waiting_for" }
+    ]
+  }
+}
+```
+
+**Create Project (POST /api/v1/projects)**:
+```json
+{
+  "title": "New Project",
+  "outcome": "What success looks like (FR-019)"
+}
+```
+
+**Update Project (PATCH /api/v1/projects/{id})**:
+```json
+{
+  "title": "Updated Title",
+  "outcome": "Updated outcome",
+  "position": 2,
+  "review_date": "2025-12-15"
+}
+```
+
+**Error Codes**:
+- `NOT_AUTHENTICATED` (401): Missing or invalid token
+- `NOT_FOUND` (404): Project not found or not owned by user
+- `VALIDATION_ERROR` (400): Invalid input data
+- `INVALID_TRANSITION` (400): Invalid status transition
+- `MISSING_TITLE` (400): Title is required
+
+### 4. ProjectTest (P5-008)
+
+**File**: `api/tests/Functional/Project/ProjectTest.php`
+
+Following the pattern from `ContextTest.php`:
+
+**Test Cases**:
+```php
+// List tests
+testListProjectsReturnsUserProjects()
+testListProjectsRequiresAuthentication()
+testListProjectsExcludesOtherUsers()
+testListProjectsFilterByStatus()
+testListProjectsOrdersByPosition()
+
+// Get single project tests
+testGetProjectById()
+testGetProjectReturnsTasksList()
+testGetProjectReturnsNextAction()
+testGetProjectNotFound()
+testCannotGetOtherUserProject()
+
+// Create tests
+testCreateProject()
+testCreateProjectWithOutcome()
+testCreateProjectRequiresTitle()
+testCreateProjectRequiresAuthentication()
+testCreateProjectSetsDefaultPosition()
+
+// Update tests
+testUpdateProjectTitle()
+testUpdateProjectOutcome()
+testUpdateProjectPosition()
+testUpdateProjectReviewDate()
+testCannotUpdateOtherUserProject()
+
+// Delete tests
+testDeleteProjectSoftDeletes()
+testCannotDeleteOtherUserProject()
+
+// Status transition tests
+testCompleteProject()
+testPutProjectOnHold()
+testActivateProjectFromHold()
+testCannotCompleteAlreadyCompletedProject()
+
+// GTD-specific tests (FR-017, FR-018)
+testGetProjectsNeedingAttention()
+testGetProjectsDueForReview()
+testProjectWithNextActionNotInNeedingAttention()
+```
+
+## Implementation Order (TDD)
+
+1. **P5-006**: Write unit tests for ProjectService (RED)
+2. **P5-005**: Implement ProjectService to pass tests (GREEN)
+3. **P5-008**: Write functional tests for ProjectController (RED)
+4. **P5-007**: Implement ProjectController to pass tests (GREEN)
+5. Run full test suite
+6. Check code coverage
+
+## Dependencies
+
+- Phase 5.1 completed (Project entity, ProjectRepository)
+- TaskRepository for next action queries
+- User authentication system
+
+## Test Commands
+
+```bash
+# Run unit tests
+docker exec gtd-api-1 php bin/phpunit tests/Unit/Service/ProjectServiceTest.php
+
+# Run functional tests
+docker exec gtd-api-1 php bin/phpunit tests/Functional/Project/ProjectTest.php
+
+# Run all Phase 5 tests
+docker exec gtd-api-1 php bin/phpunit tests/Unit/Entity/ProjectTest.php tests/Unit/Repository/ProjectRepositoryTest.php tests/Unit/Service/ProjectServiceTest.php tests/Functional/Project/ProjectTest.php
+
+# Code coverage
+docker exec gtd-api-1 php bin/phpunit --coverage-text
+```
+
+## Acceptance Criteria
+
+- [ ] All unit tests pass for ProjectService
+- [ ] All functional tests pass for ProjectController
+- [ ] API endpoints follow REST conventions
+- [ ] FR-017: Next action is correctly identified per project
+- [ ] FR-018: Projects without next action are flagged
+- [ ] FR-019: Outcome can be defined and retrieved
+- [ ] Code coverage >= 80%
+- [ ] CI pipeline passes


### PR DESCRIPTION
## Summary

- Implement GTD project management REST API endpoints with next action tracking and review support
- Add ProjectService with business logic for status transitions, next action identification (FR-017), and review scheduling (FR-018)
- Add ProjectController with full CRUD operations and GTD-specific endpoints (needing-attention, due-for-review)
- Add project_id support to TaskController for task-project assignment

## Endpoints Added

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | /api/v1/projects | List all projects |
| GET | /api/v1/projects/{id} | Get project details with tasks |
| POST | /api/v1/projects | Create new project |
| PATCH | /api/v1/projects/{id} | Update project |
| DELETE | /api/v1/projects/{id} | Soft delete project |
| POST | /api/v1/projects/{id}/complete | Mark completed |
| POST | /api/v1/projects/{id}/hold | Put on hold |
| POST | /api/v1/projects/{id}/activate | Reactivate |
| GET | /api/v1/projects/needing-attention | List projects without next action |
| GET | /api/v1/projects/due-for-review | List projects due for review |

## Test plan

- [x] 31 unit tests for ProjectService (status transitions, next action logic)
- [x] 35 functional tests for ProjectController (CRUD, GTD-specific endpoints)
- [x] All 564 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)