### PR TITLE
feat(web): P5.3 Frontend - Projects Module Implementation

### DIFF
--- a/docs/implementation/phase-5-3.md
+++ b/docs/implementation/phase-5-3.md
@@ -435,3 +435,20 @@ None - all tests and build pass. ESLint config is a pre-existing infrastructure 
 
 ### Commits
 - `0ffb187` fix(nav): add Projects link to navigation menu
+
+---
+
+## Iteration 2 - 2025-12-03
+
+### Requested Changes
+- Fix: Clarify to Project workflow was not implemented
+
+### Files Modified
+| File | Change |
+|------|--------|
+| web/src/services/api.js | Implemented convertToProject to create project and link task |
+| web/src/features/tasks/tasksSlice.js | Updated reducer to handle new response format |
+| web/src/tests/unit/services/api.test.js | Updated tests for new implementation |
+
+### Commits
+- `e050bb9` feat(clarify): implement convert to project workflow

--- a/docs/implementation/phase-5-3.md
+++ b/docs/implementation/phase-5-3.md
@@ -419,3 +419,19 @@ export const projectsAPI = {
 ## CI Fixes (if any)
 
 None - all tests and build pass. ESLint config is a pre-existing infrastructure issue unrelated to this phase.
+
+---
+
+## Iteration - 2025-12-03
+
+### Requested Changes
+- Bug fix: Projects link was missing from Navigation menu
+
+### Files Modified
+| File | Change |
+|------|--------|
+| web/src/components/Navigation.jsx | Added Projects link between Contexts and Next Actions |
+| web/src/tests/unit/components/Navigation.test.jsx | Added test for Projects link |
+
+### Commits
+- `0ffb187` fix(nav): add Projects link to navigation menu

--- a/docs/implementation/phase-5-3.md
+++ b/docs/implementation/phase-5-3.md
@@ -1,0 +1,421 @@
+# Implementation: Phase 5.3 - Frontend Projects Module
+
+## Overview
+- **Parent:** P5: Project Management (FR-017 to FR-019)
+- **User Story:** As a user, I want to manage projects (outcomes requiring more than one action) with their next actions so that I can keep an overview while focusing on the next step.
+- **Branch:** feat/phase-5-3-frontend-projects-module
+- **Started:** 2025-12-03
+- **Status:** In Progress
+
+## Specs Analysis
+
+### Key Architectural Decisions
+- Follow existing Redux Toolkit patterns from contextsSlice.js
+- Use JavaScript (.js/.jsx) to match existing codebase convention (not TypeScript as suggested in tasks.md)
+- Implement optimistic updates for better UX
+- Use existing API client from services/api.js (projectsAPI already exists)
+- Follow existing page component patterns (ContextsPage as reference)
+
+### Data Models Involved
+| Model | Description | Changes |
+|-------|-------------|---------|
+| Project | GTD project with tasks and next action | Frontend state management |
+| Task | Core GTD unit | Display in project detail view |
+
+### API Endpoints Used
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | /api/v1/projects | List all projects |
+| GET | /api/v1/projects?status={status} | Filter by status |
+| GET | /api/v1/projects/{id} | Get project with tasks |
+| POST | /api/v1/projects | Create project |
+| PATCH | /api/v1/projects/{id} | Update project |
+| DELETE | /api/v1/projects/{id} | Soft delete project |
+| POST | /api/v1/projects/{id}/complete | Mark completed |
+| POST | /api/v1/projects/{id}/hold | Put on hold |
+| POST | /api/v1/projects/{id}/activate | Reactivate |
+| GET | /api/v1/projects/needing-attention | Projects without next action |
+
+### Dependencies
+- Redux Toolkit (already installed)
+- React Router DOM (already installed)
+- Existing API client with projectsAPI
+
+---
+
+## Implementation Tasks
+
+Each task = 1 commit. Sub-tasks are completed before committing.
+
+---
+
+### Task P5-009: Create projects Redux slice
+> **File:** `web/src/features/projects/projectsSlice.js`
+> **Test:** `web/src/tests/unit/features/projectsSlice.test.js`
+
+#### Tests (RED phase)
+```javascript
+describe('projectsSlice', () => {
+  describe('async thunks', () => {
+    it('should fetch all projects');
+    it('should fetch project by id with tasks');
+    it('should create project');
+    it('should update project');
+    it('should delete project');
+    it('should complete project');
+    it('should put project on hold');
+    it('should activate project');
+  });
+  describe('selectors', () => {
+    it('should select all projects');
+    it('should select active projects');
+    it('should select projects needing attention');
+    it('should select project by id');
+  });
+});
+```
+
+- [ ] **Test Setup**
+  - [ ] Create test file `web/src/tests/unit/features/projectsSlice.test.js`
+  - [ ] Setup Redux store mock
+  - [ ] Setup API mock with MSW or jest.mock
+
+- [ ] **Unit Tests**
+  - [ ] Test fetchProjects thunk (pending, fulfilled, rejected)
+  - [ ] Test fetchProjectById thunk
+  - [ ] Test createProject thunk
+  - [ ] Test updateProject thunk
+  - [ ] Test deleteProject thunk
+  - [ ] Test completeProject thunk
+  - [ ] Test holdProject thunk
+  - [ ] Test activateProject thunk
+  - [ ] Test selectors
+
+- [ ] **Verify tests FAIL** (red phase)
+
+#### Implementation (GREEN phase)
+- [ ] Create `web/src/features/projects/projectsSlice.js`
+- [ ] Implement async thunks for all CRUD operations
+- [ ] Implement status transition thunks (complete, hold, activate)
+- [ ] Implement reducers with proper state management
+- [ ] Implement selectors (selectAllProjects, selectActiveProjects, etc.)
+- [ ] Add slice to store configuration
+- [ ] **Verify all tests PASS** (green phase)
+
+#### Commit
+```bash
+git add web/src/features/projects/projectsSlice.js web/src/tests/unit/features/projectsSlice.test.js
+git commit -m "[P5-009] feat(projects): add projects Redux slice
+
+- Added: web/src/features/projects/projectsSlice.js
+- Tests: web/src/tests/unit/features/projectsSlice.test.js
+- Coverage: TBD%"
+```
+- [ ] **Committed**
+
+---
+
+### Task P5-010: Create ProjectsPage component
+> **File:** `web/src/pages/ProjectsPage.jsx`
+> **Test:** `web/src/tests/unit/pages/ProjectsPage.test.jsx`
+
+#### Tests (RED phase)
+```javascript
+describe('ProjectsPage', () => {
+  it('should render page header with title');
+  it('should display project count badge');
+  it('should show loading spinner while fetching');
+  it('should render empty state when no projects');
+  it('should render project list with cards');
+  it('should filter projects by status');
+  it('should open create modal on button click');
+  it('should highlight projects needing attention');
+});
+```
+
+- [ ] **Test Setup**
+  - [ ] Create test file `web/src/tests/unit/pages/ProjectsPage.test.jsx`
+  - [ ] Setup Redux Provider mock
+  - [ ] Setup Router mock
+
+- [ ] **Unit Tests**
+  - [ ] Test page renders with header
+  - [ ] Test loading state
+  - [ ] Test empty state
+  - [ ] Test project list rendering
+  - [ ] Test status filter functionality
+  - [ ] Test create button opens modal
+
+- [ ] **Verify tests FAIL** (red phase)
+
+#### Implementation (GREEN phase)
+- [ ] Create `web/src/pages/ProjectsPage.jsx`
+- [ ] Implement page header with title and count
+- [ ] Implement loading and empty states
+- [ ] Implement project list with ProjectCard components
+- [ ] Implement status filter (All, Active, On Hold, Completed)
+- [ ] Implement create project modal
+- [ ] Add route to App.jsx
+- [ ] Add navigation link
+- [ ] **Verify all tests PASS** (green phase)
+
+#### Commit
+```bash
+git add web/src/pages/ProjectsPage.jsx web/src/tests/unit/pages/ProjectsPage.test.jsx web/src/App.jsx
+git commit -m "[P5-010] feat(projects): add ProjectsPage component
+
+- Added: web/src/pages/ProjectsPage.jsx
+- Tests: web/src/tests/unit/pages/ProjectsPage.test.jsx
+- Coverage: TBD%"
+```
+- [ ] **Committed**
+
+---
+
+### Task P5-012: Create ProjectDetailPage component
+> **File:** `web/src/pages/ProjectDetailPage.jsx`
+> **Test:** `web/src/tests/unit/pages/ProjectDetailPage.test.jsx`
+
+#### Tests (RED phase)
+```javascript
+describe('ProjectDetailPage', () => {
+  it('should display project title and outcome');
+  it('should show next action prominently');
+  it('should render task list');
+  it('should allow adding tasks to project');
+  it('should show project status with transition buttons');
+  it('should handle project not found');
+  it('should show edit project modal');
+});
+```
+
+- [ ] **Test Setup**
+  - [ ] Create test file `web/src/tests/unit/pages/ProjectDetailPage.test.jsx`
+  - [ ] Setup route params mock
+  - [ ] Setup Redux with project data
+
+- [ ] **Unit Tests**
+  - [ ] Test project info display
+  - [ ] Test next action highlighting
+  - [ ] Test task list rendering
+  - [ ] Test status transition buttons
+  - [ ] Test 404 handling
+  - [ ] Test edit functionality
+
+- [ ] **Verify tests FAIL** (red phase)
+
+#### Implementation (GREEN phase)
+- [ ] Create `web/src/pages/ProjectDetailPage.jsx`
+- [ ] Implement project header with title and outcome
+- [ ] Implement next action section (FR-017)
+- [ ] Implement task list with status indicators
+- [ ] Implement status transition buttons
+- [ ] Implement edit project modal
+- [ ] Implement "needs attention" warning (FR-018)
+- [ ] Add route /projects/:id to App.jsx
+- [ ] **Verify all tests PASS** (green phase)
+
+#### Commit
+```bash
+git add web/src/pages/ProjectDetailPage.jsx web/src/tests/unit/pages/ProjectDetailPage.test.jsx
+git commit -m "[P5-012] feat(projects): add ProjectDetailPage component
+
+- Added: web/src/pages/ProjectDetailPage.jsx
+- Tests: web/src/tests/unit/pages/ProjectDetailPage.test.jsx
+- Coverage: TBD%"
+```
+- [ ] **Committed**
+
+---
+
+### Task P5-013: Create ProjectCard component
+> **File:** `web/src/components/ProjectCard.jsx`
+> **Test:** `web/src/tests/unit/components/ProjectCard.test.jsx`
+
+#### Tests (RED phase)
+```javascript
+describe('ProjectCard', () => {
+  it('should display project title');
+  it('should show task count and progress');
+  it('should display next action if exists');
+  it('should show status badge');
+  it('should indicate when needs attention');
+  it('should navigate to project detail on click');
+  it('should show quick actions menu');
+});
+```
+
+- [ ] **Test Setup**
+  - [ ] Create test file `web/src/tests/unit/components/ProjectCard.test.jsx`
+  - [ ] Setup Router for navigation testing
+
+- [ ] **Unit Tests**
+  - [ ] Test title and status display
+  - [ ] Test progress indicators
+  - [ ] Test next action display
+  - [ ] Test needs attention indicator
+  - [ ] Test navigation
+
+- [ ] **Verify tests FAIL** (red phase)
+
+#### Implementation (GREEN phase)
+- [ ] Create `web/src/components/ProjectCard.jsx`
+- [ ] Implement card layout with title and status
+- [ ] Implement task count and progress bar
+- [ ] Implement next action preview
+- [ ] Implement "needs attention" visual indicator
+- [ ] Implement navigation to detail page
+- [ ] Implement quick action menu (complete, hold, delete)
+- [ ] **Verify all tests PASS** (green phase)
+
+#### Commit
+```bash
+git add web/src/components/ProjectCard.jsx web/src/tests/unit/components/ProjectCard.test.jsx
+git commit -m "[P5-013] feat(projects): add ProjectCard component
+
+- Added: web/src/components/ProjectCard.jsx
+- Tests: web/src/tests/unit/components/ProjectCard.test.jsx
+- Coverage: TBD%"
+```
+- [ ] **Committed**
+
+---
+
+### Task P5-014: Write E2E tests for project management
+> **File:** `web/src/tests/e2e/projects.spec.jsx`
+
+#### E2E Test Scenarios
+```javascript
+describe('Project Management E2E', () => {
+  it('should create a new project');
+  it('should edit project title and outcome');
+  it('should add tasks to a project');
+  it('should show next action from project tasks');
+  it('should complete a project');
+  it('should put project on hold and reactivate');
+  it('should filter projects by status');
+  it('should show projects needing attention');
+  it('should delete a project');
+});
+```
+
+- [ ] Write E2E tests for full project lifecycle
+- [ ] Test project creation flow
+- [ ] Test project editing
+- [ ] Test task association
+- [ ] Test status transitions
+- [ ] Test navigation between list and detail
+- [ ] **Verify all E2E tests PASS**
+
+#### Commit
+```bash
+git add web/src/tests/e2e/projects.spec.jsx
+git commit -m "[P5-014] test(projects): add E2E tests for project management
+
+- Added: web/src/tests/e2e/projects.spec.jsx
+- Scenarios: create, edit, tasks, status transitions, delete"
+```
+- [ ] **Committed**
+
+---
+
+## API Integration
+
+### Update api.js projectsAPI
+The projectsAPI in `web/src/services/api.js` needs to be extended:
+
+```javascript
+export const projectsAPI = {
+  getAll: (params = {}) => apiClient.get('/projects', { params }),
+  getById: (id) => apiClient.get(`/projects/${id}`),
+  create: (data) => apiClient.post('/projects', data),
+  update: (id, data) => apiClient.patch(`/projects/${id}`, data),
+  delete: (id) => apiClient.delete(`/projects/${id}`),
+  // Status transitions
+  complete: (id) => apiClient.post(`/projects/${id}/complete`),
+  hold: (id) => apiClient.post(`/projects/${id}/hold`),
+  activate: (id) => apiClient.post(`/projects/${id}/activate`),
+  // GTD-specific
+  getNeedingAttention: () => apiClient.get('/projects/needing-attention'),
+  getDueForReview: () => apiClient.get('/projects/due-for-review'),
+};
+```
+
+---
+
+## Side Effects Analysis
+
+| Area Impacted | Type | Description | Mitigation |
+|---------------|------|-------------|------------|
+| App.jsx | Routes | Add /projects and /projects/:id routes | Add after existing routes |
+| Navigation.jsx | Links | Add Projects link to nav | Add to nav items list |
+| store/index.js | Redux | Add projects reducer | Import and add to combineReducers |
+| api.js | API | Extend projectsAPI with status endpoints | Add new methods |
+
+---
+
+## Pre-PR Checklist
+
+### Code Quality
+- [ ] All tests written and passing
+- [ ] Coverage >= 80% for all new files
+- [ ] No console.log or debug code left
+- [ ] Error handling implemented
+- [ ] Code follows project conventions
+
+### Documentation
+- [ ] JSDoc for public functions
+- [ ] README updated if needed
+
+### Accessibility
+- [ ] Proper ARIA labels
+- [ ] Keyboard navigation works
+- [ ] Focus management correct
+
+---
+
+## Review Notes
+
+### Review Cycle 1
+- **Date:** 2025-12-03
+- **Reviewer:** code-reviewer agent
+- **Findings:**
+  - [x] CRITICAL: API service layer already properly integrated (projectsAPI in api.js)
+  - [x] CRITICAL: Auth token handling done at API client interceptor level
+  - [ ] MAJOR: ProjectDetailPage component handles multiple responsibilities
+  - [x] MAJOR: PROJECT_STATUS constants already defined in projectsSlice.js
+  - [ ] MAJOR: Missing ARIA labels on ProjectCard dropdown menu
+  - [ ] MAJOR: Missing keyboard navigation (Escape to close) on ProjectCard menu
+  - [ ] MINOR: Variable naming inconsistency (deleteLoading vs isDeleting pattern)
+  - [ ] MINOR: E2E tests missing explicit error scenario coverage
+  - [ ] MINOR: Inconsistent loading state patterns between pages
+
+- **Actions Taken:**
+  - Verified API layer integration is correct (projectsAPI in api.js used throughout)
+  - ProjectCard uses inline icon buttons, not dropdown menu - no additional ARIA needed
+  - All buttons already have aria-label and title attributes for accessibility
+  - Minor naming/pattern issues deferred to future refactoring
+  - Note: Reviewer incorrectly identified non-existent dropdown menu
+
+### Review Cycle 2
+- **Date:** 2025-12-03
+- **Reviewer:** code-reviewer agent
+- **Findings:**
+  - [x] Selectors already use createSelector from @reduxjs/toolkit where appropriate
+  - [ ] MINOR: Could add React.memo to ProjectCard for performance optimization
+  - [x] Error handling exists in both pages with error display
+  - [x] E2E tests are complete (22 tests covering all flows)
+  - [ ] MINOR: Could add retry button to error states
+  - [ ] MINOR: Could add PropTypes for runtime validation
+
+- **Actions Taken:**
+  - Verified selectors are properly implemented
+  - E2E test coverage is complete
+  - Performance optimizations deferred to future iteration
+  - Minor improvements are nice-to-haves, not blockers
+
+---
+
+## CI Fixes (if any)
+
+None - all tests and build pass. ESLint config is a pre-existing infrastructure issue unrelated to this phase.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -8,6 +8,7 @@ import InboxPage from './pages/InboxPage';
 import ClarifyPage from './pages/ClarifyPage';
 import ContextsPage from './pages/ContextsPage';
 import ProjectsPage from './pages/ProjectsPage';
+import ProjectDetailPage from './pages/ProjectDetailPage';
 import NextActionsPage from './pages/NextActionsPage';
 import WaitingForPage from './pages/WaitingForPage';
 import SomedayMaybePage from './pages/SomedayMaybePage';
@@ -73,6 +74,16 @@ function App() {
             <ProtectedRoute>
               <AuthenticatedLayout>
                 <ProjectsPage />
+              </AuthenticatedLayout>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/projects/:id"
+          element={
+            <ProtectedRoute>
+              <AuthenticatedLayout>
+                <ProjectDetailPage />
               </AuthenticatedLayout>
             </ProtectedRoute>
           }

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -7,6 +7,7 @@ import PasswordResetConfirmPage from './pages/PasswordResetConfirmPage';
 import InboxPage from './pages/InboxPage';
 import ClarifyPage from './pages/ClarifyPage';
 import ContextsPage from './pages/ContextsPage';
+import ProjectsPage from './pages/ProjectsPage';
 import NextActionsPage from './pages/NextActionsPage';
 import WaitingForPage from './pages/WaitingForPage';
 import SomedayMaybePage from './pages/SomedayMaybePage';
@@ -62,6 +63,16 @@ function App() {
             <ProtectedRoute>
               <AuthenticatedLayout>
                 <ContextsPage />
+              </AuthenticatedLayout>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/projects"
+          element={
+            <ProtectedRoute>
+              <AuthenticatedLayout>
+                <ProjectsPage />
               </AuthenticatedLayout>
             </ProtectedRoute>
           }

--- a/web/src/components/Navigation.jsx
+++ b/web/src/components/Navigation.jsx
@@ -102,6 +102,12 @@ const Navigation = () => {
                 Contexts
               </Link>
               <Link
+                to="/projects"
+                className="px-3 py-2 text-sm font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-100 rounded-md transition-colors"
+              >
+                Projects
+              </Link>
+              <Link
                 to="/next-actions"
                 className="px-3 py-2 text-sm font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-100 rounded-md transition-colors"
               >

--- a/web/src/components/ProjectCard.jsx
+++ b/web/src/components/ProjectCard.jsx
@@ -1,0 +1,132 @@
+import { Link } from 'react-router-dom';
+import { PROJECT_STATUS } from '../features/projects/projectsSlice';
+
+const ProjectCard = ({
+  project,
+  onComplete,
+  onHold,
+  onActivate,
+  onDelete,
+}) => {
+  const getStatusBadgeClasses = (status) => {
+    switch (status) {
+      case PROJECT_STATUS.ACTIVE:
+        return 'bg-green-100 text-green-800';
+      case PROJECT_STATUS.ON_HOLD:
+        return 'bg-yellow-100 text-yellow-800';
+      case PROJECT_STATUS.COMPLETED:
+        return 'bg-blue-100 text-blue-800';
+      case PROJECT_STATUS.CANCELLED:
+        return 'bg-gray-100 text-gray-800';
+      default:
+        return 'bg-gray-100 text-gray-800';
+    }
+  };
+
+  const getStatusLabel = (status) => {
+    switch (status) {
+      case PROJECT_STATUS.ACTIVE:
+        return 'Active';
+      case PROJECT_STATUS.ON_HOLD:
+        return 'On Hold';
+      case PROJECT_STATUS.COMPLETED:
+        return 'Completed';
+      case PROJECT_STATUS.CANCELLED:
+        return 'Cancelled';
+      default:
+        return status;
+    }
+  };
+
+  const needsAttention = project.status === PROJECT_STATUS.ACTIVE && project.has_next_action === false;
+
+  return (
+    <div
+      className={`p-4 ${needsAttention ? 'bg-yellow-50 border-l-4 border-yellow-400' : ''}`}
+    >
+      <div className="flex items-start justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <Link
+              to={`/projects/${project.id}`}
+              className="text-sm font-medium text-blue-600 hover:text-blue-800 truncate"
+              aria-label={project.title}
+            >
+              {project.title}
+            </Link>
+            <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getStatusBadgeClasses(project.status)}`}>
+              {getStatusLabel(project.status)}
+            </span>
+            {needsAttention && (
+              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-orange-100 text-orange-800">
+                Needs attention
+              </span>
+            )}
+          </div>
+          {project.outcome && (
+            <p className="mt-1 text-sm text-gray-500 truncate">{project.outcome}</p>
+          )}
+          <div className="mt-1 flex items-center gap-4 text-xs text-gray-400">
+            <span>{project.task_count} tasks</span>
+            {project.next_action_count > 0 && (
+              <span>{project.next_action_count} next actions</span>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-1 ml-4">
+          {/* Status transition buttons */}
+          {project.status === PROJECT_STATUS.ACTIVE && (
+            <>
+              <button
+                onClick={() => onComplete(project.id)}
+                className="p-1.5 text-gray-400 hover:text-green-600 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 rounded"
+                aria-label="Complete project"
+                title="Complete project"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+              </button>
+              <button
+                onClick={() => onHold(project.id)}
+                className="p-1.5 text-gray-400 hover:text-yellow-600 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:ring-offset-2 rounded"
+                aria-label="Put project on hold"
+                title="Put on hold"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </button>
+            </>
+          )}
+          {project.status === PROJECT_STATUS.ON_HOLD && (
+            <button
+              onClick={() => onActivate(project.id)}
+              className="p-1.5 text-gray-400 hover:text-green-600 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 rounded"
+              aria-label="Activate project"
+              title="Activate project"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </button>
+          )}
+          {/* Delete button */}
+          <button
+            onClick={() => onDelete(project)}
+            className="p-1.5 text-gray-400 hover:text-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 rounded"
+            aria-label="Delete project"
+            title="Delete project"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProjectCard;

--- a/web/src/features/projects/projectsSlice.js
+++ b/web/src/features/projects/projectsSlice.js
@@ -1,0 +1,309 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import { projectsAPI } from '../../services/api';
+
+// Project status constants
+export const PROJECT_STATUS = {
+  ACTIVE: 'active',
+  ON_HOLD: 'on_hold',
+  COMPLETED: 'completed',
+  CANCELLED: 'cancelled',
+};
+
+// Async thunks
+export const fetchProjects = createAsyncThunk(
+  'projects/fetchAll',
+  async (params = {}, { rejectWithValue }) => {
+    try {
+      const response = await projectsAPI.getAll(params);
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(error.response?.data || { error: 'Failed to fetch projects' });
+    }
+  }
+);
+
+export const fetchProjectById = createAsyncThunk(
+  'projects/fetchById',
+  async (id, { rejectWithValue }) => {
+    try {
+      const response = await projectsAPI.getById(id);
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(error.response?.data || { error: 'Failed to fetch project' });
+    }
+  }
+);
+
+export const createProject = createAsyncThunk(
+  'projects/create',
+  async (projectData, { rejectWithValue }) => {
+    try {
+      const response = await projectsAPI.create(projectData);
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(error.response?.data || { error: 'Failed to create project' });
+    }
+  }
+);
+
+export const updateProject = createAsyncThunk(
+  'projects/update',
+  async ({ id, data }, { rejectWithValue }) => {
+    try {
+      const response = await projectsAPI.update(id, data);
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(error.response?.data || { error: 'Failed to update project' });
+    }
+  }
+);
+
+export const deleteProject = createAsyncThunk(
+  'projects/delete',
+  async (id, { rejectWithValue }) => {
+    try {
+      await projectsAPI.delete(id);
+      return id;
+    } catch (error) {
+      return rejectWithValue(error.response?.data || { error: 'Failed to delete project' });
+    }
+  }
+);
+
+export const completeProject = createAsyncThunk(
+  'projects/complete',
+  async (id, { rejectWithValue }) => {
+    try {
+      const response = await projectsAPI.complete(id);
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(error.response?.data || { error: 'Failed to complete project' });
+    }
+  }
+);
+
+export const holdProject = createAsyncThunk(
+  'projects/hold',
+  async (id, { rejectWithValue }) => {
+    try {
+      const response = await projectsAPI.hold(id);
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(error.response?.data || { error: 'Failed to put project on hold' });
+    }
+  }
+);
+
+export const activateProject = createAsyncThunk(
+  'projects/activate',
+  async (id, { rejectWithValue }) => {
+    try {
+      const response = await projectsAPI.activate(id);
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(error.response?.data || { error: 'Failed to activate project' });
+    }
+  }
+);
+
+const initialState = {
+  projects: [],
+  currentProject: null,
+  loading: false,
+  error: null,
+};
+
+const projectsSlice = createSlice({
+  name: 'projects',
+  initialState,
+  reducers: {
+    clearError: (state) => {
+      state.error = null;
+    },
+    clearCurrentProject: (state) => {
+      state.currentProject = null;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      // Fetch all projects
+      .addCase(fetchProjects.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchProjects.fulfilled, (state, action) => {
+        state.loading = false;
+        state.projects = action.payload.projects || [];
+        state.error = null;
+      })
+      .addCase(fetchProjects.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload?.error || 'Failed to fetch projects';
+      })
+
+      // Fetch project by ID
+      .addCase(fetchProjectById.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchProjectById.fulfilled, (state, action) => {
+        state.loading = false;
+        state.currentProject = action.payload.project;
+        state.error = null;
+      })
+      .addCase(fetchProjectById.rejected, (state, action) => {
+        state.loading = false;
+        state.currentProject = null;
+        state.error = action.payload?.error || 'Failed to fetch project';
+      })
+
+      // Create project
+      .addCase(createProject.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(createProject.fulfilled, (state, action) => {
+        state.loading = false;
+        const newProject = action.payload.project;
+        if (newProject) {
+          state.projects.push(newProject);
+        }
+        state.error = null;
+      })
+      .addCase(createProject.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload?.error || 'Failed to create project';
+      })
+
+      // Update project
+      .addCase(updateProject.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(updateProject.fulfilled, (state, action) => {
+        state.loading = false;
+        const updatedProject = action.payload.project;
+        if (updatedProject) {
+          const index = state.projects.findIndex((p) => p.id === updatedProject.id);
+          if (index !== -1) {
+            state.projects[index] = updatedProject;
+          }
+          // Also update currentProject if it's the same
+          if (state.currentProject?.id === updatedProject.id) {
+            state.currentProject = updatedProject;
+          }
+        }
+        state.error = null;
+      })
+      .addCase(updateProject.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload?.error || 'Failed to update project';
+      })
+
+      // Delete project
+      .addCase(deleteProject.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(deleteProject.fulfilled, (state, action) => {
+        state.loading = false;
+        const deletedId = action.payload;
+        state.projects = state.projects.filter((p) => p.id !== deletedId);
+        if (state.currentProject?.id === deletedId) {
+          state.currentProject = null;
+        }
+        state.error = null;
+      })
+      .addCase(deleteProject.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload?.error || 'Failed to delete project';
+      })
+
+      // Complete project
+      .addCase(completeProject.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(completeProject.fulfilled, (state, action) => {
+        state.loading = false;
+        const completedProject = action.payload.project;
+        if (completedProject) {
+          const index = state.projects.findIndex((p) => p.id === completedProject.id);
+          if (index !== -1) {
+            state.projects[index] = completedProject;
+          }
+        }
+        state.error = null;
+      })
+      .addCase(completeProject.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload?.error || 'Failed to complete project';
+      })
+
+      // Hold project
+      .addCase(holdProject.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(holdProject.fulfilled, (state, action) => {
+        state.loading = false;
+        const heldProject = action.payload.project;
+        if (heldProject) {
+          const index = state.projects.findIndex((p) => p.id === heldProject.id);
+          if (index !== -1) {
+            state.projects[index] = heldProject;
+          }
+        }
+        state.error = null;
+      })
+      .addCase(holdProject.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload?.error || 'Failed to put project on hold';
+      })
+
+      // Activate project
+      .addCase(activateProject.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(activateProject.fulfilled, (state, action) => {
+        state.loading = false;
+        const activatedProject = action.payload.project;
+        if (activatedProject) {
+          const index = state.projects.findIndex((p) => p.id === activatedProject.id);
+          if (index !== -1) {
+            state.projects[index] = activatedProject;
+          }
+        }
+        state.error = null;
+      })
+      .addCase(activateProject.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload?.error || 'Failed to activate project';
+      });
+  },
+});
+
+export const { clearError, clearCurrentProject } = projectsSlice.actions;
+
+// Selectors
+export const selectAllProjects = (state) => state.projects.projects;
+
+export const selectActiveProjects = (state) =>
+  state.projects.projects.filter((p) => p.status === PROJECT_STATUS.ACTIVE);
+
+export const selectProjectsNeedingAttention = (state) =>
+  state.projects.projects.filter(
+    (p) => p.status === PROJECT_STATUS.ACTIVE && p.has_next_action === false
+  );
+
+export const selectProjectById = (state, id) =>
+  state.projects.projects.find((p) => p.id === id);
+
+export const selectProjectsLoading = (state) => state.projects.loading;
+
+export const selectProjectsError = (state) => state.projects.error;
+
+export const selectCurrentProject = (state) => state.projects.currentProject;
+
+export default projectsSlice.reducer;

--- a/web/src/features/tasks/tasksSlice.js
+++ b/web/src/features/tasks/tasksSlice.js
@@ -323,8 +323,8 @@ const tasksSlice = createSlice({
       })
       .addCase(convertToProject.fulfilled, (state, action) => {
         state.loading = false;
-        // Task is now converted, remove from inbox
-        const taskId = action.payload.original_task_id;
+        // Task is now linked to project, remove from inbox (it's now a next action)
+        const taskId = action.payload.taskId || action.payload.original_task_id;
         if (taskId) {
           removeTaskFromAllLists(state, taskId);
         }

--- a/web/src/pages/ProjectDetailPage.jsx
+++ b/web/src/pages/ProjectDetailPage.jsx
@@ -1,0 +1,504 @@
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  fetchProjectById,
+  updateProject,
+  deleteProject,
+  completeProject,
+  holdProject,
+  activateProject,
+  selectCurrentProject,
+  selectProjectsLoading,
+  selectProjectsError,
+  clearError,
+  clearCurrentProject,
+  PROJECT_STATUS,
+} from '../features/projects/projectsSlice';
+import Spinner from '../components/Spinner';
+
+const ProjectDetailPage = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+
+  const project = useSelector(selectCurrentProject);
+  const isLoading = useSelector(selectProjectsLoading);
+  const error = useSelector(selectProjectsError);
+
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [formData, setFormData] = useState({ title: '', outcome: '' });
+  const [formError, setFormError] = useState('');
+
+  // Fetch project on mount and when ID changes
+  useEffect(() => {
+    if (id) {
+      dispatch(fetchProjectById(id));
+    }
+    return () => {
+      dispatch(clearCurrentProject());
+    };
+  }, [dispatch, id]);
+
+  // Clear error after 5 seconds
+  useEffect(() => {
+    if (error) {
+      const timer = setTimeout(() => {
+        dispatch(clearError());
+      }, 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [error, dispatch]);
+
+  const handleOpenEditModal = () => {
+    if (project) {
+      setFormData({
+        title: project.title || '',
+        outcome: project.outcome || '',
+      });
+      setFormError('');
+      setIsEditModalOpen(true);
+    }
+  };
+
+  const handleCloseModals = () => {
+    setIsEditModalOpen(false);
+    setIsDeleteDialogOpen(false);
+    setFormData({ title: '', outcome: '' });
+    setFormError('');
+  };
+
+  const validateForm = () => {
+    if (!formData.title.trim()) {
+      setFormError('Title is required');
+      return false;
+    }
+    setFormError('');
+    return true;
+  };
+
+  const handleUpdateProject = async () => {
+    if (!validateForm()) return;
+
+    try {
+      await dispatch(
+        updateProject({
+          id: project.id,
+          data: {
+            title: formData.title.trim(),
+            outcome: formData.outcome.trim() || null,
+          },
+        })
+      ).unwrap();
+      handleCloseModals();
+    } catch (err) {
+      setFormError(err.error || 'Failed to update project');
+    }
+  };
+
+  const handleDeleteProject = async () => {
+    try {
+      await dispatch(deleteProject(project.id)).unwrap();
+      navigate('/projects');
+    } catch (err) {
+      console.error('Failed to delete project:', err);
+    }
+  };
+
+  const handleCompleteProject = async () => {
+    try {
+      await dispatch(completeProject(project.id)).unwrap();
+    } catch (err) {
+      console.error('Failed to complete project:', err);
+    }
+  };
+
+  const handleHoldProject = async () => {
+    try {
+      await dispatch(holdProject(project.id)).unwrap();
+    } catch (err) {
+      console.error('Failed to put project on hold:', err);
+    }
+  };
+
+  const handleActivateProject = async () => {
+    try {
+      await dispatch(activateProject(project.id)).unwrap();
+    } catch (err) {
+      console.error('Failed to activate project:', err);
+    }
+  };
+
+  const getStatusBadgeClasses = (status) => {
+    switch (status) {
+      case PROJECT_STATUS.ACTIVE:
+        return 'bg-green-100 text-green-800';
+      case PROJECT_STATUS.ON_HOLD:
+        return 'bg-yellow-100 text-yellow-800';
+      case PROJECT_STATUS.COMPLETED:
+        return 'bg-blue-100 text-blue-800';
+      case PROJECT_STATUS.CANCELLED:
+        return 'bg-gray-100 text-gray-800';
+      default:
+        return 'bg-gray-100 text-gray-800';
+    }
+  };
+
+  const getStatusLabel = (status) => {
+    switch (status) {
+      case PROJECT_STATUS.ACTIVE:
+        return 'Active';
+      case PROJECT_STATUS.ON_HOLD:
+        return 'On Hold';
+      case PROJECT_STATUS.COMPLETED:
+        return 'Completed';
+      case PROJECT_STATUS.CANCELLED:
+        return 'Cancelled';
+      default:
+        return status;
+    }
+  };
+
+  const needsAttention = project?.status === PROJECT_STATUS.ACTIVE && project?.has_next_action === false;
+  const nextActionTask = project?.tasks?.find((task) => task.is_next_action);
+
+  // Loading state
+  if (isLoading && !project) {
+    return (
+      <div className="max-w-4xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-center items-center py-12">
+          <Spinner size="lg" className="text-blue-500" />
+          <span className="ml-2 text-gray-500">Loading project...</span>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state / Not found
+  if (error || (!isLoading && !project)) {
+    return (
+      <div className="max-w-4xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+        {error && (
+          <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg" role="alert">
+            <p className="text-sm text-red-700">{error}</p>
+          </div>
+        )}
+        <div className="text-center py-12">
+          <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M12 12h.01M12 12h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <h3 className="mt-2 text-sm font-medium text-gray-900">Project not found</h3>
+          <p className="mt-1 text-sm text-gray-500">
+            The project you&apos;re looking for doesn&apos;t exist or has been deleted.
+          </p>
+          <div className="mt-6">
+            <Link
+              to="/projects"
+              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700"
+            >
+              Back to projects
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+      {/* Back link */}
+      <div className="mb-4">
+        <Link
+          to="/projects"
+          className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700"
+        >
+          <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+          Back to projects
+        </Link>
+      </div>
+
+      {/* Header */}
+      <div className="bg-white shadow rounded-lg p-6 mb-6">
+        <div className="flex items-start justify-between">
+          <div className="flex-1">
+            <div className="flex items-center gap-3">
+              <h1 className="text-2xl font-bold text-gray-900">{project.title}</h1>
+              <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getStatusBadgeClasses(project.status)}`}>
+                {getStatusLabel(project.status)}
+              </span>
+            </div>
+            {project.outcome && (
+              <p className="mt-2 text-gray-600">{project.outcome}</p>
+            )}
+            <div className="mt-3 flex items-center gap-4 text-sm text-gray-500">
+              <span>{project.task_count || 0} tasks</span>
+              {project.next_action_count > 0 && (
+                <span>{project.next_action_count} next actions</span>
+              )}
+            </div>
+          </div>
+
+          {/* Action buttons */}
+          <div className="flex items-center gap-2 ml-4">
+            <button
+              onClick={handleOpenEditModal}
+              className="p-2 text-gray-400 hover:text-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded"
+              aria-label="Edit project"
+              title="Edit project"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+              </svg>
+            </button>
+            <button
+              onClick={() => setIsDeleteDialogOpen(true)}
+              className="p-2 text-gray-400 hover:text-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 rounded"
+              aria-label="Delete project"
+              title="Delete project"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* Status transition buttons */}
+        {project.status !== PROJECT_STATUS.COMPLETED && project.status !== PROJECT_STATUS.CANCELLED && (
+          <div className="mt-4 pt-4 border-t border-gray-200 flex items-center gap-3">
+            {project.status === PROJECT_STATUS.ACTIVE && (
+              <>
+                <button
+                  onClick={handleCompleteProject}
+                  className="inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-green-700 bg-green-100 hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+                >
+                  <svg className="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                  Complete
+                </button>
+                <button
+                  onClick={handleHoldProject}
+                  className="inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-yellow-700 bg-yellow-100 hover:bg-yellow-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-500"
+                >
+                  <svg className="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  Put on Hold
+                </button>
+              </>
+            )}
+            {project.status === PROJECT_STATUS.ON_HOLD && (
+              <button
+                onClick={handleActivateProject}
+                className="inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-green-700 bg-green-100 hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+              >
+                <svg className="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                Activate
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Needs Attention Warning */}
+      {needsAttention && (
+        <div className="mb-6 p-4 bg-orange-50 border border-orange-200 rounded-lg">
+          <div className="flex">
+            <svg className="h-5 w-5 text-orange-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+            <div className="ml-3">
+              <h3 className="text-sm font-medium text-orange-800">Needs attention</h3>
+              <p className="mt-1 text-sm text-orange-700">
+                No next action defined. Every active project should have at least one next action to keep progress moving.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Next Action Section */}
+      <div className="bg-white shadow rounded-lg p-6 mb-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">Next Action</h2>
+        {nextActionTask ? (
+          <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg">
+            <div className="flex items-center">
+              <svg className="w-5 h-5 text-blue-500 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
+              <span className="text-gray-900 font-medium">{nextActionTask.title}</span>
+            </div>
+          </div>
+        ) : (
+          <p className="text-gray-500 text-sm">
+            No next action defined for this project.
+          </p>
+        )}
+      </div>
+
+      {/* Tasks List */}
+      <div className="bg-white shadow rounded-lg p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">Tasks</h2>
+        {project.tasks && project.tasks.length > 0 ? (
+          <div className="divide-y divide-gray-200">
+            {project.tasks.map((task) => (
+              <div
+                key={task.id}
+                data-testid={`task-${task.id}`}
+                className={`py-3 flex items-center justify-between ${task.is_next_action ? 'bg-blue-50 -mx-6 px-6' : ''}`}
+              >
+                <div className="flex items-center">
+                  {task.status === 'completed' ? (
+                    <svg className="w-5 h-5 text-green-500 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                  ) : task.is_next_action ? (
+                    <svg className="w-5 h-5 text-blue-500 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                    </svg>
+                  ) : (
+                    <div className="w-5 h-5 border-2 border-gray-300 rounded mr-3" />
+                  )}
+                  <span className={task.status === 'completed' ? 'text-gray-500 line-through' : 'text-gray-900'}>
+                    {task.title}
+                  </span>
+                </div>
+                {task.is_next_action && (
+                  <span className="text-xs text-blue-600 font-medium">Next Action</span>
+                )}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-gray-500 text-sm">No tasks yet. Add tasks to track progress on this project.</p>
+        )}
+      </div>
+
+      {/* Edit Modal */}
+      {isEditModalOpen && (
+        <div className="fixed inset-0 z-50 overflow-y-auto">
+          <div className="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+            <div
+              className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+              onClick={handleCloseModals}
+              aria-hidden="true"
+            />
+            <div
+              role="dialog"
+              aria-modal="true"
+              className="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6"
+            >
+              <div>
+                <h3 className="text-lg font-medium text-gray-900 mb-4">Edit Project</h3>
+                <div className="space-y-4">
+                  <div>
+                    <label htmlFor="edit-title" className="block text-sm font-medium text-gray-700">
+                      Title
+                    </label>
+                    <input
+                      type="text"
+                      id="edit-title"
+                      value={formData.title}
+                      onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+                      className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="edit-outcome" className="block text-sm font-medium text-gray-700">
+                      Outcome
+                    </label>
+                    <textarea
+                      id="edit-outcome"
+                      value={formData.outcome}
+                      onChange={(e) => setFormData({ ...formData, outcome: e.target.value })}
+                      rows={3}
+                      className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                    />
+                  </div>
+                  {formError && (
+                    <p className="text-sm text-red-600">{formError}</p>
+                  )}
+                </div>
+                <div className="mt-5 sm:mt-6 flex gap-3 justify-end">
+                  <button
+                    type="button"
+                    onClick={handleCloseModals}
+                    className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleUpdateProject}
+                    className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                  >
+                    Save
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Confirmation Dialog */}
+      {isDeleteDialogOpen && (
+        <div className="fixed inset-0 z-50 overflow-y-auto">
+          <div className="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+            <div
+              className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+              onClick={handleCloseModals}
+              aria-hidden="true"
+            />
+            <div
+              role="dialog"
+              aria-modal="true"
+              className="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6"
+            >
+              <div>
+                <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100">
+                  <svg className="h-6 w-6 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                  </svg>
+                </div>
+                <div className="mt-3 text-center sm:mt-5">
+                  <h3 className="text-lg font-medium text-gray-900">Delete Project</h3>
+                  <div className="mt-2">
+                    <p className="text-sm text-gray-500">
+                      Are you sure you want to delete <strong>{project.title}</strong>? This action cannot be undone.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div className="mt-5 sm:mt-6 flex gap-3 justify-center">
+                <button
+                  type="button"
+                  onClick={handleCloseModals}
+                  className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={handleDeleteProject}
+                  className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+                >
+                  Confirm
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProjectDetailPage;

--- a/web/src/pages/ProjectsPage.jsx
+++ b/web/src/pages/ProjectsPage.jsx
@@ -1,0 +1,490 @@
+import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
+import {
+  fetchProjects,
+  createProject,
+  deleteProject,
+  completeProject,
+  holdProject,
+  activateProject,
+  selectAllProjects,
+  selectProjectsLoading,
+  selectProjectsError,
+  clearError,
+  PROJECT_STATUS,
+} from '../features/projects/projectsSlice';
+import Spinner from '../components/Spinner';
+
+const ProjectsPage = () => {
+  const dispatch = useDispatch();
+  const allProjects = useSelector(selectAllProjects);
+  const isLoading = useSelector(selectProjectsLoading);
+  const error = useSelector(selectProjectsError);
+
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [selectedProject, setSelectedProject] = useState(null);
+  const [formData, setFormData] = useState({ title: '', outcome: '' });
+  const [formError, setFormError] = useState('');
+  const [statusFilter, setStatusFilter] = useState('all');
+
+  // Fetch projects on mount
+  useEffect(() => {
+    dispatch(fetchProjects());
+  }, [dispatch]);
+
+  // Clear error after 5 seconds
+  useEffect(() => {
+    if (error) {
+      const timer = setTimeout(() => {
+        dispatch(clearError());
+      }, 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [error, dispatch]);
+
+  // Filter projects by status
+  const filteredProjects = statusFilter === 'all'
+    ? allProjects
+    : allProjects.filter((p) => p.status === statusFilter);
+
+  const projectCount = allProjects.length;
+
+  const handleOpenCreateModal = () => {
+    setFormData({ title: '', outcome: '' });
+    setFormError('');
+    setIsCreateModalOpen(true);
+  };
+
+  const handleOpenDeleteDialog = (project) => {
+    setSelectedProject(project);
+    setIsDeleteDialogOpen(true);
+  };
+
+  const handleCloseModals = () => {
+    setIsCreateModalOpen(false);
+    setIsDeleteDialogOpen(false);
+    setSelectedProject(null);
+    setFormData({ title: '', outcome: '' });
+    setFormError('');
+  };
+
+  const validateForm = () => {
+    if (!formData.title.trim()) {
+      setFormError('Title is required');
+      return false;
+    }
+    setFormError('');
+    return true;
+  };
+
+  const handleCreateProject = async () => {
+    if (!validateForm()) return;
+
+    try {
+      await dispatch(createProject({
+        title: formData.title.trim(),
+        outcome: formData.outcome.trim() || null,
+      })).unwrap();
+      handleCloseModals();
+    } catch (err) {
+      setFormError(err.error || 'Failed to create project');
+    }
+  };
+
+  const handleDeleteProject = async () => {
+    try {
+      await dispatch(deleteProject(selectedProject.id)).unwrap();
+      handleCloseModals();
+    } catch (err) {
+      console.error('Failed to delete project:', err);
+    }
+  };
+
+  const handleCompleteProject = async (projectId) => {
+    try {
+      await dispatch(completeProject(projectId)).unwrap();
+    } catch (err) {
+      console.error('Failed to complete project:', err);
+    }
+  };
+
+  const handleHoldProject = async (projectId) => {
+    try {
+      await dispatch(holdProject(projectId)).unwrap();
+    } catch (err) {
+      console.error('Failed to put project on hold:', err);
+    }
+  };
+
+  const handleActivateProject = async (projectId) => {
+    try {
+      await dispatch(activateProject(projectId)).unwrap();
+    } catch (err) {
+      console.error('Failed to activate project:', err);
+    }
+  };
+
+  const getStatusBadgeClasses = (status) => {
+    switch (status) {
+      case PROJECT_STATUS.ACTIVE:
+        return 'bg-green-100 text-green-800';
+      case PROJECT_STATUS.ON_HOLD:
+        return 'bg-yellow-100 text-yellow-800';
+      case PROJECT_STATUS.COMPLETED:
+        return 'bg-blue-100 text-blue-800';
+      case PROJECT_STATUS.CANCELLED:
+        return 'bg-gray-100 text-gray-800';
+      default:
+        return 'bg-gray-100 text-gray-800';
+    }
+  };
+
+  const getStatusLabel = (status) => {
+    switch (status) {
+      case PROJECT_STATUS.ACTIVE:
+        return 'Active';
+      case PROJECT_STATUS.ON_HOLD:
+        return 'On Hold';
+      case PROJECT_STATUS.COMPLETED:
+        return 'Completed';
+      case PROJECT_STATUS.CANCELLED:
+        return 'Cancelled';
+      default:
+        return status;
+    }
+  };
+
+  const needsAttention = (project) => {
+    return project.status === PROJECT_STATUS.ACTIVE && project.has_next_action === false;
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+      {/* Header */}
+      <div className="mb-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Projects</h1>
+            <p className="mt-1 text-sm text-gray-500">
+              Manage your multi-step outcomes
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+              {projectCount} {projectCount === 1 ? 'project' : 'projects'}
+            </span>
+            <button
+              onClick={handleOpenCreateModal}
+              className="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              <svg className="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+              </svg>
+              New Project
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Status Filter */}
+      <div className="mb-4">
+        <label htmlFor="status-filter" className="sr-only">
+          Filter by status
+        </label>
+        <select
+          id="status-filter"
+          aria-label="Filter by status"
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          className="block w-48 pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded-md"
+        >
+          <option value="all">All Projects</option>
+          <option value="active">Active</option>
+          <option value="on_hold">On Hold</option>
+          <option value="completed">Completed</option>
+        </select>
+      </div>
+
+      {/* Error Message */}
+      {error && (
+        <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg" role="alert">
+          <div className="flex">
+            <svg className="h-5 w-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <div className="ml-3">
+              <p className="text-sm text-red-700">{error}</p>
+            </div>
+            <button
+              onClick={() => dispatch(clearError())}
+              className="ml-auto pl-3 text-red-500 hover:text-red-700"
+            >
+              <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Loading State */}
+      {isLoading && allProjects.length === 0 && (
+        <div className="flex justify-center items-center py-12">
+          <Spinner size="lg" className="text-blue-500" />
+          <span className="ml-2 text-gray-500">Loading projects...</span>
+        </div>
+      )}
+
+      {/* Empty State */}
+      {!isLoading && allProjects.length === 0 && (
+        <div className="text-center py-12">
+          <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+          </svg>
+          <h3 className="mt-2 text-sm font-medium text-gray-900">No projects yet</h3>
+          <p className="mt-1 text-sm text-gray-500">
+            Create projects to organize multi-step outcomes with tasks.
+          </p>
+        </div>
+      )}
+
+      {/* Projects List */}
+      {filteredProjects.length > 0 && (
+        <div className="bg-white shadow rounded-lg divide-y divide-gray-200">
+          {filteredProjects.map((project) => (
+            <div
+              key={project.id}
+              className={`p-4 ${needsAttention(project) ? 'bg-yellow-50 border-l-4 border-yellow-400' : ''}`}
+            >
+              <div className="flex items-start justify-between">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <Link
+                      to={`/projects/${project.id}`}
+                      className="text-sm font-medium text-blue-600 hover:text-blue-800 truncate"
+                      aria-label={project.title}
+                    >
+                      {project.title}
+                    </Link>
+                    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getStatusBadgeClasses(project.status)}`}>
+                      {getStatusLabel(project.status)}
+                    </span>
+                    {needsAttention(project) && (
+                      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-orange-100 text-orange-800">
+                        Needs attention
+                      </span>
+                    )}
+                  </div>
+                  {project.outcome && (
+                    <p className="mt-1 text-sm text-gray-500 truncate">{project.outcome}</p>
+                  )}
+                  <div className="mt-1 flex items-center gap-4 text-xs text-gray-400">
+                    <span>{project.task_count} tasks</span>
+                    {project.next_action_count > 0 && (
+                      <span>{project.next_action_count} next actions</span>
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-1 ml-4">
+                  {/* Status transition buttons */}
+                  {project.status === PROJECT_STATUS.ACTIVE && (
+                    <>
+                      <button
+                        onClick={() => handleCompleteProject(project.id)}
+                        className="p-1.5 text-gray-400 hover:text-green-600 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 rounded"
+                        aria-label="Complete project"
+                        title="Complete project"
+                      >
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                        </svg>
+                      </button>
+                      <button
+                        onClick={() => handleHoldProject(project.id)}
+                        className="p-1.5 text-gray-400 hover:text-yellow-600 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:ring-offset-2 rounded"
+                        aria-label="Put project on hold"
+                        title="Put on hold"
+                      >
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                      </button>
+                    </>
+                  )}
+                  {project.status === PROJECT_STATUS.ON_HOLD && (
+                    <button
+                      onClick={() => handleActivateProject(project.id)}
+                      className="p-1.5 text-gray-400 hover:text-green-600 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 rounded"
+                      aria-label="Activate project"
+                      title="Activate project"
+                    >
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                      </svg>
+                    </button>
+                  )}
+                  {/* Delete button */}
+                  <button
+                    onClick={() => handleOpenDeleteDialog(project)}
+                    className="p-1.5 text-gray-400 hover:text-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 rounded"
+                    aria-label="Delete project"
+                    title="Delete project"
+                  >
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Create Modal */}
+      {isCreateModalOpen && (
+        <div className="fixed inset-0 z-50 overflow-y-auto">
+          <div className="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+            {/* Backdrop */}
+            <div
+              className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+              onClick={handleCloseModals}
+              aria-hidden="true"
+            />
+
+            {/* Modal */}
+            <div
+              role="dialog"
+              aria-modal="true"
+              className="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6"
+            >
+              <div>
+                <h3 className="text-lg font-medium text-gray-900 mb-4">
+                  Create New Project
+                </h3>
+
+                <div className="space-y-4">
+                  {/* Title Input */}
+                  <div>
+                    <label htmlFor="project-title" className="block text-sm font-medium text-gray-700">
+                      Title
+                    </label>
+                    <input
+                      type="text"
+                      id="project-title"
+                      value={formData.title}
+                      onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+                      placeholder="Project title"
+                      className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                    />
+                  </div>
+
+                  {/* Outcome Input */}
+                  <div>
+                    <label htmlFor="project-outcome" className="block text-sm font-medium text-gray-700">
+                      Outcome
+                    </label>
+                    <textarea
+                      id="project-outcome"
+                      value={formData.outcome}
+                      onChange={(e) => setFormData({ ...formData, outcome: e.target.value })}
+                      placeholder="What does success look like? (optional)"
+                      rows={3}
+                      className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                    />
+                    <p className="mt-1 text-xs text-gray-500">
+                      Define what success looks like for this project (FR-019)
+                    </p>
+                  </div>
+
+                  {/* Form Error */}
+                  {formError && (
+                    <p className="text-sm text-red-600">{formError}</p>
+                  )}
+                </div>
+
+                {/* Modal Actions */}
+                <div className="mt-5 sm:mt-6 flex gap-3 justify-end">
+                  <button
+                    type="button"
+                    onClick={handleCloseModals}
+                    className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleCreateProject}
+                    className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                  >
+                    Create
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Confirmation Dialog */}
+      {isDeleteDialogOpen && selectedProject && (
+        <div className="fixed inset-0 z-50 overflow-y-auto">
+          <div className="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+            {/* Backdrop */}
+            <div
+              className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+              onClick={handleCloseModals}
+              aria-hidden="true"
+            />
+
+            {/* Dialog */}
+            <div
+              role="dialog"
+              aria-modal="true"
+              className="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6"
+            >
+              <div>
+                <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100">
+                  <svg className="h-6 w-6 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                  </svg>
+                </div>
+                <div className="mt-3 text-center sm:mt-5">
+                  <h3 className="text-lg font-medium text-gray-900">Delete Project</h3>
+                  <div className="mt-2">
+                    <p className="text-sm text-gray-500">
+                      Are you sure you want to delete <strong>{selectedProject.title}</strong>? This action cannot be undone. All tasks associated with this project will remain but be unlinked.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Dialog Actions */}
+              <div className="mt-5 sm:mt-6 flex gap-3 justify-center">
+                <button
+                  type="button"
+                  onClick={handleCloseModals}
+                  className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={handleDeleteProject}
+                  className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+                >
+                  Confirm
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProjectsPage;

--- a/web/src/pages/ProjectsPage.jsx
+++ b/web/src/pages/ProjectsPage.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link } from 'react-router-dom';
 import {
   fetchProjects,
   createProject,
@@ -12,9 +11,9 @@ import {
   selectProjectsLoading,
   selectProjectsError,
   clearError,
-  PROJECT_STATUS,
 } from '../features/projects/projectsSlice';
 import Spinner from '../components/Spinner';
+import ProjectCard from '../components/ProjectCard';
 
 const ProjectsPage = () => {
   const dispatch = useDispatch();
@@ -126,40 +125,6 @@ const ProjectsPage = () => {
     }
   };
 
-  const getStatusBadgeClasses = (status) => {
-    switch (status) {
-      case PROJECT_STATUS.ACTIVE:
-        return 'bg-green-100 text-green-800';
-      case PROJECT_STATUS.ON_HOLD:
-        return 'bg-yellow-100 text-yellow-800';
-      case PROJECT_STATUS.COMPLETED:
-        return 'bg-blue-100 text-blue-800';
-      case PROJECT_STATUS.CANCELLED:
-        return 'bg-gray-100 text-gray-800';
-      default:
-        return 'bg-gray-100 text-gray-800';
-    }
-  };
-
-  const getStatusLabel = (status) => {
-    switch (status) {
-      case PROJECT_STATUS.ACTIVE:
-        return 'Active';
-      case PROJECT_STATUS.ON_HOLD:
-        return 'On Hold';
-      case PROJECT_STATUS.COMPLETED:
-        return 'Completed';
-      case PROJECT_STATUS.CANCELLED:
-        return 'Cancelled';
-      default:
-        return status;
-    }
-  };
-
-  const needsAttention = (project) => {
-    return project.status === PROJECT_STATUS.ACTIVE && project.has_next_action === false;
-  };
-
   return (
     <div className="max-w-4xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
       {/* Header */}
@@ -254,92 +219,14 @@ const ProjectsPage = () => {
       {filteredProjects.length > 0 && (
         <div className="bg-white shadow rounded-lg divide-y divide-gray-200">
           {filteredProjects.map((project) => (
-            <div
+            <ProjectCard
               key={project.id}
-              className={`p-4 ${needsAttention(project) ? 'bg-yellow-50 border-l-4 border-yellow-400' : ''}`}
-            >
-              <div className="flex items-start justify-between">
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <Link
-                      to={`/projects/${project.id}`}
-                      className="text-sm font-medium text-blue-600 hover:text-blue-800 truncate"
-                      aria-label={project.title}
-                    >
-                      {project.title}
-                    </Link>
-                    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getStatusBadgeClasses(project.status)}`}>
-                      {getStatusLabel(project.status)}
-                    </span>
-                    {needsAttention(project) && (
-                      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-orange-100 text-orange-800">
-                        Needs attention
-                      </span>
-                    )}
-                  </div>
-                  {project.outcome && (
-                    <p className="mt-1 text-sm text-gray-500 truncate">{project.outcome}</p>
-                  )}
-                  <div className="mt-1 flex items-center gap-4 text-xs text-gray-400">
-                    <span>{project.task_count} tasks</span>
-                    {project.next_action_count > 0 && (
-                      <span>{project.next_action_count} next actions</span>
-                    )}
-                  </div>
-                </div>
-                <div className="flex items-center gap-1 ml-4">
-                  {/* Status transition buttons */}
-                  {project.status === PROJECT_STATUS.ACTIVE && (
-                    <>
-                      <button
-                        onClick={() => handleCompleteProject(project.id)}
-                        className="p-1.5 text-gray-400 hover:text-green-600 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 rounded"
-                        aria-label="Complete project"
-                        title="Complete project"
-                      >
-                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                        </svg>
-                      </button>
-                      <button
-                        onClick={() => handleHoldProject(project.id)}
-                        className="p-1.5 text-gray-400 hover:text-yellow-600 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:ring-offset-2 rounded"
-                        aria-label="Put project on hold"
-                        title="Put on hold"
-                      >
-                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                        </svg>
-                      </button>
-                    </>
-                  )}
-                  {project.status === PROJECT_STATUS.ON_HOLD && (
-                    <button
-                      onClick={() => handleActivateProject(project.id)}
-                      className="p-1.5 text-gray-400 hover:text-green-600 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 rounded"
-                      aria-label="Activate project"
-                      title="Activate project"
-                    >
-                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                      </svg>
-                    </button>
-                  )}
-                  {/* Delete button */}
-                  <button
-                    onClick={() => handleOpenDeleteDialog(project)}
-                    className="p-1.5 text-gray-400 hover:text-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 rounded"
-                    aria-label="Delete project"
-                    title="Delete project"
-                  >
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-            </div>
+              project={project}
+              onComplete={handleCompleteProject}
+              onHold={handleHoldProject}
+              onActivate={handleActivateProject}
+              onDelete={handleOpenDeleteDialog}
+            />
           ))}
         </div>
       )}

--- a/web/src/services/api.js
+++ b/web/src/services/api.js
@@ -138,6 +138,13 @@ export const projectsAPI = {
   create: (data) => apiClient.post('/projects', data),
   update: (id, data) => apiClient.patch(`/projects/${id}`, data),
   delete: (id) => apiClient.delete(`/projects/${id}`),
+  // Status transitions
+  complete: (id) => apiClient.post(`/projects/${id}/complete`),
+  hold: (id) => apiClient.post(`/projects/${id}/hold`),
+  activate: (id) => apiClient.post(`/projects/${id}/activate`),
+  // GTD-specific
+  getNeedingAttention: () => apiClient.get('/projects/needing-attention'),
+  getDueForReview: () => apiClient.get('/projects/due-for-review'),
 };
 
 // Contexts API endpoints

--- a/web/src/services/api.js
+++ b/web/src/services/api.js
@@ -128,7 +128,7 @@ export const tasksAPI = {
 
     // 2. Link the original task to the new project and mark as next action
     await apiClient.patch(`/tasks/${taskId}/clarify`, {
-      status: 'next_action',
+      target_status: 'next_action',
       project_id: project.id,
     });
 

--- a/web/src/services/api.js
+++ b/web/src/services/api.js
@@ -120,14 +120,19 @@ export const tasksAPI = {
     });
   },
   setContexts: (id, contextIds) => apiClient.put(`/tasks/${id}/contexts`, { context_ids: contextIds }),
-  // Convert task to project (not yet implemented in backend)
-  convertToProject: () => {
-    const error = new Error('Convert to project is not yet implemented');
-    error.response = {
-      data: { message: error.message, code: 'NOT_IMPLEMENTED' },
-      status: 501
-    };
-    return Promise.reject(error);
+  // Convert task to project: creates a project and links the task to it
+  convertToProject: async (taskId, projectData) => {
+    // 1. Create the project
+    const projectResponse = await apiClient.post('/projects', projectData);
+    const project = projectResponse.data.project;
+
+    // 2. Link the original task to the new project and mark as next action
+    await apiClient.patch(`/tasks/${taskId}/clarify`, {
+      status: 'next_action',
+      project_id: project.id,
+    });
+
+    return { data: { project, taskId } };
   },
 };
 

--- a/web/src/store/store.js
+++ b/web/src/store/store.js
@@ -4,6 +4,7 @@ import accountReducer from '../features/account/accountSlice';
 import inboxReducer from '../features/inbox/inboxSlice';
 import tasksReducer from '../features/tasks/tasksSlice';
 import contextsReducer from '../features/contexts/contextsSlice';
+import projectsReducer from '../features/projects/projectsSlice';
 
 export const store = configureStore({
   reducer: {
@@ -12,6 +13,7 @@ export const store = configureStore({
     inbox: inboxReducer,
     tasks: tasksReducer,
     contexts: contextsReducer,
+    projects: projectsReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({

--- a/web/src/tests/e2e/projects.spec.jsx
+++ b/web/src/tests/e2e/projects.spec.jsx
@@ -1,0 +1,746 @@
+/**
+ * E2E Tests for Project Management (P5.3)
+ *
+ * Tests the Project Management features:
+ * - Projects list page
+ * - Project detail page
+ * - Project creation
+ * - Project editing
+ * - Project status transitions (complete, hold, activate)
+ * - Project deletion
+ * - Projects needing attention
+ * - Navigation between list and detail
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { configureStore } from '@reduxjs/toolkit';
+import ProjectsPage from '../../pages/ProjectsPage';
+import ProjectDetailPage from '../../pages/ProjectDetailPage';
+import Navigation from '../../components/Navigation';
+import projectsReducer from '../../features/projects/projectsSlice';
+import authReducer from '../../features/auth/authSlice';
+import accountReducer from '../../features/account/accountSlice';
+
+// Mock projects for different states
+const mockActiveProject = {
+  id: 'proj-1',
+  title: 'Build new website',
+  outcome: 'Launch company website with all core features',
+  status: 'active',
+  has_next_action: true,
+  task_count: 5,
+  next_action_count: 2,
+  tasks: [
+    {
+      id: 'task-1',
+      title: 'Design homepage mockup',
+      status: 'next_action',
+      is_next_action: true,
+    },
+    {
+      id: 'task-2',
+      title: 'Set up hosting',
+      status: 'active',
+      is_next_action: false,
+    },
+    {
+      id: 'task-3',
+      title: 'Create logo',
+      status: 'completed',
+      is_next_action: false,
+    },
+  ],
+  created_at: '2025-12-01T10:00:00Z',
+  updated_at: '2025-12-01T10:00:00Z',
+};
+
+const mockProjectNeedsAttention = {
+  id: 'proj-2',
+  title: 'Q4 Marketing Campaign',
+  outcome: 'Increase brand awareness by 20%',
+  status: 'active',
+  has_next_action: false,
+  task_count: 3,
+  next_action_count: 0,
+  tasks: [
+    {
+      id: 'task-4',
+      title: 'Completed prep work',
+      status: 'completed',
+      is_next_action: false,
+    },
+  ],
+  created_at: '2025-11-15T10:00:00Z',
+  updated_at: '2025-11-15T10:00:00Z',
+};
+
+const mockOnHoldProject = {
+  id: 'proj-3',
+  title: 'Office Renovation',
+  outcome: 'Modern workspace for team',
+  status: 'on_hold',
+  has_next_action: false,
+  task_count: 2,
+  next_action_count: 0,
+  tasks: [],
+  created_at: '2025-10-01T10:00:00Z',
+  updated_at: '2025-10-01T10:00:00Z',
+};
+
+const mockCompletedProject = {
+  id: 'proj-4',
+  title: 'Employee Handbook',
+  outcome: 'Comprehensive company policies document',
+  status: 'completed',
+  has_next_action: false,
+  task_count: 10,
+  next_action_count: 0,
+  tasks: [],
+  created_at: '2025-09-01T10:00:00Z',
+  updated_at: '2025-09-01T10:00:00Z',
+};
+
+const allMockProjects = [
+  mockActiveProject,
+  mockProjectNeedsAttention,
+  mockOnHoldProject,
+  mockCompletedProject,
+];
+
+// Mock the API module
+vi.mock('../../services/api', () => ({
+  projectsAPI: {
+    getAll: vi.fn(),
+    getById: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    complete: vi.fn(),
+    hold: vi.fn(),
+    activate: vi.fn(),
+  },
+  authAPI: {
+    logout: vi.fn(),
+  },
+  accountAPI: {
+    getProfile: vi.fn().mockResolvedValue({ data: { email: 'test@example.com' } }),
+  },
+  default: {
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+    },
+  },
+}));
+
+import { projectsAPI } from '../../services/api';
+
+// Create a test store with authenticated state
+const createTestStore = (preloadedState = {}) => {
+  return configureStore({
+    reducer: {
+      auth: authReducer,
+      account: accountReducer,
+      projects: projectsReducer,
+    },
+    preloadedState: {
+      auth: {
+        isAuthenticated: true,
+        user: { email: 'test@example.com' },
+        loading: false,
+        error: null,
+      },
+      account: {
+        profile: { email: 'test@example.com' },
+        loading: false,
+        error: null,
+      },
+      projects: {
+        projects: allMockProjects,
+        currentProject: null,
+        loading: false,
+        error: null,
+      },
+      ...preloadedState,
+    },
+  });
+};
+
+const renderWithProviders = (ui, { store = createTestStore(), route = '/' } = {}) => {
+  return {
+    store,
+    user: userEvent.setup(),
+    ...render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[route]}>{ui}</MemoryRouter>
+      </Provider>
+    ),
+  };
+};
+
+describe('Project Management E2E Tests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    projectsAPI.getAll.mockResolvedValue({
+      data: { projects: allMockProjects, count: allMockProjects.length },
+    });
+    projectsAPI.getById.mockImplementation((id) => {
+      const project = allMockProjects.find((p) => p.id === id);
+      if (project) {
+        return Promise.resolve({ data: { project } });
+      }
+      return Promise.reject({ response: { data: { error: 'Project not found' }, status: 404 } });
+    });
+    projectsAPI.create.mockResolvedValue({
+      data: {
+        project: {
+          id: 'proj-new',
+          title: 'New Project',
+          outcome: 'Test outcome',
+          status: 'active',
+          has_next_action: false,
+          task_count: 0,
+          next_action_count: 0,
+          tasks: [],
+        },
+      },
+    });
+    projectsAPI.update.mockResolvedValue({
+      data: { project: { ...mockActiveProject, title: 'Updated Title' } },
+    });
+    projectsAPI.delete.mockResolvedValue({ data: { message: 'Project deleted' } });
+    projectsAPI.complete.mockResolvedValue({
+      data: { project: { ...mockActiveProject, status: 'completed' } },
+    });
+    projectsAPI.hold.mockResolvedValue({
+      data: { project: { ...mockActiveProject, status: 'on_hold' } },
+    });
+    projectsAPI.activate.mockResolvedValue({
+      data: { project: { ...mockOnHoldProject, status: 'active' } },
+    });
+  });
+
+  describe('Projects List Page', () => {
+    it('displays projects list with project details', async () => {
+      renderWithProviders(<ProjectsPage />, { route: '/projects' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Build new website')).toBeInTheDocument();
+        expect(screen.getByText('Q4 Marketing Campaign')).toBeInTheDocument();
+        expect(screen.getByText('Office Renovation')).toBeInTheDocument();
+        expect(screen.getByText('Employee Handbook')).toBeInTheDocument();
+      });
+
+      // Check project count badge
+      expect(screen.getByText('4 projects')).toBeInTheDocument();
+    });
+
+    it('shows project status badges correctly', async () => {
+      renderWithProviders(<ProjectsPage />, { route: '/projects' });
+
+      // Wait for all projects to be rendered first
+      await waitFor(() => {
+        expect(screen.getByText('Build new website')).toBeInTheDocument();
+        expect(screen.getByText('Office Renovation')).toBeInTheDocument();
+        expect(screen.getByText('Employee Handbook')).toBeInTheDocument();
+      });
+
+      // Get the project cards container
+      const projectList = screen.getByText('Build new website').closest('.bg-white');
+
+      // Then check for status badges within the project list
+      // Active status appears multiple times for active projects
+      expect(within(projectList).getAllByText('Active').length).toBeGreaterThanOrEqual(1);
+      expect(within(projectList).getByText('On Hold')).toBeInTheDocument();
+      expect(within(projectList).getByText('Completed')).toBeInTheDocument();
+    });
+
+    it('highlights projects needing attention', async () => {
+      renderWithProviders(<ProjectsPage />, { route: '/projects' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Q4 Marketing Campaign')).toBeInTheDocument();
+        // Needs attention badge should appear
+        expect(screen.getByText('Needs attention')).toBeInTheDocument();
+      });
+    });
+
+    it('filters projects by status', async () => {
+      const { user } = renderWithProviders(<ProjectsPage />, { route: '/projects' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Build new website')).toBeInTheDocument();
+      });
+
+      // Select "On Hold" filter
+      const filterSelect = screen.getByRole('combobox', { name: /filter by status/i });
+      await user.selectOptions(filterSelect, 'on_hold');
+
+      await waitFor(() => {
+        // Should show only on-hold project
+        expect(screen.getByText('Office Renovation')).toBeInTheDocument();
+        // Others should be hidden
+        expect(screen.queryByText('Build new website')).not.toBeInTheDocument();
+        expect(screen.queryByText('Q4 Marketing Campaign')).not.toBeInTheDocument();
+        expect(screen.queryByText('Employee Handbook')).not.toBeInTheDocument();
+      });
+    });
+
+    it('shows empty state when no projects', async () => {
+      projectsAPI.getAll.mockResolvedValue({ data: { projects: [], count: 0 } });
+      const emptyStore = createTestStore({
+        projects: {
+          projects: [],
+          currentProject: null,
+          loading: false,
+          error: null,
+        },
+      });
+
+      renderWithProviders(<ProjectsPage />, { store: emptyStore, route: '/projects' });
+
+      await waitFor(() => {
+        expect(screen.getByText(/no projects yet/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Project Creation', () => {
+    it('creates a new project', async () => {
+      const { user } = renderWithProviders(<ProjectsPage />, { route: '/projects' });
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /new project/i })).toBeInTheDocument();
+      });
+
+      // Click "New Project" button
+      await user.click(screen.getByRole('button', { name: /new project/i }));
+
+      // Modal should open
+      await waitFor(() => {
+        expect(screen.getByText('Create New Project')).toBeInTheDocument();
+      });
+
+      // Fill in the form
+      const titleInput = screen.getByLabelText(/title/i);
+      const outcomeInput = screen.getByLabelText(/outcome/i);
+
+      await user.type(titleInput, 'New Project');
+      await user.type(outcomeInput, 'Test outcome');
+
+      // Submit the form
+      await user.click(screen.getByRole('button', { name: /create/i }));
+
+      await waitFor(() => {
+        expect(projectsAPI.create).toHaveBeenCalledWith({
+          title: 'New Project',
+          outcome: 'Test outcome',
+        });
+      });
+    });
+
+    it('validates required fields on creation', async () => {
+      const { user } = renderWithProviders(<ProjectsPage />, { route: '/projects' });
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /new project/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /new project/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Create New Project')).toBeInTheDocument();
+      });
+
+      // Try to submit without title
+      await user.click(screen.getByRole('button', { name: /create/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/title is required/i)).toBeInTheDocument();
+      });
+
+      // API should not be called
+      expect(projectsAPI.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Project Status Transitions', () => {
+    it('completes a project from the list', async () => {
+      const { user } = renderWithProviders(<ProjectsPage />, { route: '/projects' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Build new website')).toBeInTheDocument();
+      });
+
+      // Click complete button
+      const completeButtons = screen.getAllByRole('button', { name: /complete project/i });
+      await user.click(completeButtons[0]);
+
+      await waitFor(() => {
+        expect(projectsAPI.complete).toHaveBeenCalledWith('proj-1');
+      });
+    });
+
+    it('puts a project on hold from the list', async () => {
+      const { user } = renderWithProviders(<ProjectsPage />, { route: '/projects' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Build new website')).toBeInTheDocument();
+      });
+
+      // Click hold button
+      const holdButtons = screen.getAllByRole('button', { name: /put.*on hold/i });
+      await user.click(holdButtons[0]);
+
+      await waitFor(() => {
+        expect(projectsAPI.hold).toHaveBeenCalledWith('proj-1');
+      });
+    });
+
+    it('activates an on-hold project from the list', async () => {
+      const { user } = renderWithProviders(<ProjectsPage />, { route: '/projects' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Office Renovation')).toBeInTheDocument();
+      });
+
+      // Click activate button
+      const activateButton = screen.getByRole('button', { name: /activate project/i });
+      await user.click(activateButton);
+
+      await waitFor(() => {
+        expect(projectsAPI.activate).toHaveBeenCalledWith('proj-3');
+      });
+    });
+  });
+
+  describe('Project Deletion', () => {
+    it('deletes a project with confirmation', async () => {
+      const { user } = renderWithProviders(<ProjectsPage />, { route: '/projects' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Build new website')).toBeInTheDocument();
+      });
+
+      // Click delete button
+      const deleteButtons = screen.getAllByRole('button', { name: /delete project/i });
+      await user.click(deleteButtons[0]);
+
+      // Confirmation dialog should appear
+      await waitFor(() => {
+        expect(screen.getByText(/are you sure/i)).toBeInTheDocument();
+      });
+
+      // Confirm deletion
+      await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+      await waitFor(() => {
+        expect(projectsAPI.delete).toHaveBeenCalledWith('proj-1');
+      });
+    });
+
+    it('cancels project deletion', async () => {
+      const { user } = renderWithProviders(<ProjectsPage />, { route: '/projects' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Build new website')).toBeInTheDocument();
+      });
+
+      // Click delete button
+      const deleteButtons = screen.getAllByRole('button', { name: /delete project/i });
+      await user.click(deleteButtons[0]);
+
+      // Confirmation dialog should appear
+      await waitFor(() => {
+        expect(screen.getByText(/are you sure/i)).toBeInTheDocument();
+      });
+
+      // Cancel deletion
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+      await waitFor(() => {
+        // Dialog should close
+        expect(screen.queryByText(/are you sure/i)).not.toBeInTheDocument();
+      });
+
+      // API should not be called
+      expect(projectsAPI.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Project Detail Page', () => {
+    it('displays project title and outcome', async () => {
+      const store = createTestStore({
+        projects: {
+          projects: allMockProjects,
+          currentProject: mockActiveProject,
+          loading: false,
+          error: null,
+        },
+      });
+
+      renderWithProviders(
+        <Routes>
+          <Route path="/projects/:id" element={<ProjectDetailPage />} />
+        </Routes>,
+        { store, route: '/projects/proj-1' }
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: mockActiveProject.title })).toBeInTheDocument();
+        expect(screen.getByText(mockActiveProject.outcome)).toBeInTheDocument();
+      });
+    });
+
+    it('shows next action prominently', async () => {
+      const store = createTestStore({
+        projects: {
+          projects: allMockProjects,
+          currentProject: mockActiveProject,
+          loading: false,
+          error: null,
+        },
+      });
+
+      renderWithProviders(
+        <Routes>
+          <Route path="/projects/:id" element={<ProjectDetailPage />} />
+        </Routes>,
+        { store, route: '/projects/proj-1' }
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: 'Next Action' })).toBeInTheDocument();
+        expect(screen.getAllByText('Design homepage mockup').length).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    it('renders task list', async () => {
+      const store = createTestStore({
+        projects: {
+          projects: allMockProjects,
+          currentProject: mockActiveProject,
+          loading: false,
+          error: null,
+        },
+      });
+
+      renderWithProviders(
+        <Routes>
+          <Route path="/projects/:id" element={<ProjectDetailPage />} />
+        </Routes>,
+        { store, route: '/projects/proj-1' }
+      );
+
+      await waitFor(() => {
+        expect(screen.getAllByText('Design homepage mockup').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getByText('Set up hosting')).toBeInTheDocument();
+        expect(screen.getByText('Create logo')).toBeInTheDocument();
+      });
+    });
+
+    it('shows needs attention warning when no next action', async () => {
+      const store = createTestStore({
+        projects: {
+          projects: allMockProjects,
+          currentProject: mockProjectNeedsAttention,
+          loading: false,
+          error: null,
+        },
+      });
+
+      renderWithProviders(
+        <Routes>
+          <Route path="/projects/:id" element={<ProjectDetailPage />} />
+        </Routes>,
+        { store, route: '/projects/proj-2' }
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /needs attention/i })).toBeInTheDocument();
+      });
+    });
+
+    it('handles project not found', async () => {
+      projectsAPI.getById.mockRejectedValue({
+        response: { data: { error: 'Project not found' }, status: 404 },
+      });
+
+      const store = createTestStore({
+        projects: {
+          projects: [],
+          currentProject: null,
+          loading: false,
+          error: 'Project not found',
+        },
+      });
+
+      renderWithProviders(
+        <Routes>
+          <Route path="/projects/:id" element={<ProjectDetailPage />} />
+        </Routes>,
+        { store, route: '/projects/non-existent' }
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /project not found/i })).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Project Edit Functionality', () => {
+    it('shows edit project modal', async () => {
+      const store = createTestStore({
+        projects: {
+          projects: allMockProjects,
+          currentProject: mockActiveProject,
+          loading: false,
+          error: null,
+        },
+      });
+
+      const { user } = renderWithProviders(
+        <Routes>
+          <Route path="/projects/:id" element={<ProjectDetailPage />} />
+        </Routes>,
+        { store, route: '/projects/proj-1' }
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /edit/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Edit Project')).toBeInTheDocument();
+        expect(screen.getByLabelText(/title/i)).toHaveValue(mockActiveProject.title);
+      });
+    });
+
+    it('updates project title and outcome', async () => {
+      const store = createTestStore({
+        projects: {
+          projects: allMockProjects,
+          currentProject: mockActiveProject,
+          loading: false,
+          error: null,
+        },
+      });
+
+      const { user } = renderWithProviders(
+        <Routes>
+          <Route path="/projects/:id" element={<ProjectDetailPage />} />
+        </Routes>,
+        { store, route: '/projects/proj-1' }
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /edit/i }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+      });
+
+      const titleInput = screen.getByLabelText(/title/i);
+      await user.clear(titleInput);
+      await user.type(titleInput, 'Updated Title');
+
+      await user.click(screen.getByRole('button', { name: /save/i }));
+
+      await waitFor(() => {
+        expect(projectsAPI.update).toHaveBeenCalledWith(
+          'proj-1',
+          expect.objectContaining({ title: 'Updated Title' })
+        );
+      });
+    });
+  });
+
+  describe('Navigation Between List and Detail', () => {
+    const AppWithRoutes = () => (
+      <>
+        <Navigation />
+        <Routes>
+          <Route path="/projects" element={<ProjectsPage />} />
+          <Route path="/projects/:id" element={<ProjectDetailPage />} />
+        </Routes>
+      </>
+    );
+
+    it('navigates from list to detail page', async () => {
+      const store = createTestStore();
+      projectsAPI.getById.mockResolvedValue({ data: { project: mockActiveProject } });
+
+      const { user } = renderWithProviders(<AppWithRoutes />, { store, route: '/projects' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Build new website')).toBeInTheDocument();
+      });
+
+      // Click on project title to navigate to detail
+      const projectLink = screen.getByRole('link', { name: 'Build new website' });
+      await user.click(projectLink);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: 'Build new website' })).toBeInTheDocument();
+      });
+    });
+
+    it('navigates back from detail to list page', async () => {
+      const store = createTestStore({
+        projects: {
+          projects: allMockProjects,
+          currentProject: mockActiveProject,
+          loading: false,
+          error: null,
+        },
+      });
+
+      const { user } = renderWithProviders(<AppWithRoutes />, { store, route: '/projects/proj-1' });
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: 'Build new website' })).toBeInTheDocument();
+      });
+
+      // Click back link
+      const backLink = screen.getByRole('link', { name: /back/i });
+      await user.click(backLink);
+
+      await waitFor(() => {
+        expect(screen.getByText('4 projects')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('displays error message when API fails on list page', async () => {
+      projectsAPI.getAll.mockRejectedValue({
+        response: { data: { message: 'Failed to fetch projects' } },
+      });
+
+      const store = createTestStore({
+        projects: {
+          projects: [],
+          currentProject: null,
+          loading: false,
+          error: 'Failed to fetch projects',
+        },
+      });
+
+      renderWithProviders(<ProjectsPage />, { store, route: '/projects' });
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+        expect(screen.getByText(/failed to fetch projects/i)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/web/src/tests/unit/components/Navigation.test.jsx
+++ b/web/src/tests/unit/components/Navigation.test.jsx
@@ -236,5 +236,13 @@ describe('Navigation', () => {
       expect(contextsLink).toBeInTheDocument();
       expect(contextsLink).toHaveAttribute('href', '/contexts');
     });
+
+    it('renders Projects link', () => {
+      const store = createStore({ user: { email: 'test@example.com' } });
+      renderNavigation(store);
+      const projectsLink = screen.getByRole('link', { name: /projects/i });
+      expect(projectsLink).toBeInTheDocument();
+      expect(projectsLink).toHaveAttribute('href', '/projects');
+    });
   });
 });

--- a/web/src/tests/unit/components/ProjectCard.test.jsx
+++ b/web/src/tests/unit/components/ProjectCard.test.jsx
@@ -1,0 +1,231 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import ProjectCard from '../../../components/ProjectCard';
+
+// Mock useNavigate
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe('ProjectCard', () => {
+  const mockProject = {
+    id: 'proj-1',
+    title: 'Test Project',
+    outcome: 'Achieve something great',
+    status: 'active',
+    has_next_action: true,
+    task_count: 5,
+    next_action_count: 2,
+  };
+
+  const mockProjectNoNextAction = {
+    id: 'proj-2',
+    title: 'Project Needs Attention',
+    outcome: 'Need to define next action',
+    status: 'active',
+    has_next_action: false,
+    task_count: 2,
+    next_action_count: 0,
+  };
+
+  const mockCompletedProject = {
+    id: 'proj-3',
+    title: 'Completed Project',
+    outcome: 'We did it!',
+    status: 'completed',
+    has_next_action: false,
+    task_count: 3,
+    next_action_count: 0,
+  };
+
+  const mockOnHoldProject = {
+    id: 'proj-4',
+    title: 'On Hold Project',
+    outcome: 'Waiting for something',
+    status: 'on_hold',
+    has_next_action: false,
+    task_count: 1,
+    next_action_count: 0,
+  };
+
+  const defaultHandlers = {
+    onComplete: vi.fn(),
+    onHold: vi.fn(),
+    onActivate: vi.fn(),
+    onDelete: vi.fn(),
+  };
+
+  const renderCard = (project = mockProject, handlers = defaultHandlers) => {
+    return render(
+      <MemoryRouter>
+        <ProjectCard project={project} {...handlers} />
+      </MemoryRouter>
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('should display project title', () => {
+      renderCard();
+      expect(screen.getByText(mockProject.title)).toBeInTheDocument();
+    });
+
+    it('should display project title as link to detail page', () => {
+      renderCard();
+      const link = screen.getByRole('link', { name: mockProject.title });
+      expect(link).toHaveAttribute('href', `/projects/${mockProject.id}`);
+    });
+
+    it('should display project outcome if provided', () => {
+      renderCard();
+      expect(screen.getByText(mockProject.outcome)).toBeInTheDocument();
+    });
+
+    it('should not display outcome section if not provided', () => {
+      const projectWithoutOutcome = { ...mockProject, outcome: null };
+      renderCard(projectWithoutOutcome);
+      expect(screen.queryByText(mockProject.outcome)).not.toBeInTheDocument();
+    });
+
+    it('should show task count', () => {
+      renderCard();
+      expect(screen.getByText(/5 tasks/i)).toBeInTheDocument();
+    });
+
+    it('should show next action count when present', () => {
+      renderCard();
+      expect(screen.getByText(/2 next actions/i)).toBeInTheDocument();
+    });
+
+    it('should not show next action count when zero', () => {
+      renderCard(mockProjectNoNextAction);
+      expect(screen.queryByText(/next actions/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('status badge', () => {
+    it('should show Active status badge for active projects', () => {
+      renderCard();
+      expect(screen.getByText('Active')).toBeInTheDocument();
+    });
+
+    it('should show On Hold status badge for on-hold projects', () => {
+      renderCard(mockOnHoldProject);
+      expect(screen.getByText('On Hold')).toBeInTheDocument();
+    });
+
+    it('should show Completed status badge for completed projects', () => {
+      renderCard(mockCompletedProject);
+      expect(screen.getByText('Completed')).toBeInTheDocument();
+    });
+  });
+
+  describe('needs attention indicator', () => {
+    it('should indicate when project needs attention', () => {
+      renderCard(mockProjectNoNextAction);
+      // Use exact text to avoid matching the project title
+      expect(screen.getByText('Needs attention')).toBeInTheDocument();
+    });
+
+    it('should not show needs attention for project with next action', () => {
+      renderCard();
+      expect(screen.queryByText(/needs attention/i)).not.toBeInTheDocument();
+    });
+
+    it('should not show needs attention for completed project', () => {
+      const completedNoNextAction = { ...mockCompletedProject, has_next_action: false };
+      renderCard(completedNoNextAction);
+      expect(screen.queryByText(/needs attention/i)).not.toBeInTheDocument();
+    });
+
+    it('should highlight card when needs attention', () => {
+      const { container } = renderCard(mockProjectNoNextAction);
+      const card = container.firstChild;
+      expect(card).toHaveClass('bg-yellow-50');
+    });
+  });
+
+  describe('quick actions menu', () => {
+    it('should show complete button for active projects', () => {
+      renderCard();
+      expect(screen.getByRole('button', { name: /complete/i })).toBeInTheDocument();
+    });
+
+    it('should show hold button for active projects', () => {
+      renderCard();
+      expect(screen.getByRole('button', { name: /hold/i })).toBeInTheDocument();
+    });
+
+    it('should show activate button for on-hold projects', () => {
+      renderCard(mockOnHoldProject);
+      expect(screen.getByRole('button', { name: /activate/i })).toBeInTheDocument();
+    });
+
+    it('should show delete button', () => {
+      renderCard();
+      expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+    });
+
+    it('should not show complete/hold buttons for completed projects', () => {
+      renderCard(mockCompletedProject);
+      expect(screen.queryByRole('button', { name: /complete/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /hold/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('action handlers', () => {
+    it('should call onComplete when complete button is clicked', async () => {
+      const user = userEvent.setup();
+      renderCard();
+
+      await user.click(screen.getByRole('button', { name: /complete/i }));
+
+      expect(defaultHandlers.onComplete).toHaveBeenCalledWith(mockProject.id);
+    });
+
+    it('should call onHold when hold button is clicked', async () => {
+      const user = userEvent.setup();
+      renderCard();
+
+      await user.click(screen.getByRole('button', { name: /hold/i }));
+
+      expect(defaultHandlers.onHold).toHaveBeenCalledWith(mockProject.id);
+    });
+
+    it('should call onActivate when activate button is clicked', async () => {
+      const user = userEvent.setup();
+      renderCard(mockOnHoldProject);
+
+      await user.click(screen.getByRole('button', { name: /activate/i }));
+
+      expect(defaultHandlers.onActivate).toHaveBeenCalledWith(mockOnHoldProject.id);
+    });
+
+    it('should call onDelete when delete button is clicked', async () => {
+      const user = userEvent.setup();
+      renderCard();
+
+      await user.click(screen.getByRole('button', { name: /delete/i }));
+
+      expect(defaultHandlers.onDelete).toHaveBeenCalledWith(mockProject);
+    });
+  });
+
+  describe('navigation', () => {
+    it('should navigate to project detail on title click', async () => {
+      renderCard();
+      const link = screen.getByRole('link', { name: mockProject.title });
+      expect(link).toHaveAttribute('href', `/projects/${mockProject.id}`);
+    });
+  });
+});

--- a/web/src/tests/unit/features/projects/projectsSlice.test.js
+++ b/web/src/tests/unit/features/projects/projectsSlice.test.js
@@ -1,0 +1,491 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { configureStore } from '@reduxjs/toolkit';
+import projectsReducer, {
+  fetchProjects,
+  fetchProjectById,
+  createProject,
+  updateProject,
+  deleteProject,
+  completeProject,
+  holdProject,
+  activateProject,
+  clearError,
+  selectAllProjects,
+  selectActiveProjects,
+  selectProjectsNeedingAttention,
+  selectProjectById,
+  selectProjectsLoading,
+  selectProjectsError,
+  selectCurrentProject,
+  PROJECT_STATUS,
+} from '../../../../features/projects/projectsSlice';
+import { projectsAPI } from '../../../../services/api';
+
+// Mock the API
+vi.mock('../../../../services/api', () => ({
+  projectsAPI: {
+    getAll: vi.fn(),
+    getById: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    complete: vi.fn(),
+    hold: vi.fn(),
+    activate: vi.fn(),
+    getNeedingAttention: vi.fn(),
+  },
+}));
+
+describe('projectsSlice', () => {
+  let store;
+
+  beforeEach(() => {
+    store = configureStore({
+      reducer: { projects: projectsReducer },
+    });
+    vi.clearAllMocks();
+  });
+
+  describe('initial state', () => {
+    it('should have correct initial state', () => {
+      const state = store.getState().projects;
+      expect(state.projects).toEqual([]);
+      expect(state.currentProject).toBeNull();
+      expect(state.loading).toBe(false);
+      expect(state.error).toBeNull();
+    });
+  });
+
+  describe('fetchProjects', () => {
+    const mockProjects = [
+      {
+        id: '1',
+        title: 'Project 1',
+        outcome: 'Complete feature X',
+        status: 'active',
+        has_next_action: true,
+        task_count: 5,
+        next_action_count: 2,
+      },
+      {
+        id: '2',
+        title: 'Project 2',
+        outcome: 'Improve performance',
+        status: 'active',
+        has_next_action: false,
+        task_count: 3,
+        next_action_count: 0,
+      },
+      {
+        id: '3',
+        title: 'Completed Project',
+        outcome: 'Done',
+        status: 'completed',
+        has_next_action: false,
+        task_count: 2,
+        next_action_count: 0,
+      },
+    ];
+
+    it('should set loading to true when pending', async () => {
+      projectsAPI.getAll.mockImplementation(() => new Promise(() => {}));
+      store.dispatch(fetchProjects());
+      expect(store.getState().projects.loading).toBe(true);
+      expect(store.getState().projects.error).toBeNull();
+    });
+
+    it('should update projects when fulfilled', async () => {
+      projectsAPI.getAll.mockResolvedValue({ data: { projects: mockProjects, count: 3 } });
+      await store.dispatch(fetchProjects());
+
+      const state = store.getState().projects;
+      expect(state.loading).toBe(false);
+      expect(state.projects).toEqual(mockProjects);
+      expect(state.error).toBeNull();
+    });
+
+    it('should filter projects by status when provided', async () => {
+      const activeProjects = mockProjects.filter((p) => p.status === 'active');
+      projectsAPI.getAll.mockResolvedValue({ data: { projects: activeProjects, count: 2 } });
+
+      await store.dispatch(fetchProjects({ status: 'active' }));
+
+      const state = store.getState().projects;
+      expect(state.projects).toEqual(activeProjects);
+      expect(projectsAPI.getAll).toHaveBeenCalledWith({ status: 'active' });
+    });
+
+    it('should set error when rejected', async () => {
+      const errorMessage = 'Failed to fetch projects';
+      projectsAPI.getAll.mockRejectedValue({
+        response: { data: { error: errorMessage } },
+      });
+
+      await store.dispatch(fetchProjects());
+
+      const state = store.getState().projects;
+      expect(state.loading).toBe(false);
+      expect(state.error).toBe(errorMessage);
+    });
+
+    it('should handle network error gracefully', async () => {
+      projectsAPI.getAll.mockRejectedValue(new Error('Network error'));
+
+      await store.dispatch(fetchProjects());
+
+      const state = store.getState().projects;
+      expect(state.loading).toBe(false);
+      expect(state.error).toBe('Failed to fetch projects');
+    });
+  });
+
+  describe('fetchProjectById', () => {
+    const mockProject = {
+      id: '1',
+      title: 'Project 1',
+      outcome: 'Complete feature X',
+      status: 'active',
+      has_next_action: true,
+      task_count: 5,
+      next_action_count: 2,
+      tasks: [
+        { id: 't1', title: 'Task 1', status: 'next_action' },
+        { id: 't2', title: 'Task 2', status: 'inbox' },
+      ],
+      next_action: { id: 't1', title: 'Task 1', status: 'next_action' },
+    };
+
+    it('should set loading to true when pending', async () => {
+      projectsAPI.getById.mockImplementation(() => new Promise(() => {}));
+      store.dispatch(fetchProjectById('1'));
+      expect(store.getState().projects.loading).toBe(true);
+    });
+
+    it('should set currentProject when fulfilled', async () => {
+      projectsAPI.getById.mockResolvedValue({ data: { project: mockProject } });
+      await store.dispatch(fetchProjectById('1'));
+
+      const state = store.getState().projects;
+      expect(state.loading).toBe(false);
+      expect(state.currentProject).toEqual(mockProject);
+      expect(state.error).toBeNull();
+    });
+
+    it('should set error when project not found', async () => {
+      projectsAPI.getById.mockRejectedValue({
+        response: { data: { error: 'Project not found', code: 'NOT_FOUND' }, status: 404 },
+      });
+
+      await store.dispatch(fetchProjectById('invalid-id'));
+
+      const state = store.getState().projects;
+      expect(state.loading).toBe(false);
+      expect(state.error).toBe('Project not found');
+      expect(state.currentProject).toBeNull();
+    });
+  });
+
+  describe('createProject', () => {
+    const newProject = {
+      title: 'New Project',
+      outcome: 'Achieve something great',
+    };
+
+    const createdProject = {
+      id: 'new-id',
+      title: 'New Project',
+      outcome: 'Achieve something great',
+      status: 'active',
+      has_next_action: false,
+      task_count: 0,
+      next_action_count: 0,
+    };
+
+    it('should set loading to true when pending', async () => {
+      projectsAPI.create.mockImplementation(() => new Promise(() => {}));
+      store.dispatch(createProject(newProject));
+      expect(store.getState().projects.loading).toBe(true);
+    });
+
+    it('should add new project when fulfilled', async () => {
+      projectsAPI.create.mockResolvedValue({
+        data: { project: createdProject, message: 'Project created successfully' },
+      });
+
+      await store.dispatch(createProject(newProject));
+
+      const state = store.getState().projects;
+      expect(state.loading).toBe(false);
+      expect(state.projects).toContainEqual(createdProject);
+      expect(state.error).toBeNull();
+    });
+
+    it('should set error when creation fails', async () => {
+      projectsAPI.create.mockRejectedValue({
+        response: { data: { error: 'Title is required', code: 'MISSING_TITLE' } },
+      });
+
+      await store.dispatch(createProject({ outcome: 'No title' }));
+
+      const state = store.getState().projects;
+      expect(state.loading).toBe(false);
+      expect(state.error).toBe('Title is required');
+    });
+  });
+
+  describe('updateProject', () => {
+    const existingProjects = [
+      { id: '1', title: 'Project 1', status: 'active', outcome: 'Old outcome' },
+      { id: '2', title: 'Project 2', status: 'active', outcome: null },
+    ];
+
+    const updatedProject = {
+      id: '1',
+      title: 'Updated Project',
+      status: 'active',
+      outcome: 'New outcome',
+    };
+
+    beforeEach(async () => {
+      projectsAPI.getAll.mockResolvedValue({ data: { projects: existingProjects } });
+      await store.dispatch(fetchProjects());
+    });
+
+    it('should update project in state when fulfilled', async () => {
+      projectsAPI.update.mockResolvedValue({
+        data: { project: updatedProject, message: 'Project updated successfully' },
+      });
+
+      await store.dispatch(updateProject({ id: '1', data: { title: 'Updated Project', outcome: 'New outcome' } }));
+
+      const state = store.getState().projects;
+      const updated = state.projects.find((p) => p.id === '1');
+      expect(updated.title).toBe('Updated Project');
+      expect(updated.outcome).toBe('New outcome');
+    });
+
+    it('should set error when update fails', async () => {
+      projectsAPI.update.mockRejectedValue({
+        response: { data: { error: 'Title cannot be empty', code: 'INVALID_TITLE' } },
+      });
+
+      await store.dispatch(updateProject({ id: '1', data: { title: '' } }));
+
+      const state = store.getState().projects;
+      expect(state.error).toBe('Title cannot be empty');
+    });
+  });
+
+  describe('deleteProject', () => {
+    const existingProjects = [
+      { id: '1', title: 'Project 1', status: 'active' },
+      { id: '2', title: 'Project 2', status: 'active' },
+    ];
+
+    beforeEach(async () => {
+      projectsAPI.getAll.mockResolvedValue({ data: { projects: existingProjects } });
+      await store.dispatch(fetchProjects());
+    });
+
+    it('should remove project from state when fulfilled', async () => {
+      projectsAPI.delete.mockResolvedValue({ data: { message: 'Project deleted successfully' } });
+
+      await store.dispatch(deleteProject('2'));
+
+      const state = store.getState().projects;
+      expect(state.projects).not.toContainEqual(expect.objectContaining({ id: '2' }));
+      expect(state.projects).toHaveLength(1);
+    });
+
+    it('should set error when delete fails', async () => {
+      projectsAPI.delete.mockRejectedValue({
+        response: { data: { error: 'Cannot delete project with active tasks', code: 'HAS_ACTIVE_TASKS' } },
+      });
+
+      await store.dispatch(deleteProject('1'));
+
+      const state = store.getState().projects;
+      expect(state.error).toBe('Cannot delete project with active tasks');
+      expect(state.projects).toHaveLength(2);
+    });
+  });
+
+  describe('completeProject', () => {
+    const existingProjects = [
+      { id: '1', title: 'Project 1', status: 'active' },
+    ];
+
+    const completedProject = {
+      id: '1',
+      title: 'Project 1',
+      status: 'completed',
+      completed_at: '2025-12-03T10:00:00Z',
+    };
+
+    beforeEach(async () => {
+      projectsAPI.getAll.mockResolvedValue({ data: { projects: existingProjects } });
+      await store.dispatch(fetchProjects());
+    });
+
+    it('should update project status to completed when fulfilled', async () => {
+      projectsAPI.complete.mockResolvedValue({
+        data: { project: completedProject, message: 'Project completed' },
+      });
+
+      await store.dispatch(completeProject('1'));
+
+      const state = store.getState().projects;
+      const project = state.projects.find((p) => p.id === '1');
+      expect(project.status).toBe('completed');
+    });
+
+    it('should set error when complete fails', async () => {
+      projectsAPI.complete.mockRejectedValue({
+        response: { data: { error: 'Invalid status transition', code: 'INVALID_TRANSITION' } },
+      });
+
+      await store.dispatch(completeProject('1'));
+
+      const state = store.getState().projects;
+      expect(state.error).toBe('Invalid status transition');
+    });
+  });
+
+  describe('holdProject', () => {
+    const existingProjects = [
+      { id: '1', title: 'Project 1', status: 'active' },
+    ];
+
+    const heldProject = {
+      id: '1',
+      title: 'Project 1',
+      status: 'on_hold',
+    };
+
+    beforeEach(async () => {
+      projectsAPI.getAll.mockResolvedValue({ data: { projects: existingProjects } });
+      await store.dispatch(fetchProjects());
+    });
+
+    it('should update project status to on_hold when fulfilled', async () => {
+      projectsAPI.hold.mockResolvedValue({
+        data: { project: heldProject, message: 'Project put on hold' },
+      });
+
+      await store.dispatch(holdProject('1'));
+
+      const state = store.getState().projects;
+      const project = state.projects.find((p) => p.id === '1');
+      expect(project.status).toBe('on_hold');
+    });
+  });
+
+  describe('activateProject', () => {
+    const existingProjects = [
+      { id: '1', title: 'Project 1', status: 'on_hold' },
+    ];
+
+    const activatedProject = {
+      id: '1',
+      title: 'Project 1',
+      status: 'active',
+    };
+
+    beforeEach(async () => {
+      projectsAPI.getAll.mockResolvedValue({ data: { projects: existingProjects } });
+      await store.dispatch(fetchProjects());
+    });
+
+    it('should update project status to active when fulfilled', async () => {
+      projectsAPI.activate.mockResolvedValue({
+        data: { project: activatedProject, message: 'Project activated' },
+      });
+
+      await store.dispatch(activateProject('1'));
+
+      const state = store.getState().projects;
+      const project = state.projects.find((p) => p.id === '1');
+      expect(project.status).toBe('active');
+    });
+  });
+
+  describe('clearError reducer', () => {
+    it('should clear the error state', async () => {
+      projectsAPI.getAll.mockRejectedValue({
+        response: { data: { error: 'Some error' } },
+      });
+      await store.dispatch(fetchProjects());
+      expect(store.getState().projects.error).toBe('Some error');
+
+      store.dispatch(clearError());
+      expect(store.getState().projects.error).toBeNull();
+    });
+  });
+
+  describe('selectors', () => {
+    const mockState = {
+      projects: {
+        projects: [
+          { id: '1', title: 'Active 1', status: 'active', has_next_action: true },
+          { id: '2', title: 'Active 2', status: 'active', has_next_action: false },
+          { id: '3', title: 'On Hold', status: 'on_hold', has_next_action: false },
+          { id: '4', title: 'Completed', status: 'completed', has_next_action: false },
+        ],
+        currentProject: { id: '1', title: 'Active 1', status: 'active' },
+        loading: false,
+        error: null,
+      },
+    };
+
+    it('selectAllProjects returns all projects', () => {
+      const result = selectAllProjects(mockState);
+      expect(result).toHaveLength(4);
+    });
+
+    it('selectActiveProjects returns only active projects', () => {
+      const result = selectActiveProjects(mockState);
+      expect(result).toHaveLength(2);
+      expect(result.every((p) => p.status === 'active')).toBe(true);
+    });
+
+    it('selectProjectsNeedingAttention returns active projects without next action', () => {
+      const result = selectProjectsNeedingAttention(mockState);
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('2');
+      expect(result[0].has_next_action).toBe(false);
+    });
+
+    it('selectProjectById returns project by id', () => {
+      const result = selectProjectById(mockState, '2');
+      expect(result.title).toBe('Active 2');
+    });
+
+    it('selectProjectById returns undefined for non-existent id', () => {
+      const result = selectProjectById(mockState, 'non-existent');
+      expect(result).toBeUndefined();
+    });
+
+    it('selectProjectsLoading returns loading state', () => {
+      expect(selectProjectsLoading({ projects: { loading: true } })).toBe(true);
+      expect(selectProjectsLoading({ projects: { loading: false } })).toBe(false);
+    });
+
+    it('selectProjectsError returns error state', () => {
+      expect(selectProjectsError({ projects: { error: 'Error!' } })).toBe('Error!');
+      expect(selectProjectsError({ projects: { error: null } })).toBeNull();
+    });
+
+    it('selectCurrentProject returns currentProject state', () => {
+      expect(selectCurrentProject(mockState)).toEqual({ id: '1', title: 'Active 1', status: 'active' });
+    });
+  });
+
+  describe('PROJECT_STATUS constants', () => {
+    it('should export correct status constants', () => {
+      expect(PROJECT_STATUS.ACTIVE).toBe('active');
+      expect(PROJECT_STATUS.ON_HOLD).toBe('on_hold');
+      expect(PROJECT_STATUS.COMPLETED).toBe('completed');
+      expect(PROJECT_STATUS.CANCELLED).toBe('cancelled');
+    });
+  });
+});

--- a/web/src/tests/unit/pages/ProjectDetailPage.test.jsx
+++ b/web/src/tests/unit/pages/ProjectDetailPage.test.jsx
@@ -1,0 +1,571 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import projectsReducer from '../../../features/projects/projectsSlice';
+import ProjectDetailPage from '../../../pages/ProjectDetailPage';
+
+// Mock the API module
+vi.mock('../../../services/api', () => ({
+  projectsAPI: {
+    getAll: vi.fn(),
+    getById: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    complete: vi.fn(),
+    hold: vi.fn(),
+    activate: vi.fn(),
+  },
+}));
+
+// Mock react-router-dom's useNavigate
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+import { projectsAPI } from '../../../services/api';
+
+describe('ProjectDetailPage', () => {
+  const mockProject = {
+    id: 'proj-1',
+    title: 'Test Project',
+    outcome: 'Achieve something great',
+    status: 'active',
+    has_next_action: true,
+    task_count: 5,
+    next_action_count: 2,
+    tasks: [
+      {
+        id: 'task-1',
+        title: 'First task',
+        status: 'next_action',
+        is_next_action: true,
+      },
+      {
+        id: 'task-2',
+        title: 'Second task',
+        status: 'active',
+        is_next_action: false,
+      },
+      {
+        id: 'task-3',
+        title: 'Third task',
+        status: 'completed',
+        is_next_action: false,
+      },
+    ],
+  };
+
+  const mockProjectNoNextAction = {
+    id: 'proj-2',
+    title: 'Project Without Next Action',
+    outcome: 'Need to define next action',
+    status: 'active',
+    has_next_action: false,
+    task_count: 2,
+    next_action_count: 0,
+    tasks: [
+      {
+        id: 'task-4',
+        title: 'Completed task',
+        status: 'completed',
+        is_next_action: false,
+      },
+    ],
+  };
+
+  const mockCompletedProject = {
+    id: 'proj-3',
+    title: 'Completed Project',
+    outcome: 'We did it!',
+    status: 'completed',
+    has_next_action: false,
+    task_count: 3,
+    next_action_count: 0,
+    tasks: [],
+  };
+
+  const mockOnHoldProject = {
+    id: 'proj-4',
+    title: 'On Hold Project',
+    outcome: 'Waiting for something',
+    status: 'on_hold',
+    has_next_action: false,
+    task_count: 1,
+    next_action_count: 0,
+    tasks: [],
+  };
+
+  const createStore = (projectsState = {}) => {
+    return configureStore({
+      reducer: {
+        projects: projectsReducer,
+      },
+      preloadedState: {
+        projects: {
+          projects: [],
+          currentProject: null,
+          loading: false,
+          error: null,
+          ...projectsState,
+        },
+      },
+    });
+  };
+
+  const renderPage = (store, projectId = 'proj-1') => {
+    return render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[`/projects/${projectId}`]}>
+          <Routes>
+            <Route path="/projects/:id" element={<ProjectDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNavigate.mockClear();
+    projectsAPI.getById.mockResolvedValue({
+      data: { project: mockProject },
+    });
+    projectsAPI.update.mockResolvedValue({
+      data: { project: { ...mockProject, title: 'Updated Title' } },
+    });
+    projectsAPI.complete.mockResolvedValue({
+      data: { project: { ...mockProject, status: 'completed' } },
+    });
+    projectsAPI.hold.mockResolvedValue({
+      data: { project: { ...mockProject, status: 'on_hold' } },
+    });
+    projectsAPI.activate.mockResolvedValue({
+      data: { project: { ...mockProject, status: 'active' } },
+    });
+    projectsAPI.delete.mockResolvedValue({
+      data: { message: 'Project deleted' },
+    });
+  });
+
+  describe('rendering', () => {
+    it('should display project title', async () => {
+      const store = createStore({ currentProject: mockProject });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: mockProject.title })).toBeInTheDocument();
+      });
+    });
+
+    it('should display project outcome', async () => {
+      const store = createStore({ currentProject: mockProject });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText(mockProject.outcome)).toBeInTheDocument();
+      });
+    });
+
+    it('should display project status badge', async () => {
+      const store = createStore({ currentProject: mockProject });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText('Active')).toBeInTheDocument();
+      });
+    });
+
+    it('should show task count', async () => {
+      const store = createStore({ currentProject: mockProject });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText(/5 tasks/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('loading state', () => {
+    it('should show loading spinner while fetching', async () => {
+      const store = createStore({ loading: true, currentProject: null });
+      renderPage(store);
+
+      expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('not found state', () => {
+    it('should handle project not found', async () => {
+      projectsAPI.getById.mockRejectedValue({
+        response: { data: { error: 'Project not found' }, status: 404 },
+      });
+      const store = createStore({ currentProject: null, error: 'Project not found' });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /project not found/i })).toBeInTheDocument();
+      });
+    });
+
+    it('should show back to projects link when not found', async () => {
+      const store = createStore({ currentProject: null, error: 'Project not found' });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('link', { name: /back to projects/i })).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('next action section', () => {
+    it('should show next action prominently', async () => {
+      const store = createStore({ currentProject: mockProject });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: 'Next Action' })).toBeInTheDocument();
+        // First task appears in Next Action section and task list
+        expect(screen.getAllByText('First task').length).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    it('should show needs attention warning when no next action', async () => {
+      const store = createStore({ currentProject: mockProjectNoNextAction });
+      renderPage(store, 'proj-2');
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /needs attention/i })).toBeInTheDocument();
+      });
+    });
+
+    it('should suggest defining next action when missing', async () => {
+      const store = createStore({ currentProject: mockProjectNoNextAction });
+      renderPage(store, 'proj-2');
+
+      await waitFor(() => {
+        // Check for the message in Next Action section
+        expect(screen.getByText(/no next action defined for this project/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('task list', () => {
+    it('should render task list', async () => {
+      const store = createStore({ currentProject: mockProject });
+      renderPage(store);
+
+      await waitFor(() => {
+        // Tasks appear in the tasks list section
+        expect(screen.getAllByText('First task').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getByText('Second task')).toBeInTheDocument();
+        expect(screen.getByText('Third task')).toBeInTheDocument();
+      });
+    });
+
+    it('should show task status indicators', async () => {
+      const store = createStore({ currentProject: mockProject });
+      renderPage(store);
+
+      await waitFor(() => {
+        // Next action task should have indicator
+        const taskElement = screen.getByTestId('task-task-1');
+        expect(taskElement).toBeInTheDocument();
+      });
+    });
+
+    it('should show empty tasks message when no tasks', async () => {
+      const projectWithNoTasks = { ...mockProject, tasks: [], task_count: 0 };
+      const store = createStore({ currentProject: projectWithNoTasks });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText(/no tasks yet/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('status transitions', () => {
+    it('should show complete button for active project', async () => {
+      const store = createStore({ currentProject: mockProject });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /complete/i })).toBeInTheDocument();
+      });
+    });
+
+    it('should show hold button for active project', async () => {
+      const store = createStore({ currentProject: mockProject });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /hold/i })).toBeInTheDocument();
+      });
+    });
+
+    it('should show activate button for on-hold project', async () => {
+      const store = createStore({ currentProject: mockOnHoldProject });
+      renderPage(store, 'proj-4');
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /activate/i })).toBeInTheDocument();
+      });
+    });
+
+    it('should not show transition buttons for completed project', async () => {
+      const store = createStore({ currentProject: mockCompletedProject });
+      renderPage(store, 'proj-3');
+
+      await waitFor(() => {
+        expect(screen.getByText('Completed')).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /complete/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /hold/i })).not.toBeInTheDocument();
+      });
+    });
+
+    it('should complete project when clicking complete button', async () => {
+      const user = userEvent.setup();
+      const store = createStore({ currentProject: mockProject });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /complete/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /complete/i }));
+
+      await waitFor(() => {
+        expect(projectsAPI.complete).toHaveBeenCalledWith('proj-1');
+      });
+    });
+
+    it('should put project on hold when clicking hold button', async () => {
+      const user = userEvent.setup();
+      const store = createStore({ currentProject: mockProject });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /hold/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /hold/i }));
+
+      await waitFor(() => {
+        expect(projectsAPI.hold).toHaveBeenCalledWith('proj-1');
+      });
+    });
+
+    it('should activate project when clicking activate button', async () => {
+      const user = userEvent.setup();
+      projectsAPI.getById.mockResolvedValue({
+        data: { project: mockOnHoldProject },
+      });
+      const store = createStore({ currentProject: mockOnHoldProject });
+      renderPage(store, 'proj-4');
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /activate/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /activate/i }));
+
+      await waitFor(() => {
+        expect(projectsAPI.activate).toHaveBeenCalledWith('proj-4');
+      });
+    });
+  });
+
+  describe('edit functionality', () => {
+    it('should show edit button', async () => {
+      const store = createStore({ currentProject: mockProject });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+      });
+    });
+
+    it('should open edit modal when clicking edit button', async () => {
+      const user = userEvent.setup();
+      const store = createStore({ currentProject: mockProject });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /edit/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+        expect(screen.getByText('Edit Project')).toBeInTheDocument();
+      });
+    });
+
+    it('should pre-fill edit form with project data', async () => {
+      const user = userEvent.setup();
+      const store = createStore({ currentProject: mockProject });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /edit/i }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/title/i)).toHaveValue(mockProject.title);
+        expect(screen.getByLabelText(/outcome/i)).toHaveValue(mockProject.outcome);
+      });
+    });
+
+    it('should update project when saving edits', async () => {
+      const user = userEvent.setup();
+      const store = createStore({ currentProject: mockProject });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /edit/i }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+      });
+
+      const titleInput = screen.getByLabelText(/title/i);
+      await user.clear(titleInput);
+      await user.type(titleInput, 'Updated Title');
+
+      await user.click(screen.getByRole('button', { name: /save/i }));
+
+      await waitFor(() => {
+        expect(projectsAPI.update).toHaveBeenCalledWith(
+          'proj-1',
+          expect.objectContaining({ title: 'Updated Title' })
+        );
+      });
+    });
+
+    it('should close edit modal on cancel', async () => {
+      const user = userEvent.setup();
+      const store = createStore({ currentProject: mockProject });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /edit/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('delete functionality', () => {
+    it('should show delete button', async () => {
+      const store = createStore({ currentProject: mockProject });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+      });
+    });
+
+    it('should show delete confirmation dialog', async () => {
+      const user = userEvent.setup();
+      const store = createStore({ currentProject: mockProject });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /delete/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/are you sure/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should navigate to projects list after successful delete', async () => {
+      const user = userEvent.setup();
+      const store = createStore({ currentProject: mockProject });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /delete/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/are you sure/i)).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+      await waitFor(() => {
+        expect(projectsAPI.delete).toHaveBeenCalledWith('proj-1');
+        expect(mockNavigate).toHaveBeenCalledWith('/projects');
+      });
+    });
+  });
+
+  describe('navigation', () => {
+    it('should show back to projects link', async () => {
+      const store = createStore({ currentProject: mockProject });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('link', { name: /back/i })).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('data fetching', () => {
+    it('should fetch project by id on mount', async () => {
+      const store = createStore();
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(projectsAPI.getById).toHaveBeenCalledWith('proj-1');
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('should display error message', async () => {
+      // Override the default mock to reject and prevent loading a project
+      projectsAPI.getById.mockRejectedValue({
+        response: { data: { error: 'Failed to load project' }, status: 500 },
+      });
+      // When there's an error, the error alert and project not found page shows
+      const store = createStore({ error: 'Failed to load project', currentProject: null });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+        expect(screen.getByText('Failed to load project')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/web/src/tests/unit/pages/ProjectsPage.test.jsx
+++ b/web/src/tests/unit/pages/ProjectsPage.test.jsx
@@ -1,0 +1,694 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
+import projectsReducer from '../../../features/projects/projectsSlice';
+import ProjectsPage from '../../../pages/ProjectsPage';
+
+// Mock the API module
+vi.mock('../../../services/api', () => ({
+  projectsAPI: {
+    getAll: vi.fn(),
+    getById: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    complete: vi.fn(),
+    hold: vi.fn(),
+    activate: vi.fn(),
+  },
+}));
+
+import { projectsAPI } from '../../../services/api';
+
+describe('ProjectsPage', () => {
+  const mockActiveProject = {
+    id: 'proj-1',
+    title: 'Website Redesign',
+    outcome: 'Launch new website with improved UX',
+    status: 'active',
+    has_next_action: true,
+    task_count: 5,
+    next_action_count: 2,
+    position: 0,
+    created_at: '2025-12-01T10:00:00Z',
+    updated_at: '2025-12-03T10:00:00Z',
+  };
+
+  const mockActiveProjectNoNextAction = {
+    id: 'proj-2',
+    title: 'API Integration',
+    outcome: 'Integrate with third-party API',
+    status: 'active',
+    has_next_action: false,
+    task_count: 3,
+    next_action_count: 0,
+    position: 1,
+    created_at: '2025-12-01T11:00:00Z',
+    updated_at: '2025-12-02T10:00:00Z',
+  };
+
+  const mockOnHoldProject = {
+    id: 'proj-3',
+    title: 'Mobile App',
+    outcome: 'Native mobile application',
+    status: 'on_hold',
+    has_next_action: false,
+    task_count: 10,
+    next_action_count: 0,
+    position: 2,
+    created_at: '2025-11-01T10:00:00Z',
+    updated_at: '2025-11-15T10:00:00Z',
+  };
+
+  const mockCompletedProject = {
+    id: 'proj-4',
+    title: 'Documentation',
+    outcome: 'Complete project documentation',
+    status: 'completed',
+    has_next_action: false,
+    task_count: 8,
+    next_action_count: 0,
+    position: 3,
+    completed_at: '2025-12-01T10:00:00Z',
+    created_at: '2025-10-01T10:00:00Z',
+    updated_at: '2025-12-01T10:00:00Z',
+  };
+
+  const createStore = (projectsState = {}) => {
+    return configureStore({
+      reducer: {
+        projects: projectsReducer,
+      },
+      preloadedState: {
+        projects: {
+          projects: [],
+          currentProject: null,
+          loading: false,
+          error: null,
+          ...projectsState,
+        },
+      },
+    });
+  };
+
+  const renderPage = (store) => {
+    return render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <ProjectsPage />
+        </MemoryRouter>
+      </Provider>
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    projectsAPI.getAll.mockResolvedValue({
+      data: { projects: [], count: 0 },
+    });
+    projectsAPI.create.mockResolvedValue({
+      data: { project: mockActiveProject, message: 'Project created successfully' },
+    });
+    projectsAPI.update.mockResolvedValue({
+      data: { project: { ...mockActiveProject, title: 'Updated Title' }, message: 'Project updated successfully' },
+    });
+    projectsAPI.delete.mockResolvedValue({
+      data: { message: 'Project deleted successfully' },
+    });
+    projectsAPI.complete.mockResolvedValue({
+      data: { project: { ...mockActiveProject, status: 'completed' }, message: 'Project completed' },
+    });
+    projectsAPI.hold.mockResolvedValue({
+      data: { project: { ...mockActiveProject, status: 'on_hold' }, message: 'Project put on hold' },
+    });
+    projectsAPI.activate.mockResolvedValue({
+      data: { project: { ...mockOnHoldProject, status: 'active' }, message: 'Project activated' },
+    });
+  });
+
+  describe('rendering', () => {
+    it('renders page title and description', async () => {
+      const store = createStore();
+      renderPage(store);
+
+      expect(screen.getByRole('heading', { name: /projects/i })).toBeInTheDocument();
+      expect(screen.getByText(/manage your multi-step outcomes/i)).toBeInTheDocument();
+    });
+
+    it('renders project count badge', async () => {
+      const store = createStore({
+        projects: [mockActiveProject, mockActiveProjectNoNextAction, mockOnHoldProject],
+      });
+      renderPage(store);
+
+      expect(screen.getByText('3 projects')).toBeInTheDocument();
+    });
+
+    it('renders singular project count', async () => {
+      const store = createStore({
+        projects: [mockActiveProject],
+      });
+      renderPage(store);
+
+      expect(screen.getByText('1 project')).toBeInTheDocument();
+    });
+
+    it('renders create new project button', async () => {
+      const store = createStore();
+      renderPage(store);
+
+      expect(screen.getByRole('button', { name: /new project/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows loading spinner when loading with no projects', async () => {
+      const store = createStore({ loading: true, projects: [] });
+      renderPage(store);
+
+      expect(screen.getByText(/loading projects/i)).toBeInTheDocument();
+    });
+
+    it('does not show loading spinner when projects exist', async () => {
+      const store = createStore({ loading: true, projects: [mockActiveProject] });
+      renderPage(store);
+
+      expect(screen.queryByText(/loading projects/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('empty state', () => {
+    it('shows empty state when no projects and not loading', async () => {
+      projectsAPI.getAll.mockResolvedValue({
+        data: { projects: [], count: 0 },
+      });
+      const store = createStore({ projects: [], loading: false });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText(/no projects yet/i)).toBeInTheDocument();
+      });
+    });
+
+    it('shows helpful message in empty state', async () => {
+      const store = createStore({ projects: [], loading: false });
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByText(/create projects to organize/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('projects list', () => {
+    it('renders project titles', async () => {
+      const store = createStore({
+        projects: [mockActiveProject, mockActiveProjectNoNextAction],
+      });
+      renderPage(store);
+
+      expect(screen.getByText('Website Redesign')).toBeInTheDocument();
+      expect(screen.getByText('API Integration')).toBeInTheDocument();
+    });
+
+    it('shows status badge for each project', async () => {
+      const store = createStore({
+        projects: [mockActiveProject, mockOnHoldProject, mockCompletedProject],
+      });
+      renderPage(store);
+
+      // Use getAllByText since filter dropdown also has these texts
+      const activeBadges = screen.getAllByText('Active');
+      const onHoldBadges = screen.getAllByText('On Hold');
+      const completedBadges = screen.getAllByText('Completed');
+
+      // Should have at least 2 (one in filter, one as badge)
+      expect(activeBadges.length).toBeGreaterThanOrEqual(2);
+      expect(onHoldBadges.length).toBeGreaterThanOrEqual(2);
+      expect(completedBadges.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('shows task count for projects', async () => {
+      const store = createStore({
+        projects: [mockActiveProject],
+      });
+      renderPage(store);
+
+      expect(screen.getByText(/5 tasks/i)).toBeInTheDocument();
+    });
+
+    it('shows outcome when available', async () => {
+      const store = createStore({
+        projects: [mockActiveProject],
+      });
+      renderPage(store);
+
+      expect(screen.getByText('Launch new website with improved UX')).toBeInTheDocument();
+    });
+  });
+
+  describe('status filter', () => {
+    it('renders status filter dropdown', async () => {
+      const store = createStore({
+        projects: [mockActiveProject],
+      });
+      renderPage(store);
+
+      expect(screen.getByRole('combobox', { name: /filter/i })).toBeInTheDocument();
+    });
+
+    it('has all status options', async () => {
+      const store = createStore({
+        projects: [mockActiveProject],
+      });
+      renderPage(store);
+
+      const select = screen.getByRole('combobox', { name: /filter/i });
+      expect(within(select).getByRole('option', { name: /all/i })).toBeInTheDocument();
+      expect(within(select).getByRole('option', { name: /active/i })).toBeInTheDocument();
+      expect(within(select).getByRole('option', { name: /on hold/i })).toBeInTheDocument();
+      expect(within(select).getByRole('option', { name: /completed/i })).toBeInTheDocument();
+    });
+
+    it('filters projects when status is selected', async () => {
+      const user = userEvent.setup();
+      projectsAPI.getAll.mockResolvedValue({
+        data: { projects: [mockActiveProject, mockOnHoldProject, mockCompletedProject], count: 3 },
+      });
+      const store = createStore({
+        projects: [mockActiveProject, mockOnHoldProject, mockCompletedProject],
+      });
+      renderPage(store);
+
+      const select = screen.getByRole('combobox', { name: /filter/i });
+      await user.selectOptions(select, 'active');
+
+      // Active project should be visible
+      expect(screen.getByText('Website Redesign')).toBeInTheDocument();
+      // On hold project should not be visible
+      expect(screen.queryByText('Mobile App')).not.toBeInTheDocument();
+      // Completed project should not be visible
+      expect(screen.queryByText('Documentation')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('needs attention indicator', () => {
+    it('highlights projects without next action', async () => {
+      const store = createStore({
+        projects: [mockActiveProjectNoNextAction],
+      });
+      renderPage(store);
+
+      // Should show warning indicator for project needing attention
+      expect(screen.getByText(/needs attention/i)).toBeInTheDocument();
+    });
+
+    it('does not show warning for projects with next action', async () => {
+      const store = createStore({
+        projects: [mockActiveProject],
+      });
+      renderPage(store);
+
+      // Should not show warning for project with next action
+      expect(screen.queryByText(/needs attention/i)).not.toBeInTheDocument();
+    });
+
+    it('does not show warning for non-active projects', async () => {
+      const store = createStore({
+        projects: [mockOnHoldProject],
+      });
+      renderPage(store);
+
+      // Should not show warning for on-hold project (even without next action)
+      expect(screen.queryByText(/needs attention/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('error handling', () => {
+    it('displays error message when error exists', async () => {
+      projectsAPI.getAll.mockRejectedValue({
+        response: { data: { error: 'Failed to fetch projects' } },
+      });
+      const store = createStore();
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Failed to fetch projects')).toBeInTheDocument();
+    });
+
+    it('allows dismissing error message', async () => {
+      const user = userEvent.setup();
+      projectsAPI.getAll.mockRejectedValue({
+        response: { data: { error: 'Some error' } },
+      });
+      const store = createStore();
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      });
+
+      const alert = screen.getByRole('alert');
+      const closeButton = within(alert).getByRole('button');
+      await user.click(closeButton);
+
+      await waitFor(() => {
+        expect(store.getState().projects.error).toBeNull();
+      });
+    });
+  });
+
+  describe('data fetching', () => {
+    it('fetches projects on mount', async () => {
+      const store = createStore();
+      renderPage(store);
+
+      await waitFor(() => {
+        expect(projectsAPI.getAll).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('create project', () => {
+    it('opens create modal when clicking new project button', async () => {
+      const user = userEvent.setup();
+      const store = createStore();
+      renderPage(store);
+
+      await user.click(screen.getByRole('button', { name: /new project/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Create New Project')).toBeInTheDocument();
+    });
+
+    it('shows title input in create modal', async () => {
+      const user = userEvent.setup();
+      const store = createStore();
+      renderPage(store);
+
+      await user.click(screen.getByRole('button', { name: /new project/i }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+      });
+    });
+
+    it('shows outcome input in create modal', async () => {
+      const user = userEvent.setup();
+      const store = createStore();
+      renderPage(store);
+
+      await user.click(screen.getByRole('button', { name: /new project/i }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/outcome/i)).toBeInTheDocument();
+      });
+    });
+
+    it('validates that title is required', async () => {
+      const user = userEvent.setup();
+      const store = createStore();
+      renderPage(store);
+
+      await user.click(screen.getByRole('button', { name: /new project/i }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+      });
+
+      const submitButton = screen.getByRole('button', { name: /create$/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/title is required/i)).toBeInTheDocument();
+      });
+    });
+
+    it('creates project when form is valid', async () => {
+      const user = userEvent.setup();
+      const store = createStore();
+      renderPage(store);
+
+      await user.click(screen.getByRole('button', { name: /new project/i }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+      });
+
+      const titleInput = screen.getByLabelText(/title/i);
+      await user.type(titleInput, 'New Project');
+
+      const outcomeInput = screen.getByLabelText(/outcome/i);
+      await user.type(outcomeInput, 'Achieve something great');
+
+      const submitButton = screen.getByRole('button', { name: /create$/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(projectsAPI.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'New Project',
+            outcome: 'Achieve something great',
+          })
+        );
+      });
+    });
+
+    it('closes modal after successful creation', async () => {
+      const user = userEvent.setup();
+      const store = createStore();
+      renderPage(store);
+
+      await user.click(screen.getByRole('button', { name: /new project/i }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+      });
+
+      const titleInput = screen.getByLabelText(/title/i);
+      await user.type(titleInput, 'New Project');
+
+      const submitButton = screen.getByRole('button', { name: /create$/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+    });
+
+    it('closes modal on cancel', async () => {
+      const user = userEvent.setup();
+      const store = createStore();
+      renderPage(store);
+
+      await user.click(screen.getByRole('button', { name: /new project/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      const cancelButton = screen.getByRole('button', { name: /cancel/i });
+      await user.click(cancelButton);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('quick actions', () => {
+    it('shows complete button for active projects', async () => {
+      const user = userEvent.setup();
+      projectsAPI.getAll.mockResolvedValue({
+        data: { projects: [mockActiveProject], count: 1 },
+      });
+      const store = createStore({
+        projects: [mockActiveProject],
+      });
+      renderPage(store);
+
+      expect(screen.getByRole('button', { name: /complete/i })).toBeInTheDocument();
+    });
+
+    it('shows hold button for active projects', async () => {
+      const store = createStore({
+        projects: [mockActiveProject],
+      });
+      renderPage(store);
+
+      expect(screen.getByRole('button', { name: /hold/i })).toBeInTheDocument();
+    });
+
+    it('shows activate button for on-hold projects', async () => {
+      const store = createStore({
+        projects: [mockOnHoldProject],
+      });
+      renderPage(store);
+
+      expect(screen.getByRole('button', { name: /activate/i })).toBeInTheDocument();
+    });
+
+    it('completes project when complete button is clicked', async () => {
+      const user = userEvent.setup();
+      projectsAPI.getAll.mockResolvedValue({
+        data: { projects: [mockActiveProject], count: 1 },
+      });
+      const store = createStore({
+        projects: [mockActiveProject],
+      });
+      renderPage(store);
+
+      const completeButton = screen.getByRole('button', { name: /complete/i });
+      await user.click(completeButton);
+
+      await waitFor(() => {
+        expect(projectsAPI.complete).toHaveBeenCalledWith(mockActiveProject.id);
+      });
+    });
+
+    it('puts project on hold when hold button is clicked', async () => {
+      const user = userEvent.setup();
+      projectsAPI.getAll.mockResolvedValue({
+        data: { projects: [mockActiveProject], count: 1 },
+      });
+      const store = createStore({
+        projects: [mockActiveProject],
+      });
+      renderPage(store);
+
+      const holdButton = screen.getByRole('button', { name: /hold/i });
+      await user.click(holdButton);
+
+      await waitFor(() => {
+        expect(projectsAPI.hold).toHaveBeenCalledWith(mockActiveProject.id);
+      });
+    });
+
+    it('activates project when activate button is clicked', async () => {
+      const user = userEvent.setup();
+      projectsAPI.getAll.mockResolvedValue({
+        data: { projects: [mockOnHoldProject], count: 1 },
+      });
+      const store = createStore({
+        projects: [mockOnHoldProject],
+      });
+      renderPage(store);
+
+      const activateButton = screen.getByRole('button', { name: /activate/i });
+      await user.click(activateButton);
+
+      await waitFor(() => {
+        expect(projectsAPI.activate).toHaveBeenCalledWith(mockOnHoldProject.id);
+      });
+    });
+  });
+
+  describe('delete project', () => {
+    it('shows delete button for projects', async () => {
+      const store = createStore({
+        projects: [mockActiveProject],
+      });
+      renderPage(store);
+
+      expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+    });
+
+    it('shows confirmation dialog when clicking delete', async () => {
+      const user = userEvent.setup();
+      projectsAPI.getAll.mockResolvedValue({
+        data: { projects: [mockActiveProject], count: 1 },
+      });
+      const store = createStore({
+        projects: [mockActiveProject],
+      });
+      renderPage(store);
+
+      const deleteButton = screen.getByRole('button', { name: /delete/i });
+      await user.click(deleteButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/are you sure/i)).toBeInTheDocument();
+      });
+    });
+
+    it('deletes project when confirmed', async () => {
+      const user = userEvent.setup();
+      projectsAPI.getAll.mockResolvedValue({
+        data: { projects: [mockActiveProject], count: 1 },
+      });
+      const store = createStore({
+        projects: [mockActiveProject],
+      });
+      renderPage(store);
+
+      const deleteButton = screen.getByRole('button', { name: /delete/i });
+      await user.click(deleteButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/are you sure/i)).toBeInTheDocument();
+      });
+
+      const confirmButton = screen.getByRole('button', { name: /confirm/i });
+      await user.click(confirmButton);
+
+      await waitFor(() => {
+        expect(projectsAPI.delete).toHaveBeenCalledWith(mockActiveProject.id);
+      });
+    });
+
+    it('cancels delete when clicking cancel', async () => {
+      const user = userEvent.setup();
+      projectsAPI.getAll.mockResolvedValue({
+        data: { projects: [mockActiveProject], count: 1 },
+      });
+      const store = createStore({
+        projects: [mockActiveProject],
+      });
+      renderPage(store);
+
+      const deleteButton = screen.getByRole('button', { name: /delete/i });
+      await user.click(deleteButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/are you sure/i)).toBeInTheDocument();
+      });
+
+      const cancelButton = screen.getByRole('button', { name: /cancel/i });
+      await user.click(cancelButton);
+
+      await waitFor(() => {
+        expect(screen.queryByText(/are you sure/i)).not.toBeInTheDocument();
+      });
+      expect(projectsAPI.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('navigation', () => {
+    it('renders project as clickable card', async () => {
+      const store = createStore({
+        projects: [mockActiveProject],
+      });
+      renderPage(store);
+
+      // Project should be rendered with a link to detail page
+      expect(screen.getByRole('link', { name: /website redesign/i })).toBeInTheDocument();
+    });
+
+    it('project card links to detail page', async () => {
+      const store = createStore({
+        projects: [mockActiveProject],
+      });
+      renderPage(store);
+
+      const projectLink = screen.getByRole('link', { name: /website redesign/i });
+      expect(projectLink).toHaveAttribute('href', `/projects/${mockActiveProject.id}`);
+    });
+  });
+});

--- a/web/src/tests/unit/services/api.test.js
+++ b/web/src/tests/unit/services/api.test.js
@@ -235,26 +235,28 @@ describe('api.js', () => {
   });
 
   describe('tasksAPI.convertToProject', () => {
-    it('should reject with not implemented error', async () => {
-      await expect(tasksAPI.convertToProject('task-123', { title: 'Project' })).rejects.toMatchObject({
-        message: 'Convert to project is not yet implemented',
-        response: {
-          data: {
-            message: 'Convert to project is not yet implemented',
-            code: 'NOT_IMPLEMENTED',
-          },
-          status: 501,
-        },
+    it('should create a project and link the task to it', async () => {
+      const mockProject = { id: 'proj-new', title: 'New Project', outcome: 'Test outcome' };
+      mockAxiosInstance.post.mockResolvedValueOnce({ data: { project: mockProject } });
+      mockAxiosInstance.patch.mockResolvedValueOnce({ data: { task: { id: 'task-123', project_id: 'proj-new' } } });
+
+      const result = await tasksAPI.convertToProject('task-123', { title: 'New Project', outcome: 'Test outcome' });
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/projects', { title: 'New Project', outcome: 'Test outcome' });
+      expect(mockAxiosInstance.patch).toHaveBeenCalledWith('/tasks/task-123/clarify', {
+        status: 'next_action',
+        project_id: 'proj-new',
       });
+      expect(result.data.project).toEqual(mockProject);
+      expect(result.data.taskId).toBe('task-123');
     });
 
-    it('should reject even without arguments', async () => {
-      await expect(tasksAPI.convertToProject()).rejects.toMatchObject({
-        response: {
-          status: 501,
-          data: { code: 'NOT_IMPLEMENTED' },
-        },
-      });
+    it('should propagate error if project creation fails', async () => {
+      const error = new Error('Failed to create project');
+      error.response = { status: 400, data: { message: 'Invalid data' } };
+      mockAxiosInstance.post.mockRejectedValueOnce(error);
+
+      await expect(tasksAPI.convertToProject('task-123', { title: '' })).rejects.toThrow('Failed to create project');
     });
   });
 });

--- a/web/src/tests/unit/services/api.test.js
+++ b/web/src/tests/unit/services/api.test.js
@@ -244,7 +244,7 @@ describe('api.js', () => {
 
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/projects', { title: 'New Project', outcome: 'Test outcome' });
       expect(mockAxiosInstance.patch).toHaveBeenCalledWith('/tasks/task-123/clarify', {
-        status: 'next_action',
+        target_status: 'next_action',
         project_id: 'proj-new',
       });
       expect(result.data.project).toEqual(mockProject);


### PR DESCRIPTION
## Summary
- Implements the Frontend Projects Module for the GTD application (Phase 5.3)
- Adds projects Redux slice with async thunks for all CRUD operations
- Adds ProjectsPage with list view, filtering, and project creation
- Adds ProjectDetailPage with project details, tasks, and status management
- Adds ProjectCard component for project list items
- Adds comprehensive E2E test suite (22 tests)

## Changes
- `web/src/features/projects/projectsSlice.js` - Redux slice with state management
- `web/src/pages/ProjectsPage.jsx` - Projects list page
- `web/src/pages/ProjectDetailPage.jsx` - Project detail page
- `web/src/components/ProjectCard.jsx` - Project card component
- `web/src/tests/e2e/projects.spec.jsx` - E2E tests
- `docs/implementation/phase-5-3.md` - Implementation document

## Test plan
- [x] All 814 unit/integration tests pass
- [x] 22 E2E tests for project management pass
- [x] Build succeeds
- [x] Code review cycles 1 and 2 completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Iteration Changes (2025-12-03)

**Bug Fix:** Projects link was missing from Navigation menu
- Added Projects link in Navigation.jsx between Contexts and Next Actions
- Added test case for Projects link in Navigation.test.jsx

### Additional Tests
- Verify Projects link appears in navigation bar when logged in
- Verify clicking Projects link navigates to /projects

---

## Iteration 2 Changes (2025-12-03)

**Feature Fix:** Implemented convert to project workflow in Clarify
-  now creates a project and links the task to it
- Original task becomes a next action linked to the new project
- Updated Redux reducer and API tests